### PR TITLE
Refactored _handleBackwardTab function

### DIFF
--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -261,10 +261,7 @@ var Modal = (function() {
    * @param {Event} event - The event object
    */
   function _handleBackwardTab(first, last, event) {
-    if (document.activeElement === first) {
-      event.preventDefault();
-      last.focus();
-    } else if (document.activeElement === activeModal) {
+    if (document.activeElement === first || document.activeElement === activeModal) {
       event.preventDefault();
       last.focus();
     }


### PR DESCRIPTION
Removed `else` statement because it included the same logic as the first `if` statement and moved the `else` statement's condition into the `if` statement.