### PR TITLE
Set ecmaVersion to 2018 in .eslintrc.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
-  'extends': 'eslint-config-rivet'
+  'extends': 'eslint-config-rivet',
+  'parserOptions': {
+    'ecmaVersion': 2018
+  }
 }


### PR DESCRIPTION
The ecmaVersion value was set to '2018' within the eslint config to prevent errors when the spread operator is used within an object.

**Example:**
```
const settings = {
  ...defaultOptions,
  ...options
};
```

Setting `"experimentalObjectRestSpread": true` was a previous solution to allow spread operators within objects, but that has been deprecated in favor of `"ecmaVersion": 2018`.

https://eslint.org/docs/user-guide/migrating-to-5.0.0#-the-experimentalobjectrestspread-option-has-been-deprecated