### PR TITLE
Fixed broken prefix variable

### DIFF
--- a/src/sass/components/_menu.scss
+++ b/src/sass/components/_menu.scss
@@ -1,4 +1,4 @@
-.#{prefix}-menu {
+.#{$prefix}-menu {
   &__list {
     list-style: none;
     margin: 0;
@@ -40,7 +40,7 @@
 }
 
 @mixin horizontal-menu($selector) {
-  .#{prefix}-menu {
+  .#{$prefix}-menu {
     #{$selector} {
       border-bottom: 1px solid $color-black--200;
     }


### PR DESCRIPTION
I noticed that the CSS for the Menu component was broken. Looks like this snuck through in #212 This should fix that up.