### PR TITLE
Added missing display property for inline-flex

### DIFF
--- a/src/sass/utilities/_utilities-flex.scss
+++ b/src/sass/utilities/_utilities-flex.scss
@@ -4,6 +4,10 @@
   display: flex !important;
 }
 
+.#{$prefix}-inline-flex {
+  display: inline-flex !important;
+}
+
 .#{$prefix}-row {
   flex-direction: row !important;
 }
@@ -24,6 +28,10 @@
   @include mq($bp-value) {
     .#{$prefix}-flex-#{$bp-name}-up {
       display: flex !important;
+    }
+
+    .#{$prefix}-inline-flex-#{$bp-name}-up {
+      display: inline-flex !important;
     }
 
     .#{$prefix}-row-#{$bp-name}-up {


### PR DESCRIPTION
This PR add the missing `.rvt-inline-flex` utility class that I forgot to add in #75 

I realized it was missing while updating the docs. I don't think we need to bother doing another release candidate for this. It will just go out with the final `1.3.0` release. I'll make sure the site includes docs for this new class.