### PR TITLE
Replaced instances of bp() with the $breakpoint variable

### DIFF
--- a/src/sass/components/_breadcrumb.scss
+++ b/src/sass/components/_breadcrumb.scss
@@ -52,7 +52,7 @@
   }
 }
 
-@include mq(bp(md)) {
+@include mq($breakpoint-md) {
   .#{$prefix}-breadcrumbs li {
     font-size: $ts-base;
   }

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -39,7 +39,7 @@
   }
 }
 
-@include mq(bp(lg)) {
+@include mq($breakpoint-lg) {
   .#{$prefix}-header__trident {
     min-width: 60px;
     flex-basis: 60px;
@@ -79,7 +79,7 @@
  * When id menu is present the title needs a little more space.
  */
 
-@include mq(bp(lg)) {
+@include mq($breakpoint-lg) {
   .#{$prefix}-header__title {
     font-size: ts(23);
   }
@@ -151,14 +151,14 @@
   }
 }
 
-@include mq(bp(lg)) {
+@include mq($breakpoint-lg) {
   .#{$prefix}-drawer-button {
     height: 70px;
     width: 71px;
   }
 }
 
-@include mq(bp(lg)) {
+@include mq($breakpoint-lg) {
   .#{$prefix}-drawer-button {
     display: none;
   }
@@ -182,7 +182,7 @@
   height: 16px;
 }
 
-@include mq(bp(lg)) {
+@include mq($breakpoint-lg) {
   .#{$prefix}-drawer-button-open,
   .#{$prefix}-drawer-button-close {
     width: 24px;
@@ -452,7 +452,7 @@
   }
 }
 
-@include mq(bp(lg)) {
+@include mq($breakpoint-lg) {
   .#{$prefix}-drawer {
     top: 70px;
   }
@@ -550,13 +550,13 @@ button.#{$prefix}-header-id__profile.#{$prefix}-header-id__profile--drawer {
   padding: $xs $sm;
 }
 
-@include mq(bp(lg)) {
+@include mq($breakpoint-lg) {
   .#{$prefix}-header-id {
     display: flex;
   }
 }
 
-@include mq(bp(lg)) {
+@include mq($breakpoint-lg) {
   .#{$prefix}-header-id--drawer {
     display: none;
   }

--- a/src/sass/components/_menu.scss
+++ b/src/sass/components/_menu.scss
@@ -81,6 +81,6 @@
 
 @include horizontal-menu('&--horizontal');
 
-@include mq(bp(md)) {
+@include mq($breakpoint-md) {
   @include horizontal-menu('&:not(&--vertical)');
 }

--- a/src/sass/components/_modals.scss
+++ b/src/sass/components/_modals.scss
@@ -106,7 +106,7 @@
       }
     }
 
-    @include mq(bp(sm)) {
+    @include mq($breakpoint-sm) {
       justify-content: flex-end;
 
       .#{$prefix}-button {

--- a/src/sass/components/_tabs.scss
+++ b/src/sass/components/_tabs.scss
@@ -71,7 +71,7 @@
   }
 }
 
-@include mq(bp(md)) {
+@include mq($breakpoint-md) {
   .#{$prefix}-tabs {
     &__tab {
       border-top-right-radius: $xxs;
@@ -95,7 +95,7 @@
 /**
  * Vertical tabs
  */
-@include mq(bp(md)) {
+@include mq($breakpoint-md) {
   .#{$prefix}-tabs--vertical {
     border: 1px solid $color-black--300;
     border-radius: $xxs;

--- a/src/sass/core/_tools.scss
+++ b/src/sass/core/_tools.scss
@@ -8,6 +8,9 @@
 // on it's own only return CSS properties or values.
 
 // Gets breakpoints out of the $breakpoints map
+// DEPRECATED: The bp() function has been deprecated in favor of using
+// the $breakpoint-* variables and will be removed in the next
+// major version.
 
 @function bp($key) {
   @return map-get($breakpoints, $key);


### PR DESCRIPTION
This pull request replaces remaining instances of the `bp()` Sass function with the appropriate `$breakpoint-*` variable. This should help make the Sass easier to read.

Fixes #115 