### PR TITLE
Fixed backward tabbing issue for modals

### DIFF
--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -260,7 +260,7 @@ var Modal = (function() {
       last.focus();
     } else if (document.activeElement === activeModal) {
       event.preventDefault();
-      first.focus();
+      last.focus();
     }
   }
 

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -258,6 +258,9 @@ var Modal = (function() {
     if (document.activeElement === first) {
       event.preventDefault();
       last.focus();
+    } else if (document.activeElement === activeModal) {
+      event.preventDefault();
+      first.focus();
     }
   }
 


### PR DESCRIPTION
When initially opening a modal, if the user presses shift + tab, the focus leaves the modal. This fix sets the focus to the first focusable element within the modal when shift + tab is pressed upon first opening the modal.

For more details, see issue #13.