### PR TITLE
Fixed issue where modal open and close methods where throwing console errors when used with out a modal trigger button

### DIFF
--- a/src/components/12-modals/modals.hbs
+++ b/src/components/12-modals/modals.hbs
@@ -101,7 +101,7 @@
     // Listen for a custom "modalOpen" event
     document.addEventListener('modalOpen', event => {
     if (event.detail.name() === 'modal-example') {
-      alert('Hey, you opened the modal!')
+      alert('Hey, you opened the ' + event.detail.name() + ' modal!');
     }
     // Maybe send some data via an AJAX request, etc...
     }, false);
@@ -109,7 +109,7 @@
     // Listen for a custom "modalOpen" event
     document.addEventListener('modalClose', event => {
     if (event.detail.name() === 'modal-example') {
-      alert('Hey, you closed the modal!')
+      alert('Hey, you closed the ' + event.detail.name() + ' modal!');
     }
     // Maybe send some data via an AJAX request, etc...
     }, false);

--- a/src/components/12-modals/modals.hbs
+++ b/src/components/12-modals/modals.hbs
@@ -86,6 +86,34 @@
 </div>
 
 <script>
+    document.addEventListener('keydown', event => {
+        if (event.keyCode === 77) {
+            Modal.open('modal-example');
+            
+            return;
+        }
+        
+        if (event.keyCode === 67) {
+            Modal.close('modal-example');
+        }
+    })
+    
+    // Listen for a custom "modalOpen" event
+    document.addEventListener('modalOpen', event => {
+    if (event.detail.name() === 'modal-example') {
+      alert('Hey, you opened the modal!')
+    }
+    // Maybe send some data via an AJAX request, etc...
+    }, false);
+    
+    // Listen for a custom "modalOpen" event
+    document.addEventListener('modalClose', event => {
+    if (event.detail.name() === 'modal-example') {
+      alert('Hey, you closed the modal!')
+    }
+    // Maybe send some data via an AJAX request, etc...
+    }, false);
+    
     const newAlert = `
         <div class="rvt-alert rvt-alert--error rvt-m-bottom-sm" role="alert" aria-labelledby="error-alert-title" tabindex="-1">
             <h1 class="rvt-alert__title" id="error-alert-title">Incorrect User ID or Password</h1>

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -246,8 +246,9 @@ var Modal = (function() {
         event.preventDefault();
 
         close(id);
-
-        activeTrigger.focus();
+        
+        // Check to make sure modal was opened via a trigger element.
+        if (activeTrigger !== null) activeTrigger.focus();
 
         break;
       case trigger === id && !event.clickedInModal:

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -119,11 +119,11 @@ var Modal = (function() {
      * be deprecated in the next major version.
      */
     if (typeof id === 'object' && id.nodeType === 1) {
-        id = id.getAttribute('id');
+      id = id.getAttribute('id');
 
-        if (!id) {
-          throw new Error('Please proved an id attribute for the modal you want to close.');
-        }
+      if (!id) {
+        throw new Error('Please proved an id attribute for the modal you want to close.');
+      }
     }
 
     var modal = _createModalObject(id);
@@ -235,7 +235,7 @@ var Modal = (function() {
       (trigger.getAttribute(CLOSE_ATTR) && trigger.getAttribute(CLOSE_ATTR) !== 'close' ? trigger.getAttribute(CLOSE_ATTR) : false) ||
       event.target.closest(MODAL_SELECTOR);
 
-    switch (trigger !== null || undefined) {
+    switch (trigger !== null) {
       case trigger.hasAttribute(TRIGGER_ATTR):
         open(id);
 
@@ -258,6 +258,8 @@ var Modal = (function() {
         close(id);
 
         activeTrigger.focus();
+        
+        break;
       default:
         return;
     }

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -82,8 +82,25 @@ var Modal = (function() {
 
     // Sets a class on the body to handle overflow and scroll.
     document.body.classList.add('rvt-modal-open');
-
-    fireCustomEvent(modal.trigger, TRIGGER_ATTR, 'modalOpen');
+    
+    /**
+     * TODO: Here we are checking to see if the modal was triggered by
+     * clicking an element with the "data-modal-trigger" attribute. This
+     * is to cover the case that someone might use a modal without a
+     * trigger associated with it i.e. opening the modal programmatically
+     * via the API. This could probably be refactored to always use the
+     * modal's "id" attribute when emitting the custom event. Same for the
+     * ".close()" method below.
+     */
+    
+    // If there is a corresponding modal trigger
+    if (activeTrigger !== null) {
+      // Fire the custom event from the trigger
+      fireCustomEvent(activeTrigger, TRIGGER_ATTR, 'modalOpen');
+    } else {
+      // Otherwise use the modal's id attribute
+      fireCustomEvent(activeModal, 'id', 'modalOpen');
+    }
 
     if (callback && typeof callback === 'function') {
       callback();
@@ -118,8 +135,23 @@ var Modal = (function() {
     modal.body.setAttribute('aria-hidden', 'true');
 
     document.body.classList.remove('rvt-modal-open');
-
-    fireCustomEvent(modal.trigger, TRIGGER_ATTR, 'modalClose');
+    
+    /**
+     * TODO: Here we are checking to see if the modal was triggered by
+     * clicking an element with the "data-modal-trigger" attribute. This
+     * is to cover the case that someone might use a modal without a
+     * trigger associated with it i.e. opening the modal programmatically
+     * via the API. This could probably be refactored to always use the
+     * modal's "id" attribute when emitting the custom event. Same for the
+     * ".open()" method above.
+     */
+    
+    // If there is a corresponding modal trigger
+    if (activeTrigger !== null) {
+      fireCustomEvent(activeTrigger, TRIGGER_ATTR, 'modalClose');
+    } else {
+      fireCustomEvent(activeModal, 'id', 'modalClose');
+    }
 
     if (callback && typeof callback === 'function') {
         callback();

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -232,8 +232,9 @@ var Modal = (function() {
 
     // Sets the id based on whatever the matching target was.
     var id = trigger.getAttribute(TRIGGER_ATTR) ||
-      (trigger.getAttribute(CLOSE_ATTR) && trigger.getAttribute(CLOSE_ATTR) !== 'close' ? trigger.getAttribute(CLOSE_ATTR) : false) ||
-      event.target.closest(MODAL_SELECTOR);
+      (trigger.getAttribute(CLOSE_ATTR) && trigger.getAttribute(CLOSE_ATTR) !== 'close' ?
+        trigger.getAttribute(CLOSE_ATTR) : false) ||
+        event.target.closest(MODAL_SELECTOR);
 
     switch (trigger !== null) {
       case trigger.hasAttribute(TRIGGER_ATTR):

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -311,9 +311,9 @@ var Modal = (function() {
         if (activeModal.hasAttribute('data-modal-dialog')) return;
 
         close(activeModal.id);
-
-        activeTrigger.focus();
-
+        
+        if (activeTrigger !== null) activeTrigger.focus();
+        
         break;
       default:
         break;

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -82,7 +82,7 @@ var Modal = (function() {
 
     // Sets a class on the body to handle overflow and scroll.
     document.body.classList.add('rvt-modal-open');
-    
+
     /**
      * Emit a custom 'modalOpen' event and send along the modal's
      * id attribute in the event.detail.name()
@@ -235,7 +235,7 @@ var Modal = (function() {
         close(id);
 
         activeTrigger.focus();
-        
+
         break;
       default:
         return;
@@ -311,9 +311,9 @@ var Modal = (function() {
         if (activeModal.hasAttribute('data-modal-dialog')) return;
 
         close(activeModal.id);
-        
+
         if (activeTrigger !== null) activeTrigger.focus();
-        
+
         break;
       default:
         break;

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -84,23 +84,10 @@ var Modal = (function() {
     document.body.classList.add('rvt-modal-open');
     
     /**
-     * TODO: Here we are checking to see if the modal was triggered by
-     * clicking an element with the "data-modal-trigger" attribute. This
-     * is to cover the case that someone might use a modal without a
-     * trigger associated with it i.e. opening the modal programmatically
-     * via the API. This could probably be refactored to always use the
-     * modal's "id" attribute when emitting the custom event. Same for the
-     * ".close()" method below.
+     * Emit a custom 'modalOpen' event and send along the modal's
+     * id attribute in the event.detail.name()
      */
-    
-    // If there is a corresponding modal trigger
-    if (activeTrigger !== null) {
-      // Fire the custom event from the trigger
-      fireCustomEvent(activeTrigger, TRIGGER_ATTR, 'modalOpen');
-    } else {
-      // Otherwise use the modal's id attribute
-      fireCustomEvent(activeModal, 'id', 'modalOpen');
-    }
+    fireCustomEvent(activeModal, 'id', 'modalOpen');
 
     if (callback && typeof callback === 'function') {
       callback();
@@ -137,21 +124,10 @@ var Modal = (function() {
     document.body.classList.remove('rvt-modal-open');
     
     /**
-     * TODO: Here we are checking to see if the modal was triggered by
-     * clicking an element with the "data-modal-trigger" attribute. This
-     * is to cover the case that someone might use a modal without a
-     * trigger associated with it i.e. opening the modal programmatically
-     * via the API. This could probably be refactored to always use the
-     * modal's "id" attribute when emitting the custom event. Same for the
-     * ".open()" method above.
+     * Emit a custom 'modalClose' event and send along the modal's
+     * id attribute in the event.detail.name()
      */
-    
-    // If there is a corresponding modal trigger
-    if (activeTrigger !== null) {
-      fireCustomEvent(activeTrigger, TRIGGER_ATTR, 'modalClose');
-    } else {
-      fireCustomEvent(activeModal, 'id', 'modalClose');
-    }
+    fireCustomEvent(activeModal, 'id', 'modalClose');
 
     if (callback && typeof callback === 'function') {
         callback();


### PR DESCRIPTION
This PR should fix console errors when opening and closing the modal programmatically without the presence of a button/element with a `data-modal-trigger` attribute used to open the modal.

This was reported to me directly offline, so no issue currently exists. The errors do not break the functionality of the modal opening or closing, but to prevent the `customEvent`s from firing off.

All the modal tests are passing, and I tested locally opening and closing the modal without the presence of a trigger element i.e. using only the `.open()` and `.close()` methods.

After a review, I think it would be good to push this out as a minor/patch release.