### PR TITLE
Updated disabled loading indicator button styles

### DIFF
--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -273,16 +273,16 @@
 
 .#{$prefix}-button--loading,
 .#{$prefix}-button--loading[disabled] {
-  background-color: $color-blue--100;
-  border-color: $color-blue--200;
-  color: $color-blue--600;
+  background-color: $color-black--100;
+  border-color: $color-black--400;
+  color: $color-black--700;
   justify-content: center;
   position: relative;
 
   &:hover {
-    background-color: $color-blue--100;
-    border-color: $color-blue--200;
-    color: $color-blue--600;
+    background-color: $color-black--100;
+    border-color: $color-black--400;
+    color: $color-black--700;
   }
 
   /**
@@ -308,6 +308,9 @@
    */
 
   .#{$prefix}-loader {
+    border-bottom-color: $color-black--400;
+    border-right-color: $color-black--400;
+    border-top-color: $color-black--400;
     display: block;
     position: absolute;
     left: 50%;


### PR DESCRIPTION
In this PR:

- Changed the background-color, border-color, and color properties of a disabled button with a loading indicator (default and hover)
- Changed the color of the loading indicator when used within a disabled button

See the original issue #54 for more details, and #68 for the discussion and updates that were rolled into this PR.