### PR TITLE
Added optional alert dismissal data selector

### DIFF
--- a/src/components/101-includes/includes--alert-close-button.hbs
+++ b/src/components/101-includes/includes--alert-close-button.hbs
@@ -1,4 +1,4 @@
-<button class="rvt-alert__dismiss">
+<button class="rvt-alert__dismiss" data-alert-close>
   <span class="rvt-sr-only">Dismiss this alert</span>
   <svg role="img" alt="" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
     <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z"/>

--- a/src/js/components/alert.js
+++ b/src/js/components/alert.js
@@ -7,6 +7,11 @@ var Alert = (function() {
   'use strict';
 
   // Selectors
+  
+  /**
+   * DEPRECATED: .rvt-alert__dismiss will be removed in the future in favor of
+   * using the more consistent data attribute data-alert-close.
+   */
   var SELECTORS = '[data-alert-close], .rvt-alert__dismiss';
 
   /**

--- a/src/js/components/alert.js
+++ b/src/js/components/alert.js
@@ -4,108 +4,111 @@
  */
 
 var Alert = (function() {
-    'use strict';
+  'use strict';
 
-    // Selectors
-    var CLOSE_ATTR = 'data-alert-close';
+  // Selectors
+  var SELECTORS = '[data-alert-close], .rvt-alert__dismiss';
 
+  /**
+   * Kicks off the Alert component and sets up all event listeners
+   *
+   * @param {HTMLElement} context - An optional DOM element that the
+   * alert can be initialized on. All event listeners will be attached
+   * to this element. Usually best to just leave it to default
+   * to the document.
+   */
+  function init(context) {
+    // Optional element to bind the event listeners to
+    if (context === undefined) {
+      context = document;
+    }
+
+    // Destroy any currently initialized alerts
+    destroy(context);
+
+    document.addEventListener('click', _handleClick, false);
+  }
+
+  /**
+   * Cleans up any currently initialized Alerts
+   *
+   * @param {HTMLElement} context - An optional DOM element. This only
+   * needs to be passed in if a DOM element was passed to the init()
+   * function. If so, the element passed in must be the same element
+   * that was passed in at initialization so that the event listeners can
+   * be properly removed.
+   */
+  function destroy(context) {
+    if (context === undefined) {
+      context = document;
+    }
+
+    document.removeEventListener('click', _handleClick, false);
+  }
+
+  var _handleClick = function(event) {
+    var dismissButton = event.target.closest(SELECTORS);
+
+    // If the target wasn't the dismiss button bail.
+    if (!dismissButton) return;
+
+    // Get the parent node of the dsimiss button i.e. the alert container
+    var alertThatWasClicked = dismissButton.parentNode;
+
+    dismissAlert(alertThatWasClicked);
+  };
+
+  /**
+   * Dismisses the alert
+   * @param {String} id - A unique string used for the alert's id attribute
+   * @param {Function} callback - A function that is executed after alert
+   * is closed.
+   */
+  function dismissAlert(id, callback) {
     /**
-     * Kicks off the Alert component and sets up all event listeners
-     *
-     * @param {HTMLElement} context - An optional DOM element that the
-     * alert can be initialized on. All event listeners will be attached
-     * to this element. Usually best to just leave it to default
-     * to the document.
+     * DEPRECATED: This is to add backwards compatibility for the older API
+     * where you needed to pass in the alert Object/HTMLElement. This should
+     * be deprecated in the next major version.
      */
-    function init(context) {
-        // Optional element to bind the event listeners to
-        if (context === undefined) {
-            context = document;
-        }
+    if (typeof id === 'object' && id.nodeType === 1) {
+      var alertEl = id;
+      id = alertEl.getAttribute('id');
 
-        // Destroy any currently initialized alerts
-        destroy(context);
+      // if an id isn't provided try aria-labelledby
+      if (!id) {
+        id = alertEl.getAttribute('aria-labelledby');
+      }
 
-        document.addEventListener('click', _handleClick, false);
+      // if aria-labelledby and id aren't provided throw an error
+      if (!id) {
+        throw new Error(
+          'Please proved an id attribute for the alert you want to dismiss.'
+        );
+      }
     }
 
-    /**
-     * Cleans up any currently initialized Alerts
-     *
-     * @param {HTMLElement} context - An optional DOM element. This only
-     * needs to be passed in if a DOM element was passed to the init()
-     * function. If so, the element passed in must be the same element
-     * that was passed in at initialization so that the event listeners can
-     * be properly removed.
-     */
-    function destroy(context) {
-        if (context === undefined) {
-            context = document;
-        }
+    var alert = document.querySelector('[aria-labelledby="' + id + '"]');
 
-        document.removeEventListener('click', _handleClick, false);
+    if (!alert) {
+      alert = document.getElementById(id);
     }
 
-    var _handleClick = function(event) {
-        var dismissButton = event.target.closest('.rvt-alert__dismiss');
-
-        // If the target wasn't the dismiss button bail.
-        if (!dismissButton) return;
-
-        // Get the parent node of the dsimiss button i.e. the alert container
-        var alertThatWasClicked = dismissButton.parentNode;
-
-        dismissAlert(alertThatWasClicked);
+    if (!alert) {
+      throw new Error(
+        'Could not find an alert with the id of ' + id + ' to dismiss.'
+      );
     }
 
-    /**
-     * Dismisses the alert
-     * @param {String} id - A unique string used for the alert's id attribute
-     * @param {Function} callback - A function that is executed after alert
-     * is closed.
-     */
-    function dismissAlert(id, callback) {
-        /**
-         * DEPRECATED: This is to add backwards compatibility for the older API
-         * where you needed to pass in the alert Object/HTMLElement. This should
-         * be deprecated in the next major version.
-         */
-        if (typeof id === 'object' && id.nodeType === 1) {
-            var alertEl = id
-            id = alertEl.getAttribute('id');
+    alert.parentNode.removeChild(alert);
 
-            // if an id isn't provided try aria-labelledby
-            if(!id) {
-                id = alertEl.getAttribute('aria-labelledby');
-            }
-
-            // if aria-labelledby and id aren't provided throw an error
-            if (!id) {
-                throw new Error('Please proved an id attribute for the alert you want to dismiss.');
-            }
-        }
-
-        var alert = document.querySelector('[aria-labelledby="' + id + '"]')
-
-        if(!alert) {
-            alert = document.getElementById(id)
-        }
-
-        if (!alert) {
-            throw new Error("Could not find an alert with the id of " + id + " to dismiss.");
-        }
-
-        alert.parentNode.removeChild(alert)
-
-        if (callback && typeof callback === 'function') {
-            callback();
-        }
+    if (callback && typeof callback === 'function') {
+      callback();
     }
+  }
 
-
-    return {
-        init: init,
-        destroy: destroy,
-        dismiss: dismissAlert
-    }
+  return {
+    init: init,
+    destroy: destroy,
+    dismiss: dismissAlert
+  };
 })();


### PR DESCRIPTION
Updated the dismiss button for alerts to allow usage of `[data-alert-close]` as an alternative option to `.rvt-alert__dismiss`. See issue #85.