### PR TITLE
Added new flexbox utility classes

### DIFF
--- a/src/components/100-utilities/config.yml
+++ b/src/components/100-utilities/config.yml
@@ -1,1 +1,0 @@
-status: "ready"

--- a/src/components/100-utilities/utilities--flex.hbs
+++ b/src/components/100-utilities/utilities--flex.hbs
@@ -1,0 +1,56 @@
+<div class="rvt-flex">
+  {{# each demos }}
+    <div class="flex-demo">
+      <div class="flex-demo-inner">Item {{ this }}</div>
+    </div>
+  {{/each}}
+</div>
+
+<div class="rvt-flex rvt-flex-row-reverse rvt-m-top-xl">
+  <div class="flex-demo">
+    <div class="flex-demo-inner">Item One</div>
+  </div>
+  <div class="flex-demo">
+    <div class="flex-demo-inner">Item Two</div>
+  </div>
+  <div class="flex-demo">
+    <div class="flex-demo-inner">Item Three</div>
+  </div>
+</div>
+
+<div class="rvt-flex rvt-m-top-xl">
+  <div class="flex-demo rvt-flex-grow-1">
+    <div class="flex-demo-inner">Item One</div>
+  </div>
+  <div class="flex-demo">
+    <div class="flex-demo-inner">Item Three</div>
+  </div>
+</div>
+
+<div class="rvt-m-top-xl rvt-grid">
+  <div class="rvt-grid__item-4">  
+    
+    <label for="test-input">First name</label>
+    <div class="rvt-flex rvt-flex-items-center">
+      <input type="text" id="test-input" class="rvt-m-right-sm">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <path fill="currentColor"
+          d="M12.29,2H12V1a1,1,0,0,0-2,0V2H6V1A1,1,0,0,0,4,1V2H3.71A2.78,2.78,0,0,0,1,4.83v7.33A2.78,2.78,0,0,0,3.71,15h8.57A2.78,2.78,0,0,0,15,12.17V4.83A2.78,2.78,0,0,0,12.29,2ZM3.71,4H4V5H6V4h4V5h2V4h.29a.78.78,0,0,1,.71.83V7H3V4.83A.78.78,0,0,1,3.71,4Zm8.57,9H3.71A.78.78,0,0,1,3,12.17V9H13v3.17A.78.78,0,0,1,12.29,13Z" />
+      </svg>
+    </div>
+    
+  </div>
+</div>
+
+<style>
+  .flex-demo {
+    background-color: #dce3ee;
+    color: #ffffff;
+    padding: .5rem;
+  }
+  
+  .flex-demo-inner {
+    background-color: #006298;
+    padding: .25rem 1rem;
+  }
+</style>

--- a/src/components/100-utilities/utilities--flex.hbs
+++ b/src/components/100-utilities/utilities--flex.hbs
@@ -1,4 +1,5 @@
-<div class="rvt-flex-md-up rvt-space-around">
+<h2 class="rvt-m-tb-md">Base flex class</h2>
+<div class="rvt-flex rvt-justify-center" style="border: 1px solid #ccc;">
   {{#each demos }}
     <div class="flex-demo">
       <div class="flex-demo-inner">Item {{ this }}</div>
@@ -18,9 +19,17 @@
   </div>
 </div>
 
-<div class="rvt-flex">
-  <div>
+<div class="rvt-flex-md-up rvt-m-top-xxl rvt-border-all rvt-p-all-md">
+  <div class="rvt-grow-1">
     <input type="text">
+  </div>
+  <div class="rvt-flex rvt-shrink-0 rvt-m-left-md-md-up rvt-m-top-md rvt-m-top-none-md-up">
+    <select name="" id="">
+      <option value="">Option one</option>
+      <option value="">Option one</option>
+      <option value="">Option one</option>
+    </select>
+    <button class="rvt-button rvt-m-left-sm">Add</button>
   </div>
 </div>
 
@@ -32,7 +41,7 @@
   }
   
   .flex-demo--tall {
-    height: 20rem;
+    height: 8rem;
     background-color: #edf1f6;
   }
   

--- a/src/components/100-utilities/utilities--flex.hbs
+++ b/src/components/100-utilities/utilities--flex.hbs
@@ -1,16 +1,16 @@
-<div class="rvt-flex-md-up rvt-flex-space-between">
-  {{# each demos }}
+<div class="rvt-flex-md-up rvt-space-around">
+  {{#each demos }}
     <div class="flex-demo">
       <div class="flex-demo-inner">Item {{ this }}</div>
     </div>
   {{/each}}
 </div>
 
-<div class="rvt-flex-md-up rvt-m-top-xl">
-  <div class="flex-demo" style="width: 16rem;">
+<div class="rvt-flex-sm-up rvt-items-center rvt-m-top-xl flex-demo--tall">
+  <div class="flex-demo">
     <div class="flex-demo-inner">Item One</div>
   </div>
-  <div class="rvt-flex-grow-1 flex-demo">
+  <div class="flex-demo rvt-grow-1-md-up">
     <div class="flex-demo-inner">Item Two</div>
   </div>
   <div class="flex-demo">
@@ -18,12 +18,9 @@
   </div>
 </div>
 
-<div class="rvt-flex rvt-m-top-xl">
-  <div class="flex-demo rvt-flex-grow-1">
-    <div class="flex-demo-inner">Item One</div>
-  </div>
-  <div class="flex-demo">
-    <div class="flex-demo-inner">Item Three</div>
+<div class="rvt-flex">
+  <div>
+    <input type="text">
   </div>
 </div>
 
@@ -32,6 +29,11 @@
     background-color: #dce3ee;
     color: #ffffff;
     padding: .5rem;
+  }
+  
+  .flex-demo--tall {
+    height: 20rem;
+    background-color: #edf1f6;
   }
   
   .flex-demo-inner {

--- a/src/components/100-utilities/utilities--flex.hbs
+++ b/src/components/100-utilities/utilities--flex.hbs
@@ -21,7 +21,7 @@
 
 <h2 class="rvt-m-tb-xxl">Navbar example</h2>
 
-<div class="rvt-flex rvt-border-bottom   rvt-p-tb-sm rvt-p-lr-md rvt-border-top">
+<div class="rvt-flex rvt-p-tb-sm rvt-p-lr-md rvt-border-top rvt-border-bottom">
   <div class="rvt-flex rvt-items-center">
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
       <title>List</title>

--- a/src/components/100-utilities/utilities--flex.hbs
+++ b/src/components/100-utilities/utilities--flex.hbs
@@ -1,4 +1,4 @@
-<div class="rvt-flex">
+<div class="rvt-flex-md-up rvt-flex-space-between">
   {{# each demos }}
     <div class="flex-demo">
       <div class="flex-demo-inner">Item {{ this }}</div>
@@ -6,11 +6,11 @@
   {{/each}}
 </div>
 
-<div class="rvt-flex rvt-flex-row-reverse rvt-m-top-xl">
-  <div class="flex-demo">
+<div class="rvt-flex-md-up rvt-m-top-xl">
+  <div class="flex-demo" style="width: 16rem;">
     <div class="flex-demo-inner">Item One</div>
   </div>
-  <div class="flex-demo">
+  <div class="rvt-flex-grow-1 flex-demo">
     <div class="flex-demo-inner">Item Two</div>
   </div>
   <div class="flex-demo">
@@ -24,21 +24,6 @@
   </div>
   <div class="flex-demo">
     <div class="flex-demo-inner">Item Three</div>
-  </div>
-</div>
-
-<div class="rvt-m-top-xl rvt-grid">
-  <div class="rvt-grid__item-4">  
-    
-    <label for="test-input">First name</label>
-    <div class="rvt-flex rvt-flex-items-center">
-      <input type="text" id="test-input" class="rvt-m-right-sm">
-      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-        <path fill="currentColor"
-          d="M12.29,2H12V1a1,1,0,0,0-2,0V2H6V1A1,1,0,0,0,4,1V2H3.71A2.78,2.78,0,0,0,1,4.83v7.33A2.78,2.78,0,0,0,3.71,15h8.57A2.78,2.78,0,0,0,15,12.17V4.83A2.78,2.78,0,0,0,12.29,2ZM3.71,4H4V5H6V4h4V5h2V4h.29a.78.78,0,0,1,.71.83V7H3V4.83A.78.78,0,0,1,3.71,4Zm8.57,9H3.71A.78.78,0,0,1,3,12.17V9H13v3.17A.78.78,0,0,1,12.29,13Z" />
-      </svg>
-    </div>
-    
   </div>
 </div>
 

--- a/src/components/100-utilities/utilities--flex.hbs
+++ b/src/components/100-utilities/utilities--flex.hbs
@@ -1,7 +1,7 @@
 <h2 class="rvt-m-tb-md">Base flex class</h2>
-<div class="rvt-flex rvt-justify-center" style="border: 1px solid #ccc;">
+<div class="rvt-flex">
   {{#each demos }}
-    <div class="flex-demo">
+    <div class="flex-demo rvt-grow-1 rvt-items-center">
       <div class="flex-demo-inner">Item {{ this }}</div>
     </div>
   {{/each}}
@@ -19,17 +19,44 @@
   </div>
 </div>
 
-<div class="rvt-flex-md-up rvt-m-top-xxl rvt-border-all rvt-p-all-md">
-  <div class="rvt-grow-1">
-    <input type="text">
+<h2 class="rvt-m-tb-xxl">Navbar example</h2>
+
+<div class="rvt-flex rvt-border-bottom   rvt-p-tb-sm rvt-p-lr-md rvt-border-top">
+  <div class="rvt-flex rvt-items-center">
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <title>List</title>
+      <g fill="currentColor">
+        <path d="M13,4H6A1,1,0,0,1,6,2h7a1,1,0,0,1,0,2Z" />
+        <path d="M13,9H6A1,1,0,0,1,6,7h7a1,1,0,0,1,0,2Z" />
+        <path d="M13,14H6a1,1,0,0,1,0-2h7a1,1,0,0,1,0,2Z" />
+        <circle cx="3" cy="3" r="1" />
+        <circle cx="3" cy="8" r="1" />
+        <circle cx="3" cy="13" r="1" />
+      </g>
+    </svg>
+    <span class="rvt-m-left-xs">List view</span>
   </div>
-  <div class="rvt-flex rvt-shrink-0 rvt-m-left-md-md-up rvt-m-top-md rvt-m-top-none-md-up">
-    <select name="" id="">
-      <option value="">Option one</option>
-      <option value="">Option one</option>
-      <option value="">Option one</option>
-    </select>
-    <button class="rvt-button rvt-m-left-sm">Add</button>
+
+  <div class="rvt-flex rvt-items-center rvt-m-left-md">
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <title>Grid</title>
+      <g fill="currentColor">
+        <path d="M6,7H2A1,1,0,0,1,1,6V2A1,1,0,0,1,2,1H6A1,1,0,0,1,7,2V6A1,1,0,0,1,6,7ZM3,5H5V3H3Z" />
+        <path d="M14,7H10A1,1,0,0,1,9,6V2a1,1,0,0,1,1-1h4a1,1,0,0,1,1,1V6A1,1,0,0,1,14,7ZM11,5h2V3H11Z" />
+        <path d="M6,15H2a1,1,0,0,1-1-1V10A1,1,0,0,1,2,9H6a1,1,0,0,1,1,1v4A1,1,0,0,1,6,15ZM3,13H5V11H3Z" />
+        <path d="M14,15H10a1,1,0,0,1-1-1V10a1,1,0,0,1,1-1h4a1,1,0,0,1,1,1v4A1,1,0,0,1,14,15Zm-3-2h2V11H11Z" />
+      </g>
+    </svg>
+    <span class="rvt-m-left-xs">Grid view</span>
+  </div>
+  
+  <div class="rvt-flex rvt-items-center rvt-grow-1 rvt-justify-end rvt-m-left-md">
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <title>Gear Icon</title>
+      <path fill="currentColor"
+        d="M13.94,8.78A6,6,0,0,0,14,8a6,6,0,0,0-.07-.9L15.73,6a7.94,7.94,0,0,0-.92-2.15l-2.06.52a6,6,0,0,0-1.2-1.18L12,1.1A7.94,7.94,0,0,0,9.87.23L8.78,2.06A6,6,0,0,0,8,2a6,6,0,0,0-.9.07L6,.27a7.94,7.94,0,0,0-2.15.92l.52,2.06a6,6,0,0,0-1.18,1.2L1.1,4A7.94,7.94,0,0,0,.23,6.13L2.06,7.22A6,6,0,0,0,2,8a6,6,0,0,0,.07.9L.27,10a7.94,7.94,0,0,0,.92,2.15l2.06-.52a6,6,0,0,0,1.2,1.18L4,14.9a7.94,7.94,0,0,0,2.17.87l1.09-1.83A6,6,0,0,0,8,14a6,6,0,0,0,.9-.07L10,15.73a7.94,7.94,0,0,0,2.15-.92l-.52-2.06a6,6,0,0,0,1.18-1.2L14.9,12a7.94,7.94,0,0,0,.87-2.17ZM8,11a3,3,0,1,1,3-3A3,3,0,0,1,8,11Z" />
+    </svg>
+    <span class="rvt-m-left-xs">Settings</span>
   </div>
 </div>
 

--- a/src/components/100-utilities/utilities.config.yml
+++ b/src/components/100-utilities/utilities.config.yml
@@ -1,0 +1,8 @@
+status: "ready"
+context:
+  demos:
+    - "One"
+    - "Two"
+    - "Three"
+    - "Four"
+    - "Five"

--- a/src/sass/core/_variables.scss
+++ b/src/sass/core/_variables.scss
@@ -1,6 +1,9 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
+// Global class name prefix
+$prefix: "rvt";
+
 // Base font family
 
 $font-base: "BentonSans", "Helvetica Neue", "Helvetica", "sans-serif" !default;

--- a/src/sass/rivet.scss
+++ b/src/sass/rivet.scss
@@ -11,6 +11,7 @@
 @import "utilities/utilities-border";
 @import "utilities/utilities-color";
 @import "utilities/utilities-display";
+@import "utilities/utilities-flex";
 @import "utilities/utilities-spacing";
 @import "utilities/utilities-text";
 @import "utilities/utilities-visibility";

--- a/src/sass/utilities/_utilities-display.scss
+++ b/src/sass/utilities/_utilities-display.scss
@@ -55,16 +55,26 @@
   display: inline !important;
 }
 
+/**
+ * DEPRECATED: This flex utility will be removed in the
+ * next major version of Rivet in favor of the new flex utilities.
+ */
 .display-flex,
 .rvt-display-flex {
   display: flex !important;
 }
+/* End DEPRECATED */
 
 .display-none,
 .rvt-display-none {
   display: none !important;
 }
 
+/**
+ * DEPRECATED: This flex utility will be removed in the
+ * next major version of Rivet in favor of the new flex utilities.
+ */
 .rvt-vertical-center {
   align-items: center !important;
 }
+/* End DEPRECATED */

--- a/src/sass/utilities/_utilities-flex.scss
+++ b/src/sass/utilities/_utilities-flex.scss
@@ -18,9 +18,35 @@
   &-column-reverse {
     flex-direction: column-reverse !important;
   }
-  
-  // Wrap
+}
 
+@each $bp-name, $bp-value in $breakpoints {
+  @include mq($bp-value) {
+    .#{$prefix}-flex-#{$bp-name}-up {
+      display: flex !important;
+    }
+
+    .#{$prefix}-flex-row-#{$bp-name}-up {
+      flex-direction: row !important;
+    }
+
+    .#{$prefix}-flex-row-reverse-#{$bp-name}-up {
+      flex-direction: row-reverse !important;
+    }
+
+    .#{$prefix}-flex-column-#{$bp-name}-up {
+      flex-direction: column !important;
+    }
+
+    .#{$prefix}-flex-column-reverse-#{$bp-name}-up {
+      flex-direction: column-reverse !important;
+    }
+  }
+}
+
+// Wrap
+
+.#{$prefix}-flex {
   &-wrap {
     flex-wrap: wrap !important;
   }
@@ -32,9 +58,27 @@
   &-wrap-reverse {
     flex-wrap: wrap-reverse !important;
   }
-  
-  // Shrink
+}
 
+@each $bp-name, $bp-value in $breakpoints {
+  @include mq($bp-value) {
+    .#{$prefix}-flex-wrap-#{$bp-name}-up {
+      flex-wrap: wrap !important;
+    }
+
+    .#{$prefix}-flex-no-wrap-#{$bp-name}-up {
+      flex-wrap: nowrap !important;
+    }
+
+    .#{$prefix}-flex-wrap-reverse-#{$bp-name}-up {
+      flex-wrap: wrap-reverse !important;
+    }
+  }
+}
+
+// Shrink
+
+.#{$prefix}-flex {
   &-shrink-1 {
     flex-shrink: 1 !important;
   }
@@ -42,9 +86,23 @@
   &-shrink-0 {
     flex-shrink: 0 !important;
   }
-  
-  // Grow
+}
 
+@each $bp-name, $bp-value in $breakpoints {
+  @include mq($bp-value) {
+    .#{$prefix}-flex-shrink-1-#{$bp-name}-up {
+      flex-shrink: 1 !important;
+    }
+
+    .#{$prefix}-flex-shrink-0-#{$bp-name}-up {
+      flex-shrink: 0 !important;
+    }
+  }
+}
+ 
+// Grow
+
+.#{$prefix}-flex {
   &-grow-1 {
     flex-grow: 1 !important;
   }
@@ -52,9 +110,23 @@
   &-grow-0 {
     flex-grow: 0 !important;
   }
-  
-  // Align items
+}
 
+@each $bp-name, $bp-value in $breakpoints {
+  @include mq($bp-value) {
+    .#{$prefix}-flex-grow-1-#{$bp-name}-up {
+      flex-grow: 1 !important;
+    }
+
+    .#{$prefix}-flex-grow-0-#{$bp-name}-up {
+      flex-grow: 0 !important;
+    }
+  }
+}
+  
+// Align items
+
+.#{$prefix}-flex {
   &-items-start {
     align-items: flex-start !important;
   }
@@ -74,9 +146,35 @@
   &-items-stretch {
     align-items: stretch !important;
   }
-  
-  //Flex justify-content
+}
 
+@each $bp-name, $bp-value in $breakpoints {
+  @include mq($bp-value) {
+    .#{$prefix}-flex-items-start-#{$bp-name}-up {
+      align-items: flex-start !important;
+    }
+
+    .#{$prefix}-flex-items-end-#{$bp-name}-up {
+      align-items: flex-end !important;
+    }
+
+    .#{$prefix}-flex-items-center-#{$bp-name}-up {
+      align-items: center !important;
+    }
+
+    .#{$prefix}-flex-items-baseline-#{$bp-name}-up {
+      align-items: baseline !important;
+    }
+
+    .#{$prefix}-flex-items-stretch-#{$bp-name}-up {
+      align-items: stretch !important;
+    }
+  }
+}
+
+//Flex justify-content
+
+.#{$prefix}-flex {
   &-start {
     justify-content: flex-start;
   }
@@ -99,5 +197,33 @@
 
   &-space-evenly {
     justify-content: space-evenly;
+  }
+}
+
+@each $bp-name, $bp-value in $breakpoints {
+  @include mq($bp-value) {
+    .#{$prefix}-flex-start-#{$bp-name}-up {
+      justify-content: flex-start;
+    }
+
+    .#{$prefix}-flex-end-#{$bp-name}-up {
+      justify-content: flex-end;
+    }
+
+    .#{$prefix}-flex-center-#{$bp-name}-up {
+      justify-content: center;
+    }
+
+    .#{$prefix}-flex-space-between-#{$bp-name}-up {
+      justify-content: space-between;
+    }
+
+    .#{$prefix}-flex-space-around-#{$bp-name}-up {
+      justify-content: space-around;
+    }
+
+    .#{$prefix}-flex-space-evenly-#{$bp-name}-up {
+      justify-content: space-evenly;
+    }
   }
 }

--- a/src/sass/utilities/_utilities-flex.scss
+++ b/src/sass/utilities/_utilities-flex.scss
@@ -1,0 +1,103 @@
+// Display flex
+
+.#{$prefix}-flex {
+  display: flex !important;
+
+  &-row {
+    flex-direction: row !important;
+  }
+
+  &-row-reverse {
+    flex-direction: row-reverse !important;
+  }
+
+  &-column {
+    flex-direction: column !important;
+  }
+
+  &-column-reverse {
+    flex-direction: column-reverse !important;
+  }
+  
+  // Wrap
+
+  &-wrap {
+    flex-wrap: wrap !important;
+  }
+
+  &-no-wrap {
+    flex-wrap: nowrap !important;
+  }
+
+  &-wrap-reverse {
+    flex-wrap: wrap-reverse !important;
+  }
+  
+  // Shrink
+
+  &-shrink-1 {
+    flex-shrink: 1 !important;
+  }
+
+  &-shrink-0 {
+    flex-shrink: 0 !important;
+  }
+  
+  // Grow
+
+  &-grow-1 {
+    flex-grow: 1 !important;
+  }
+
+  &-grow-0 {
+    flex-grow: 0 !important;
+  }
+  
+  // Align items
+
+  &-items-start {
+    align-items: flex-start !important;
+  }
+
+  &-items-end {
+    align-items: flex-end !important;
+  }
+
+  &-items-center {
+    align-items: center !important;
+  }
+
+  &-items-baseline {
+    align-items: baseline !important;
+  }
+
+  &-items-stretch {
+    align-items: stretch !important;
+  }
+  
+  //Flex justify-content
+
+  &-start {
+    justify-content: flex-start;
+  }
+
+  &-end {
+    justify-content: flex-end;
+  }
+
+  &-center {
+    justify-content: center;
+  }
+
+  &-space-between {
+    justify-content: space-between;
+  }
+
+  &-space-around {
+    justify-content: space-around;
+  }
+
+  &-space-evenly {
+    justify-content: space-evenly;
+  }
+}

--- a/src/sass/utilities/_utilities-flex.scss
+++ b/src/sass/utilities/_utilities-flex.scss
@@ -212,54 +212,100 @@
 
 //Flex justify-content
 
-.#{$prefix}-start {
+.#{$prefix}-justify-start {
   justify-content: flex-start;
 }
 
-.#{$prefix}-end {
+.#{$prefix}-justify-end {
   justify-content: flex-end;
 }
 
-.#{$prefix}-center {
+.#{$prefix}-justify-center {
   justify-content: center;
 }
 
-.#{$prefix}-space-between {
+.#{$prefix}-justify-space-between {
   justify-content: space-between;
 }
 
-.#{$prefix}-space-around {
+.#{$prefix}-justify-space-around {
   justify-content: space-around;
 }
 
-.#{$prefix}-space-evenly {
+.#{$prefix}-justify-space-evenly {
   justify-content: space-evenly;
 }
 
 @each $bp-name, $bp-value in $breakpoints {
   @include mq($bp-value) {
-    .#{$prefix}-start-#{$bp-name}-up {
+    .#{$prefix}-justify-start-#{$bp-name}-up {
       justify-content: flex-start;
     }
 
-    .#{$prefix}-end-#{$bp-name}-up {
+    .#{$prefix}-justify-end-#{$bp-name}-up {
       justify-content: flex-end;
     }
 
-    .#{$prefix}-center-#{$bp-name}-up {
+    .#{$prefix}-justify-center-#{$bp-name}-up {
       justify-content: center;
     }
 
-    .#{$prefix}-space-between-#{$bp-name}-up {
+    .#{$prefix}-justify-space-between-#{$bp-name}-up {
       justify-content: space-between;
     }
 
-    .#{$prefix}-space-around-#{$bp-name}-up {
+    .#{$prefix}-justify-space-around-#{$bp-name}-up {
       justify-content: space-around;
     }
 
-    .#{$prefix}-space-evenly-#{$bp-name}-up {
+    .#{$prefix}-justify-space-evenly-#{$bp-name}-up {
       justify-content: space-evenly;
+    }
+  }
+}
+
+// self
+
+.#{$prefix}-self-start {
+  align-self: flex-start !important;
+}
+
+.#{$prefix}-self-end {
+  align-self: flex-end !important;
+}
+
+.#{$prefix}-self-center {
+  align-self: center !important;
+}
+
+.#{$prefix}-self-baseline {
+  align-self: baseline !important;
+}
+
+.#{$prefix}-self-stretch {
+  align-self: stretch !important;
+}
+
+@each $bp-name, $bp-value in $breakpoints {
+  @include mq($bp-value) {
+    .#{$prefix}-self-start-#{$bp-name}-up {
+      align-self: flex-start;
+    }
+
+    .#{$prefix}-self-end-#{$bp-name}-up {
+      align-self: flex-end;
+    }
+
+    .#{$prefix}-self-center-#{$bp-name}-up {
+      align-self: center;
+    }
+
+    .#{$prefix}-self-baseline-#{$bp-name}-up {
+      align-self: baseline;
+    }
+
+    .#{$prefix}-self-stretch-#{$bp-name}-up {
+      align-self: stretch;
     }
   }
 }

--- a/src/sass/utilities/_utilities-flex.scss
+++ b/src/sass/utilities/_utilities-flex.scss
@@ -2,22 +2,22 @@
 
 .#{$prefix}-flex {
   display: flex !important;
+}
 
-  &-row {
-    flex-direction: row !important;
-  }
+.#{$prefix}-row {
+  flex-direction: row !important;
+}
 
-  &-row-reverse {
-    flex-direction: row-reverse !important;
-  }
+.#{$prefix}-row-reverse {
+  flex-direction: row-reverse !important;
+}
 
-  &-column {
-    flex-direction: column !important;
-  }
+.#{$prefix}-column {
+  flex-direction: column !important;
+}
 
-  &-column-reverse {
-    flex-direction: column-reverse !important;
-  }
+.#{$prefix}-column-reverse {
+  flex-direction: column-reverse !important;
 }
 
 @each $bp-name, $bp-value in $breakpoints {
@@ -26,19 +26,19 @@
       display: flex !important;
     }
 
-    .#{$prefix}-flex-row-#{$bp-name}-up {
+    .#{$prefix}-row-#{$bp-name}-up {
       flex-direction: row !important;
     }
 
-    .#{$prefix}-flex-row-reverse-#{$bp-name}-up {
+    .#{$prefix}-row-reverse-#{$bp-name}-up {
       flex-direction: row-reverse !important;
     }
 
-    .#{$prefix}-flex-column-#{$bp-name}-up {
+    .#{$prefix}-column-#{$bp-name}-up {
       flex-direction: column !important;
     }
 
-    .#{$prefix}-flex-column-reverse-#{$bp-name}-up {
+    .#{$prefix}-column-reverse-#{$bp-name}-up {
       flex-direction: column-reverse !important;
     }
   }
@@ -46,31 +46,29 @@
 
 // Wrap
 
-.#{$prefix}-flex {
-  &-wrap {
-    flex-wrap: wrap !important;
-  }
+.#{$prefix}-wrap {
+  flex-wrap: wrap !important;
+}
 
-  &-no-wrap {
-    flex-wrap: nowrap !important;
-  }
+.#{$prefix}-no-wrap {
+  flex-wrap: nowrap !important;
+}
 
-  &-wrap-reverse {
-    flex-wrap: wrap-reverse !important;
-  }
+.#{$prefix}-wrap-reverse {
+  flex-wrap: wrap-reverse !important;
 }
 
 @each $bp-name, $bp-value in $breakpoints {
   @include mq($bp-value) {
-    .#{$prefix}-flex-wrap-#{$bp-name}-up {
+    .#{$prefix}-wrap-#{$bp-name}-up {
       flex-wrap: wrap !important;
     }
 
-    .#{$prefix}-flex-no-wrap-#{$bp-name}-up {
+    .#{$prefix}-no-wrap-#{$bp-name}-up {
       flex-wrap: nowrap !important;
     }
 
-    .#{$prefix}-flex-wrap-reverse-#{$bp-name}-up {
+    .#{$prefix}-wrap-reverse-#{$bp-name}-up {
       flex-wrap: wrap-reverse !important;
     }
   }
@@ -78,23 +76,21 @@
 
 // Shrink
 
-.#{$prefix}-flex {
-  &-shrink-1 {
-    flex-shrink: 1 !important;
-  }
+.#{$prefix}-shrink-1 {
+  flex-shrink: 1 !important;
+}
 
-  &-shrink-0 {
-    flex-shrink: 0 !important;
-  }
+.#{$prefix}-shrink-0 {
+  flex-shrink: 0 !important;
 }
 
 @each $bp-name, $bp-value in $breakpoints {
   @include mq($bp-value) {
-    .#{$prefix}-flex-shrink-1-#{$bp-name}-up {
+    .#{$prefix}-shrink-1-#{$bp-name}-up {
       flex-shrink: 1 !important;
     }
 
-    .#{$prefix}-flex-shrink-0-#{$bp-name}-up {
+    .#{$prefix}-shrink-0-#{$bp-name}-up {
       flex-shrink: 0 !important;
     }
   }
@@ -102,23 +98,21 @@
  
 // Grow
 
-.#{$prefix}-flex {
-  &-grow-1 {
-    flex-grow: 1 !important;
-  }
+.#{$prefix}-grow-1 {
+  flex-grow: 1 !important;
+}
 
-  &-grow-0 {
-    flex-grow: 0 !important;
-  }
+.#{$prefix}-grow-0 {
+  flex-grow: 0 !important;
 }
 
 @each $bp-name, $bp-value in $breakpoints {
   @include mq($bp-value) {
-    .#{$prefix}-flex-grow-1-#{$bp-name}-up {
+    .#{$prefix}-grow-1-#{$bp-name}-up {
       flex-grow: 1 !important;
     }
 
-    .#{$prefix}-flex-grow-0-#{$bp-name}-up {
+    .#{$prefix}-grow-0-#{$bp-name}-up {
       flex-grow: 0 !important;
     }
   }
@@ -126,103 +120,145 @@
   
 // Align items
 
-.#{$prefix}-flex {
-  &-items-start {
-    align-items: flex-start !important;
-  }
+.#{$prefix}-items-start {
+  align-items: flex-start !important;
+}
 
-  &-items-end {
-    align-items: flex-end !important;
-  }
+.#{$prefix}-items-end {
+  align-items: flex-end !important;
+}
 
-  &-items-center {
-    align-items: center !important;
-  }
+.#{$prefix}-items-center {
+  align-items: center !important;
+}
 
-  &-items-baseline {
-    align-items: baseline !important;
-  }
+.#{$prefix}-items-baseline {
+  align-items: baseline !important;
+}
 
-  &-items-stretch {
-    align-items: stretch !important;
-  }
+.#{$prefix}-items-stretch {
+  align-items: stretch !important;
 }
 
 @each $bp-name, $bp-value in $breakpoints {
   @include mq($bp-value) {
-    .#{$prefix}-flex-items-start-#{$bp-name}-up {
+    .#{$prefix}-items-start-#{$bp-name}-up {
       align-items: flex-start !important;
     }
 
-    .#{$prefix}-flex-items-end-#{$bp-name}-up {
+    .#{$prefix}-items-end-#{$bp-name}-up {
       align-items: flex-end !important;
     }
 
-    .#{$prefix}-flex-items-center-#{$bp-name}-up {
+    .#{$prefix}-items-center-#{$bp-name}-up {
       align-items: center !important;
     }
 
-    .#{$prefix}-flex-items-baseline-#{$bp-name}-up {
+    .#{$prefix}-items-baseline-#{$bp-name}-up {
       align-items: baseline !important;
     }
 
-    .#{$prefix}-flex-items-stretch-#{$bp-name}-up {
+    .#{$prefix}-items-stretch-#{$bp-name}-up {
       align-items: stretch !important;
+    }
+  }
+}
+
+// Align content
+
+.#{$prefix}-content-start {
+  align-content: flex-start !important;
+}
+
+.#{$prefix}-content-end {
+  align-content: flex-end !important;
+}
+
+.#{$prefix}-content-center {
+  align-content: center !important;
+}
+
+.#{$prefix}-content-stretch {
+  align-content: stretch !important;
+}
+
+.#{$prefix}-content-baseline {
+  align-content: baseline !important;
+}
+
+@each $bp-name, $bp-value in $breakpoints {
+  @include mq($bp-value) {
+    .#{$prefix}-content-start-#{$bp-name}-up {
+      align-content: flex-start !important;
+    }
+
+    .#{$prefix}-content-end-#{$bp-name}-up {
+      align-content: flex-end !important;
+    }
+
+    .#{$prefix}-content-center-#{$bp-name}-up {
+      align-content: center !important;
+    }
+
+    .#{$prefix}-content-stretch-#{$bp-name}-up {
+      align-content: stretch !important;
+    }
+
+    .#{$prefix}-content-baseline-#{$bp-name}-up {
+      align-content: baseline !important;
     }
   }
 }
 
 //Flex justify-content
 
-.#{$prefix}-flex {
-  &-start {
-    justify-content: flex-start;
-  }
+.#{$prefix}-start {
+  justify-content: flex-start;
+}
 
-  &-end {
-    justify-content: flex-end;
-  }
+.#{$prefix}-end {
+  justify-content: flex-end;
+}
 
-  &-center {
-    justify-content: center;
-  }
+.#{$prefix}-center {
+  justify-content: center;
+}
 
-  &-space-between {
-    justify-content: space-between;
-  }
+.#{$prefix}-space-between {
+  justify-content: space-between;
+}
 
-  &-space-around {
-    justify-content: space-around;
-  }
+.#{$prefix}-space-around {
+  justify-content: space-around;
+}
 
-  &-space-evenly {
-    justify-content: space-evenly;
-  }
+.#{$prefix}-space-evenly {
+  justify-content: space-evenly;
 }
 
 @each $bp-name, $bp-value in $breakpoints {
   @include mq($bp-value) {
-    .#{$prefix}-flex-start-#{$bp-name}-up {
+    .#{$prefix}-start-#{$bp-name}-up {
       justify-content: flex-start;
     }
 
-    .#{$prefix}-flex-end-#{$bp-name}-up {
+    .#{$prefix}-end-#{$bp-name}-up {
       justify-content: flex-end;
     }
 
-    .#{$prefix}-flex-center-#{$bp-name}-up {
+    .#{$prefix}-center-#{$bp-name}-up {
       justify-content: center;
     }
 
-    .#{$prefix}-flex-space-between-#{$bp-name}-up {
+    .#{$prefix}-space-between-#{$bp-name}-up {
       justify-content: space-between;
     }
 
-    .#{$prefix}-flex-space-around-#{$bp-name}-up {
+    .#{$prefix}-space-around-#{$bp-name}-up {
       justify-content: space-around;
     }
 
-    .#{$prefix}-flex-space-evenly-#{$bp-name}-up {
+    .#{$prefix}-space-evenly-#{$bp-name}-up {
       justify-content: space-evenly;
     }
   }


### PR DESCRIPTION
This PR adds a new set of comprehensive flex utilities to help developers have more fine-grained control over layout. White the grid is good for overall page layout, things can get messy when trying to nest too many grids to achieve complex layouts.

This new set of flex utilities gives developers a set of CSS classes they can combine to create more complex responsive layouts at the component level.

This adds utility classes for all of the major flexbox properties that affect **flex containers**:

- `display`
- `flex-direction`
- `flex-wrap`
- `justify-content`
- `align-items`
- `align-content`

And some that apply to **flex items**:

- `flex-shrink`
- `flex-grow`
- `align-self`

Flex properties **not included** in these utilities (container and items):

- `flex-flow` - This container property is just shorthand for `flex-direction` and `flex-wrap` no need to repeat
- `flex-basis` - This property is used to set default widths of flex items. We already have the grid for defined widths.
- `order` - this is a hard one to standardize as we don't know how many flex items will be in any given flex container.

I've added some basic examples, but I'll plan to write more comprehensive docs when I update the docs site before the February release.