### PR TITLE
Replaced aria-describedby with aria-hidden

### DIFF
--- a/src/components/includes/includes--trident.njk
+++ b/src/components/includes/includes--trident.njk
@@ -1,4 +1,4 @@
-<svg role="img" alt="" class="rvt-header__trident-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 41 48" aria-describedby="iu-logo">
+<svg role="img" alt="" class="rvt-header__trident-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 41 48" aria-hidden="true">
     <title id="iu-logo">Indiana University Logo</title>
     <rect width="41" height="48" fill="#900"/>
     <polygon points="24.59 12.64 24.59 14.98 26.34 14.98 26.34 27.78 22.84 27.78 22.84 10.9 24.59 10.9 24.59 8.57 16.41 8.57 16.41 10.9 18.16 10.9 18.16 27.78 14.66 27.78 14.66 14.98 16.41 14.98 16.41 12.64 8.22 12.64 8.22 14.98 9.97 14.98 9.97 30.03 12.77 33.02 18.16 33.02 18.16 36.52 16.41 36.52 16.41 39.43 24.59 39.43 24.59 36.52 22.84 36.52 22.84 33.02 28 33.02 31.01 30.03 31.01 14.98 32.78 14.98 32.78 12.64 24.59 12.64" fill="#fff"/>


### PR DESCRIPTION
In `includes--trident.njk`, the `aria-describedby` on the `svg` element was removed and `aria-hidden="true"` was added.

See issue #200 for more details.