### PR TITLE
Added status/package badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rivet
 
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![Node version](https://img.shields.io/node/v/[NPM-MODULE-NAME].svg?style=flat)](http://nodejs.org/download/) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=svg)](https://circleci.com/gh/indiana-university/rivet-source)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![npm version](https://badge.fury.io/js/rivet-uits.svg)](https://badge.fury.io/js/rivet-uits) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=svg)](https://circleci.com/gh/indiana-university/rivet-source)
 
 ## Principles
 Designers and developers can use this system as a foundation for great experiences across all UITS applications. They can also contribute to it—and make the system relevant to any team.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Principles
+# Rivet
+
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![Node version](https://img.shields.io/node/v/[rivet-uits].svg?style=flat)](http://nodejs.org/download/) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=svg)](https://circleci.com/gh/indiana-university/rivet-source)
+
+## Principles
 Designers and developers can use this system as a foundation for great experiences across all UITS applications. They can also contribute to it—and make the system relevant to any team.
 
 We want to hear about the patterns you need, but we need to make sure all patterns are cohesive. So, we’ve established these principles to help guide the creation process:
@@ -64,7 +68,7 @@ To help us understand the kind of contribution you want to make we ask that you 
 5. Push your feature branch to your fork: `git push origin feature/**your feature**`
 6. [Open a pull request](https://help.github.com/articles/about-pull-requests/) with a title and clear description of your feature branch against `develop`
 
-### Testing Javascript
+## Testing Javascript
 We use [Cypress](https://www.cypress.io/) to run automated end-to-end tests on Rivet's JavaScript components. To run tests do the following:
 
 1. Start the local development server by typing `npm run start` in your terminal.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rivet
+# [Rivet](https://rivet.iu.edu/)
 
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![npm version](https://img.shields.io/npm/v/rivet-uits.svg?style=flat)](https://www.npmjs.com/package/rivet-uits) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/indiana-university/rivet-source)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rivet
 
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![npm version](https://img.shields.io/npm/v/rivet-uits.svg?style=flat)](https://www.npmjs.com/package/react) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/indiana-university/rivet-source)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![npm version](https://img.shields.io/npm/v/rivet-uits.svg?style=flat)](https://www.npmjs.com/package/rivet-uits) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/indiana-university/rivet-source)
 
 ## Principles
 Designers and developers can use this system as a foundation for great experiences across all UITS applications. They can also contribute to it—and make the system relevant to any team.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The default gulp task will watch all component templates (.hbs) and Sass (.scss)
 
 Read more about configuring components on the [Fractal webiste](http://fractal.build/guide/components).
 
-## Submitting a Github issue
+### Submitting a Github issue
 To help us understand the kind of contribution you want to make we ask that you first submit a Github issue. Here are a few guidelines to follow when creating a new issue:
 
 1. Go to the Rivet repository on [GitHub](https://github.com/indiana-university/rivet-source/issues).
@@ -60,7 +60,7 @@ To help us understand the kind of contribution you want to make we ask that you 
 5. After you have filled out the issue template click the **Submit new issue** button to create your new issue :tada:.
 6. Once the team has had a chance to review the issue they will either mark it as **request**, or ask you for more information before moving on to the next steps.
 
-## Submitting a pull request
+### Submitting a pull request
 1. Fork the main `rivet-source` repository and then clone your fork locally. Follow [these instructions on syncing your local fork](https://help.github.com/articles/fork-a-repo/#keep-your-fork-synced). Set your new `upstream` remote to point to `https://github.com/indiana-university/rivet-source.git`.
 2. Create a new feature branch off of `develop` (the default branch) with the prefix `feature/` e.g. `feature/modal`
 3. Commit your changes. Be sure to keep your commits narrow in scope and avoid committing changes not related to your feature.
@@ -68,7 +68,7 @@ To help us understand the kind of contribution you want to make we ask that you 
 5. Push your feature branch to your fork: `git push origin feature/**your feature**`
 6. [Open a pull request](https://help.github.com/articles/about-pull-requests/) with a title and clear description of your feature branch against `develop`
 
-## Testing Javascript
+### Testing Javascript
 We use [Cypress](https://www.cypress.io/) to run automated end-to-end tests on Rivet's JavaScript components. To run tests do the following:
 
 1. Start the local development server by typing `npm run start` in your terminal.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rivet
 
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![Node version](https://img.shields.io/node/v/rivet-uits.svg?style=flat)](http://nodejs.org/download/) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=svg)](https://circleci.com/gh/indiana-university/rivet-source)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![Node version](https://img.shields.io/node/v/[NPM-MODULE-NAME].svg?style=flat)](http://nodejs.org/download/) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=svg)](https://circleci.com/gh/indiana-university/rivet-source)
 
 ## Principles
 Designers and developers can use this system as a foundation for great experiences across all UITS applications. They can also contribute to it—and make the system relevant to any team.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rivet
 
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![Node version](https://img.shields.io/node/v/[rivet-uits].svg?style=flat)](http://nodejs.org/download/) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=svg)](https://circleci.com/gh/indiana-university/rivet-source)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![Node version](https://img.shields.io/node/v/rivet-uits.svg?style=flat)](http://nodejs.org/download/) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=svg)](https://circleci.com/gh/indiana-university/rivet-source)
 
 ## Principles
 Designers and developers can use this system as a foundation for great experiences across all UITS applications. They can also contribute to it—and make the system relevant to any team.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rivet
 
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![npm version](https://badge.fury.io/js/rivet-uits.svg)](https://badge.fury.io/js/rivet-uits) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=svg)](https://circleci.com/gh/indiana-university/rivet-source)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![npm version](https://img.shields.io/npm/v/react.svg?style=flat)](https://www.npmjs.com/package/react) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/indiana-university/rivet-source)
 
 ## Principles
 Designers and developers can use this system as a foundation for great experiences across all UITS applications. They can also contribute to it—and make the system relevant to any team.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rivet
 
-[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![npm version](https://img.shields.io/npm/v/react.svg?style=flat)](https://www.npmjs.com/package/react) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/indiana-university/rivet-source)
+[![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause) [![npm version](https://img.shields.io/npm/v/rivet-uits.svg?style=flat)](https://www.npmjs.com/package/react) [![CircleCI](https://circleci.com/gh/indiana-university/rivet-source.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/indiana-university/rivet-source)
 
 ## Principles
 Designers and developers can use this system as a foundation for great experiences across all UITS applications. They can also contribute to it—and make the system relevant to any team.


### PR DESCRIPTION
Austin recently requested that we add badges similar to ones on other GitHub repos (see the [React repo](https://github.com/facebook/react/) for an example). In doing so, I also restructured the README to begin with the name 'Rivet', and moved other headings down in the hierarchy to reflect this.