### PR TITLE
Darkened background on disabled checked radio inputs

### DIFF
--- a/src/components/07-radio-input/radio-input.config.yml
+++ b/src/components/07-radio-input/radio-input.config.yml
@@ -15,6 +15,19 @@ variants:
           id: "disabled"
           modifier: "disabled"
           legend: "Radio input (disabled)"
+    - name: "disabled-checked"
+      context:
+          id: "disabled"
+          modifier: "disabled"
+          legend: "Radio input (disabled with one option checked)"
+          options:
+            one:
+              text: Option one
+              checked: checked
+              modifier: disabled
+            two:
+              text: Option two
+              modifier: disabled
     - name: "hidden fields"
       context:
           id: "hidden"

--- a/src/sass/components/_radios.scss
+++ b/src/sass/components/_radios.scss
@@ -86,8 +86,8 @@ input[type='radio']:disabled + label::before,
 
 input[type='radio']:checked:disabled + label::before,
 .#{$prefix}-radio-wrapper input[type='radio']:checked:disabled ~ label::before {
-  background-color: $color-black--300;
-  box-shadow: inset 0 0 0 .125rem $color-black--200, 0 0 0 .08rem $color-black--300;
+  background-color: $color-black--600;
+  box-shadow: inset 0 0 0 .125rem $color-black--200, 0 0 0 .08rem $color-black--600;
 }
 
 input[type='radio']:disabled + label,


### PR DESCRIPTION
In this PR:

- Adds a "disabled-checked" variant to the `radio-input.config.yml` to test for radio inputs that are both disabled and checked.
- Increases the background-color from `$color-black-300` to `$color-black-600` for radio inputs that are both disabled and checked.

See issue #101.