### PR TITLE
Fixed active state background color for small secondary button

### DIFF
--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -203,7 +203,6 @@
 
   &-active,
   &:active {
-    background-color: $color-blue--800;
     border-color: $color-blue--800;
   }
 }


### PR DESCRIPTION
Removed unnecessary background-color property from active state for small buttons. See issue #102.