### PR TITLE
Release 1.2.1-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rivet-uits",
   "description": "Indiana University design system",
   "homepage": "https://rivet.iu.edu",
-  "version": "1.2.0",
+  "version": "1.2.1-alpha",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This release is the alpha for a patch for the modal where it was throwing errors when no modal trigger was present.

See #52 for more info