### PR TITLE
Added copyright header to flex sass file

### DIFF
--- a/src/sass/utilities/_utilities-flex.scss
+++ b/src/sass/utilities/_utilities-flex.scss
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 // Display flex
 
 .#{$prefix}-flex {


### PR DESCRIPTION
The copyright header for sass files is handled manually, and this one was missed previously. See issue #90.