### PR TITLE
Removed border-top for first-child of rows within a box

### DIFF
--- a/src/sass/components/_box.scss
+++ b/src/sass/components/_box.scss
@@ -14,6 +14,10 @@
     border-top: 1px solid $color-black--150;
     margin-top: -1px;
     padding: $sm;
+
+    &:first-child {
+      border-top: none;
+    }
   }
 
   &__row--selected,
@@ -97,10 +101,6 @@
   &--light &__header,
   &--light &__footer {
     background-color: $color-white;
-  }
-
-  &--card &__row:first-child {
-    border-top: none;
   }
 
   &--compact &__header,


### PR DESCRIPTION
This fix extends `border-top: none` to include all rows within the box component, not just those rows within the card variant as before. For instances where there isn't a header preceding the first row, `.rvt-box` still provides a border-top.

See issue #133.