### PR TITLE
Created filter for v2 dev and master branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,12 @@ aliases:
         - /^release.*/
         - /^hotfix.*/
 
+  - &filter-ignore-v2
+    branches:
+      ignore:
+        - 2.0.0-dev
+        - 2.0.0-master
+
 defaults: &defaults
   working_directory: ~/rivet-source
   docker:
@@ -139,7 +145,8 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - build
+      - build:
+          filters: *&filter-ignore-v2
       - test:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ workflows:
   build-test:
     jobs:
       - build:
-          filters: *&filter-ignore-v2
+          filters: *filter-ignore-v2
       - test:
           requires:
             - build


### PR DESCRIPTION
In this PR:

- Created filter for `2.0.0-dev` and `2.0.0-master` branches in CircleCI
- Applied filter to `build` job in CircleCI workflow

What this doesn't do:

- This does not filter out feature branches intended for inclusion in `v2` branches