### PR TITLE
Added none alias to spacing classes

### DIFF
--- a/src/sass/utilities/_utilities-spacing.scss
+++ b/src/sass/utilities/_utilities-spacing.scss
@@ -149,22 +149,30 @@ $spacing-sizes: (
 @each $direction in $spacing-directions {
   @if $direction == null {
     .m-all-remove,
-    .rvt-m-all-remove {
+    .rvt-m-all-remove,
+    .m-all-none, 
+    .rvt-m-all-none {
       margin: 0 !important;
     }
 
     .p-all-remove,
-    .rvt-p-all-remove {
+    .rvt-p-all-remove, 
+    .p-all-none,
+    .rvt-p-all-none {
       padding: 0 !important;
     }
   } @else {
     .m#{$direction}-remove,
-    .rvt-m#{$direction}-remove {
+    .rvt-m#{$direction}-remove, 
+    .m#{$direction}-none,
+    .rvt-m#{$direction}-none {
       margin#{$direction}: 0 !important;
     }
 
     .p#{$direction}-remove,
-    .rvt-p#{$direction}-remove {
+    .rvt-p#{$direction}-remove,
+    .p#{$direction}-none, 
+    .rvt-p#{$direction}-none {
       padding#{$direction}: 0 !important;
     }
   }

--- a/src/sass/utilities/_utilities-spacing.scss
+++ b/src/sass/utilities/_utilities-spacing.scss
@@ -4,7 +4,7 @@
 /* stylelint-disable */
 
 // Spacing direction values
-// NOTE: using "-bottom" will break the orginal version of the bottom utility classes
+// NOTE: using "-bottom" will break the original version of the bottom utility classes
 // That used "-btm" for class names. The documentation needs to be updated to reflect
 // This change.
 $spacing-directions: (
@@ -37,6 +37,9 @@ $spacing-sizes: (
   @each $size, $value in $spacing-sizes {
     // NOTE: We use !important here because we want these utilities to always
     // produced the same result.
+    
+    // DEPRECATED: In the next major version of Rivet we will be removing
+    // any non-prefixed versions of utility classes.
 
     // If the direction is "null", add margin to all directions.
     @if $direction == null {
@@ -93,7 +96,10 @@ $spacing-sizes: (
       @each $size, $value in $spacing-sizes {
         // NOTE: We use !important here because we want these utilities to always
         // produced the same result.
-
+        
+        // DEPRECATED: In the next major version of Rivet we will be removing
+        // any non-prefixed versions of utility classes.
+    
         // If the direction is "null", add margin to all directions.
         @if $direction == null {
           .m-all#{$size}-#{$bp-name}-up,
@@ -144,38 +150,63 @@ $spacing-sizes: (
 }
 
 // This loop creates classes that remove margin and padding from
-// and element.
+// an element.
 
+// NOTE: Adding the "-none" alias here without un-prefixed version
+// because the "-none" alias is totally new. We will always prefix every
+// class with "rvt-" moving forward.
 @each $direction in $spacing-directions {
   @if $direction == null {
     .m-all-remove,
     .rvt-m-all-remove,
-    .m-all-none, 
     .rvt-m-all-none {
       margin: 0 !important;
     }
 
     .p-all-remove,
     .rvt-p-all-remove, 
-    .p-all-none,
     .rvt-p-all-none {
       padding: 0 !important;
     }
   } @else {
     .m#{$direction}-remove,
     .rvt-m#{$direction}-remove, 
-    .m#{$direction}-none,
     .rvt-m#{$direction}-none {
       margin#{$direction}: 0 !important;
     }
 
     .p#{$direction}-remove,
     .rvt-p#{$direction}-remove,
-    .p#{$direction}-none, 
     .rvt-p#{$direction}-none {
       padding#{$direction}: 0 !important;
     }
   }
 } // End remove loop
 
+// NOTE: Adding the "-none" alias to the responsive classes without
+// un-prefixed version because the "-none" alias is totally new. We will
+// always prefix every class with "rvt-" moving forward.
+@each $bp-name, $bp-value in $breakpoints {
+  @include mq($bp-value) {
+    @each $direction in $spacing-directions {
+      @if $direction == null {
+        .rvt-m-all-none-#{$bp-name}-up {
+          margin: 0 !important;
+        }
+        
+        .rvt-p-all-none-#{$bp-name}-up {
+          padding: 0 !important;
+        }
+      } @else {
+        .rvt-m#{$direction}-none-#{$bp-name}-up {
+          margin#{$direction}: 0 !important;
+        }
+        
+        .rvt-p#{$direction}-none-#{$bp-name}-up {
+          padding#{$direction}: 0 !important;
+        }
+      }
+    }
+  }
+}
 /* stylelint-enable */


### PR DESCRIPTION
Can use `rvt-m-all-none`, `rvt-p-all-none`, or other spacing classes to remove padding or margins. From issue #24. Still need to edit the documentation to reflect this change. 