### PR TITLE
Moved global data into components.config.yml

### DIFF
--- a/src/components/04-list/list-definition/list-definition.config.yml
+++ b/src/components/04-list/list-definition/list-definition.config.yml
@@ -1,7 +1,6 @@
 title: "Definition List"
 label: "Definition"
 status: "ready"
-collated: true
 context:
     texts:
     - term:

--- a/src/components/04-list/list-ordered/list-ordered.config.yml
+++ b/src/components/04-list/list-ordered/list-ordered.config.yml
@@ -1,10 +1,3 @@
 title: "Ordered List"
 label: "Ordered"
 status: "ready"
-collated: true
-context:
-    texts:
-    - List Item One
-    - List Item Two
-    - List Item Three
-    - List Item Four

--- a/src/components/04-list/list-ordered/list-ordered.njk
+++ b/src/components/04-list/list-ordered/list-ordered.njk
@@ -1,5 +1,5 @@
 <ol>
-  {% for text in texts %}
-    <li>{{ text }}</li>
+  {% for list_item in list_items %}
+    <li>{{ list_item }}</li>
   {% endfor %}
 </ol>

--- a/src/components/04-list/list-plain-text/list-plain-text.config.yml
+++ b/src/components/04-list/list-plain-text/list-plain-text.config.yml
@@ -1,10 +1,3 @@
 title: "Plain Text List"
 label: "Plain Text"
 status: "ready"
-collated: true
-context:
-    texts:
-    - List Item One
-    - List Item Two
-    - List Item Three
-    - List Item Four

--- a/src/components/04-list/list-plain-text/list-plain-text.njk
+++ b/src/components/04-list/list-plain-text/list-plain-text.njk
@@ -1,5 +1,5 @@
 <ul class="rvt-plain-list">
-  {% for text in texts %}
-    <li>{{ text }}</li>
+  {% for list_item in list_items %}
+    <li>{{ list_item }}</li>
   {% endfor %}
 </ul>

--- a/src/components/04-list/list-unordered/list-unordered.config.yml
+++ b/src/components/04-list/list-unordered/list-unordered.config.yml
@@ -1,10 +1,3 @@
 title: "Unordered List"
 label: "Unordered"
 status: "ready"
-collated: true
-context:
-    texts:
-    - List Item One
-    - List Item Two
-    - List Item Three
-    - List Item Four

--- a/src/components/04-list/list-unordered/list-unordered.njk
+++ b/src/components/04-list/list-unordered/list-unordered.njk
@@ -1,5 +1,5 @@
 <ul>
-  {% for text in texts %}
-    <li>{{ text }}</li>
+  {% for list_item in list_items %}
+    <li>{{ list_item }}</li>
   {% endfor %}
 </ul>

--- a/src/components/components.config.yml
+++ b/src/components/components.config.yml
@@ -4,13 +4,20 @@ context:
 
     # Fake people
     people:
-        -   name: Bert Macklin
-            title: The FBI
-        -   name: Leslie Knope
-            title: Assistan Director, Pawnee Parks Department
-        -   name: Ron Swanson
-            title: Director, Pawnee Parks Department
-        -   name: April Ludgate
-            title: Animal Control
-        -   name: Ben Wayatt
-            title: Creator, The Cones of Dunshire
+        - name: Bert Macklin
+          title: The FBI
+        - name: Leslie Knope
+          title: Assistant Director, Pawnee Parks Department
+        - name: Ron Swanson
+          title: Director, Pawnee Parks Department
+        - name: April Ludgate
+          title: Animal Control
+        - name: Ben Wayatt
+          title: Creator, The Cones of Dunshire
+
+    # For unordered/ordered lists
+    list_items:
+        - List Item One
+        - List Item Two
+        - List Item Three
+        - List Item Four


### PR DESCRIPTION
This moves global data that can be used across components and variants into the `components.config.yml` file. An example that's used within the `list` component:

```
list_items:
    - List Item One
    - List Item Two
    - List Item Three
    - List Item Four
```

Other related fixes:
- Adjusted indentation inside components.config.yml.
- Removed 'collated: true' from list component variants since it's not needed in this case.