### PR TITLE
Reintegrated gulp build task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -252,6 +252,16 @@ exports.release = series(
   example
 );
 
+exports.build = series(
+  lintSassBuild,
+  compileSass,
+  compileJS,
+  concatJS,
+  vendorJS,
+  fractalBuild,
+  prefixFractalCSS
+);
+
 exports.fractalBuild = fractalBuild;
 
 exports.headless = series(compileSass,


### PR DESCRIPTION
The bamboo build has been breaking. It seems that I removed the build task from the Gulpfile when I rewrote everything. It's not used in the npm scripts, so I probably missed that it was being used by Bamboo.