### PR TITLE
Updated loading indicator to calculate the appropriate border-width

### DIFF
--- a/src/sass/components/_loading-indicator.scss
+++ b/src/sass/components/_loading-indicator.scss
@@ -22,36 +22,43 @@
   &--xxs {
     width: $sm;
     height: $sm;
+    border-width: $sm * .125;
   }
 
   &--xs {
     width: $sm * 1.25;
     height: $sm * 1.25;
+    border-width: $sm * (.125 * 1.25);
   }
 
   &--sm {
     width: $sm * 1.75;
     height: $sm * 1.75;
+    border-width: $sm * (.125 * 1.75);
   }
 
   &--md {
     width: $sm * 2;
     height: $sm * 2;
+    border-width: $sm * (.125 * 2);
   }
 
   &--lg {
     width: $sm * 2.75;
     height: $sm * 2.75;
+    border-width: $sm * (.125 * 2.75);
   }
 
   &--xl {
     width: $sm * 3.25;
     height: $sm * 3.25;
+    border-width: $sm * (.125 * 3.25);
   }
 
   &--xxl {
     width: $sm * 4;
     height: $sm * 4;
+    border-width: $sm * (.125 * 4);
   }
 }
 


### PR DESCRIPTION
In this PR:

- Refactored the loading indicator to recalculate the `border-width` based on the width being used (this is based on the understanding that at `16px` or `1rem` the border should be `2px` or `.125rem`
- Calculated border widths:
  - `xxs`: 2px
  - `xs`: 2.5px
  - `sm`: 3.5px
  - `md`: 4px
  - `lg`: 5.5px
  - `xl`: 6.5px
  - `xxl`: 8px

For more details, see issue #131.