### PR TITLE
Update color scale naming conventions

### DIFF
--- a/src/components/utilities/utilities.config.yml
+++ b/src/components/utilities/utilities.config.yml
@@ -102,113 +102,113 @@ context:
           hex: "990000"
         - variable: black
           hex: "243142"
-        - variable: black--050
+        - variable: black-050
           hex: "f7f7f8"
-        - variable: black--100
+        - variable: black-100
           hex: "ebecee"
-        - variable: black--200
+        - variable: black-200
           hex: "c4c7cc"
-        - variable: black--300
+        - variable: black-300
           hex: "a7abb3"
-        - variable: black--400
+        - variable: black-400
           hex: "8b919b"
-        - variable: black--500
+        - variable: black-500
           hex: "707784"
-        - variable: black--600
+        - variable: black-600
           hex: "565f6d"
-        - variable: black--700
+        - variable: black-700
           hex: "3d4757"
-        - variable: black--800
+        - variable: black-800
           hex: "243142"
-        - variable: black--900
+        - variable: black-900
           hex: "161c24"
         - variable: blue
           hex: "006298"
-        - variable: blue--050
+        - variable: blue-050
           hex: "edf1f6"
-        - variable: blue--100
+        - variable: blue-100
           hex: "dce3ee"
-        - variable: blue--200
+        - variable: blue-200
           hex: "b8c8dc"
-        - variable: blue--300
+        - variable: blue-300
           hex: "95adcb"
-        - variable: blue--400
+        - variable: blue-400
           hex: "7194ba"
-        - variable: blue--500
+        - variable: blue-500
           hex: "497ba9"
-        - variable: blue--600
+        - variable: blue-600
           hex: "006298"
-        - variable: blue--700
+        - variable: blue-700
           hex: "134a71"
-        - variable: blue--800
+        - variable: blue-800
           hex: "16324b"
-        - variable: blue--900
+        - variable: blue-900
           hex: "121c28"
         - variable: green
           hex: "008a28"
-        - variable: green--050
+        - variable: green-050
           hex: "eaf3e8"
-        - variable: green--100
+        - variable: green-100
           hex: "d4e8d2"
-        - variable: green--200
+        - variable: green-200
           hex: "aad1a7"
-        - variable: green--300
+        - variable: green-300
           hex: "7eb97c"
-        - variable: green--400
+        - variable: green-400
           hex: "50a253"
-        - variable: green--500
+        - variable: green-500
           hex: "008a28"
-        - variable: green--600
+        - variable: green-600
           hex: "116d23"
-        - variable: green--700
+        - variable: green-700
           hex: "16521d"
-        - variable: green--800
+        - variable: green-800
           hex: "153717"
-        - variable: green--900
+        - variable: green-900
           hex: "111f0f"
         - variable: yellow
           hex: "f5bb17"
-        - variable: yellow--050
+        - variable: yellow-050
           hex: "ffeecd"
-        - variable: yellow--100
+        - variable: yellow-100
           hex: "ffdd9b"
-        - variable: yellow--200
+        - variable: yellow-200
           hex: "d6a31a"
-        - variable: yellow--300
+        - variable: yellow-300
           hex: "b58a1b"
-        - variable: yellow--400
+        - variable: yellow-400
           hex: "94721b"
-        - variable: yellow--500
+        - variable: yellow-500
           hex: "f5bb17"
-        - variable: yellow--600
+        - variable: yellow-600
           hex: "765a19"
-        - variable: yellow--700
+        - variable: yellow-700
           hex: "584416"
-        - variable: yellow--800
+        - variable: yellow-800
           hex: "3c2e13"
-        - variable: yellow--900
+        - variable: yellow-900
           hex: "221b0c"
         - variable: orange
           hex: "df3603"
-        - variable: orange--050
+        - variable: orange-050
           hex: "ffece5"
-        - variable: orange--100
+        - variable: orange-100
           hex: "ffd9cc"
-        - variable: orange--200
+        - variable: orange-200
           hex: "ffb49a"
-        - variable: orange--300
+        - variable: orange-300
           hex: "fa8e6b"
-        - variable: orange--400
+        - variable: orange-400
           hex: "ef663c"
-        - variable: orange--500
+        - variable: orange-500
           hex: "df3603"
-        - variable: orange--600
+        - variable: orange-600
           hex: "b02f0a"
-        - variable: orange--700
+        - variable: orange-700
           hex: "82270d"
-        - variable: orange--800
+        - variable: orange-800
           hex: "571e0c"
-        - variable: orange--900
+        - variable: orange-900
           hex: "2f1407"
     zIndexes:
         - number: 1000

--- a/src/components/utilities/utilities.config.yml
+++ b/src/components/utilities/utilities.config.yml
@@ -102,7 +102,7 @@ context:
           hex: "990000"
         - variable: black
           hex: "243142"
-        - variable: black-050
+        - variable: black-000
           hex: "f7f7f8"
         - variable: black-100
           hex: "ebecee"
@@ -124,7 +124,7 @@ context:
           hex: "161c24"
         - variable: blue
           hex: "006298"
-        - variable: blue-050
+        - variable: blue-000
           hex: "edf1f6"
         - variable: blue-100
           hex: "dce3ee"
@@ -146,7 +146,7 @@ context:
           hex: "121c28"
         - variable: green
           hex: "008a28"
-        - variable: green-050
+        - variable: green-000
           hex: "eaf3e8"
         - variable: green-100
           hex: "d4e8d2"
@@ -168,7 +168,7 @@ context:
           hex: "111f0f"
         - variable: yellow
           hex: "f5bb17"
-        - variable: yellow-050
+        - variable: yellow-000
           hex: "ffeecd"
         - variable: yellow-100
           hex: "ffdd9b"
@@ -190,7 +190,7 @@ context:
           hex: "221b0c"
         - variable: orange
           hex: "df3603"
-        - variable: orange-050
+        - variable: orange-000
           hex: "ffece5"
         - variable: orange-100
           hex: "ffd9cc"

--- a/src/sass/components/_alerts.scss
+++ b/src/sass/components/_alerts.scss
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 .#{$prefix}-alert {
-  background-color: $color-black--100;
-  border-left: $xxs solid $color-black--400;
+  background-color: $color-black-100;
+  border-left: $xxs solid $color-black-400;
   padding: $sm;
   position: relative;
 
@@ -52,7 +52,7 @@
 
     &:focus {
       outline: none;
-      box-shadow: 0 0 0 $xxs/2 $color-blue--600 !important;
+      box-shadow: 0 0 0 $xxs/2 $color-blue-600 !important;
     }
   }
 }
@@ -68,29 +68,29 @@
  */
 
 .#{$prefix}-alert--info {
-  background-color: $color-blue--050;
-  border-left-color: $color-blue--600;
-  color: $color-blue--700;
+  background-color: $color-blue-050;
+  border-left-color: $color-blue-600;
+  color: $color-blue-700;
 }
 
 .#{$prefix}-alert--success {
-  background-color: $color-green--050;
-  border-left-color: $color-green--500;
-  color: $color-green--700;
+  background-color: $color-green-050;
+  border-left-color: $color-green-500;
+  color: $color-green-700;
 }
 
 .#{$prefix}-alert--message,
 .#{$prefix}-alert--warning {
-  background-color: $color-yellow--050;
-  border-left-color: $color-yellow--200;
-  color: $color-yellow--700;
+  background-color: $color-yellow-050;
+  border-left-color: $color-yellow-200;
+  color: $color-yellow-700;
 }
 
 .#{$prefix}-alert--error,
 .#{$prefix}-alert--danger {
-  background-color: $color-orange--050;
-  border-left-color: $color-orange--500;
-  color: $color-orange--700;
+  background-color: $color-orange-050;
+  border-left-color: $color-orange-500;
+  color: $color-orange-700;
 }
 
 /**
@@ -142,7 +142,7 @@
   input[type='week']:focus,
   textarea,
   select {
-    box-shadow: 0 0 0 $xxs/2 $color-orange--500;
-    border-color: $color-orange--500;
+    box-shadow: 0 0 0 $xxs/2 $color-orange-500;
+    border-color: $color-orange-500;
   }
 }

--- a/src/sass/components/_alerts.scss
+++ b/src/sass/components/_alerts.scss
@@ -68,27 +68,27 @@
  */
 
 .#{$prefix}-alert--info {
-  background-color: $color-blue-050;
+  background-color: $color-blue-000;
   border-left-color: $color-blue-600;
   color: $color-blue-700;
 }
 
 .#{$prefix}-alert--success {
-  background-color: $color-green-050;
+  background-color: $color-green-000;
   border-left-color: $color-green-500;
   color: $color-green-700;
 }
 
 .#{$prefix}-alert--message,
 .#{$prefix}-alert--warning {
-  background-color: $color-yellow-050;
+  background-color: $color-yellow-000;
   border-left-color: $color-yellow-200;
   color: $color-yellow-700;
 }
 
 .#{$prefix}-alert--error,
 .#{$prefix}-alert--danger {
-  background-color: $color-orange-050;
+  background-color: $color-orange-000;
   border-left-color: $color-orange-500;
   color: $color-orange-700;
 }

--- a/src/sass/components/_badges.scss
+++ b/src/sass/components/_badges.scss
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 .#{$prefix}-badge {
-  background-color: $color-black--200;
-  border: 2px solid $color-black--200;
+  background-color: $color-black-200;
+  border: 2px solid $color-black-200;
   border-radius: 999px;
   color: $color-black;
   display: inline-block;
@@ -36,35 +36,35 @@ a.#{$prefix}-badge {
 
   &:hover {
     color: $color-black;
-    background-color: $color-black--400;
-    border-color: $color-black--400;
+    background-color: $color-black-400;
+    border-color: $color-black-400;
   }
 
   &--info:hover,
   &--info-secondary:hover {
-    background-color: $color-blue--700;
-    border-color: $color-blue--700;
+    background-color: $color-blue-700;
+    border-color: $color-blue-700;
     color: $color-white;
   }
 
   &--success:hover,
   &--success-secondary:hover {
-    background-color: $color-green--700;
-    border-color: $color-green--700;
+    background-color: $color-green-700;
+    border-color: $color-green-700;
     color: $color-white;
   }
 
   &--warning:hover,
   &--warning-secondary:hover {
-    background-color: $color-yellow--700;
-    border-color: $color-yellow--700;
+    background-color: $color-yellow-700;
+    border-color: $color-yellow-700;
     color: $color-white;
   }
 
   &--danger:hover,
   &--danger-secondary:hover {
-    background-color: $color-orange--700;
-    border-color: $color-orange--700;
+    background-color: $color-orange-700;
+    border-color: $color-orange-700;
     color: $color-white;
   }
 
@@ -74,49 +74,49 @@ a.#{$prefix}-badge {
 }
 
 .#{$prefix}-badge--info {
-  background-color: $color-blue--600;
-  border-color: $color-blue--600;
+  background-color: $color-blue-600;
+  border-color: $color-blue-600;
   color: $color-white;
 
   &-secondary {
     background-color: transparent;
-    border-color: $color-blue--600;
-    color: $color-blue--600;
+    border-color: $color-blue-600;
+    color: $color-blue-600;
   }
 }
 
 .#{$prefix}-badge--success {
-  background-color: $color-green--500;
-  border-color: $color-green--500;
+  background-color: $color-green-500;
+  border-color: $color-green-500;
   color: $color-white;
 
   &-secondary {
     background-color: transparent;
-    border-color: $color-green--500;
-    color: $color-green--500;
+    border-color: $color-green-500;
+    color: $color-green-500;
   }
 }
 
 .#{$prefix}-badge--warning {
-  background-color: $color-yellow--200;
-  border-color: $color-yellow--200;
-  color: $color-black--900;
+  background-color: $color-yellow-200;
+  border-color: $color-yellow-200;
+  color: $color-black-900;
 
   &-secondary {
     background-color: transparent;
-    border-color: $color-yellow--200;
-    color: $color-black--900;
+    border-color: $color-yellow-200;
+    color: $color-black-900;
   }
 }
 
 .#{$prefix}-badge--danger {
-  background-color: $color-orange--500;
-  border-color: $color-orange--500;
+  background-color: $color-orange-500;
+  border-color: $color-orange-500;
   color: $color-white;
 
   &-secondary {
     background-color: transparent;
-    border-color: $color-orange--500;
-    color: $color-orange--500;
+    border-color: $color-orange-500;
+    color: $color-orange-500;
   }
 }

--- a/src/sass/components/_box.scss
+++ b/src/sass/components/_box.scss
@@ -3,7 +3,7 @@
 
 .#{$prefix}-box {
   background-color: $color-white;
-  border: 1px solid $color-black--200;
+  border: 1px solid $color-black-200;
   border-radius: $xxs;
 
   &__body {
@@ -11,7 +11,7 @@
   }
 
   &__row {
-    border-top: 1px solid $color-black--100;
+    border-top: 1px solid $color-black-100;
     margin-top: -1px;
     padding: $sm;
 
@@ -22,37 +22,37 @@
 
   &__row--selected,
   &__row[aria-current] {
-    background-color: $color-black--050;
-    box-shadow: $xxs 0 0 0 $color-blue--600 inset;
+    background-color: $color-black-050;
+    box-shadow: $xxs 0 0 0 $color-blue-600 inset;
   }
 
   &__row--info {
-    background-color: $color-blue--050;
-    box-shadow: $xxs 0 0 0 $color-blue--600 inset;
-    color: $color-blue--700;
+    background-color: $color-blue-050;
+    box-shadow: $xxs 0 0 0 $color-blue-600 inset;
+    color: $color-blue-700;
   }
 
   &__row--success {
-    background-color: $color-green--050;
-    color: $color-green--700;
-    box-shadow: $xxs 0 0 0 $color-green--500 inset;
+    background-color: $color-green-050;
+    color: $color-green-700;
+    box-shadow: $xxs 0 0 0 $color-green-500 inset;
   }
 
   &__row--warning {
-    background-color: $color-yellow--050;
-    box-shadow: $xxs 0 0 0 $color-yellow--200 inset;
-    color: $color-yellow--700;
+    background-color: $color-yellow-050;
+    box-shadow: $xxs 0 0 0 $color-yellow-200 inset;
+    color: $color-yellow-700;
   }
 
   &__row--danger {
-    background-color: $color-orange--050;
-    box-shadow: $xxs 0 0 0 $color-orange--500 inset;
-    color: $color-orange--700;
+    background-color: $color-orange-050;
+    box-shadow: $xxs 0 0 0 $color-orange-500 inset;
+    color: $color-orange-700;
   }
 
   &__footer {
-    background-color: $color-black--050;
-    border-top: 1px solid $color-black--200;
+    background-color: $color-black-050;
+    border-top: 1px solid $color-black-200;
     border-bottom-right-radius: $xxs; // Gets rid of border clipping
     border-bottom-left-radius: $xxs; // Gets rid of border clipping
     padding: $xxs $sm;
@@ -60,10 +60,10 @@
 
   &__header {
     align-items: center;
-    background-color: $color-black--050;
+    background-color: $color-black-050;
     border-top: none;
     border-right: none;
-    border-bottom: 1px solid $color-black--200;
+    border-bottom: 1px solid $color-black-200;
     border-top-right-radius: $xxs; // Gets rid of border clipping
     border-top-left-radius: $xxs; // Gets rid of border clipping
     border-left: none;
@@ -82,7 +82,7 @@
      */
 
     &:focus {
-      box-shadow: 0 0 0 $xxs/2 #ffffff, 0 0 0 $xxs $color-blue--600;
+      box-shadow: 0 0 0 $xxs/2 #ffffff, 0 0 0 $xxs $color-blue-600;
       outline: none;
     }
   }
@@ -114,63 +114,63 @@
    */
 
   &--info {
-    border-color: $color-blue--200;
+    border-color: $color-blue-200;
   }
 
   &--info &__header,
   &--info &__footer {
-    background-color: $color-blue--050;
-    border-color: $color-blue--200;
-    color: $color-blue--700;
+    background-color: $color-blue-050;
+    border-color: $color-blue-200;
+    color: $color-blue-700;
   }
 
   &--info &__row {
-    border-color: $color-blue--200;
+    border-color: $color-blue-200;
   }
 
   &--success {
-    border-color: $color-green--200;
+    border-color: $color-green-200;
   }
 
   &--success &__header,
   &--success &__footer {
-    background-color: $color-green--050;
-    border-color: $color-green--200;
-    color: $color-green--700;
+    background-color: $color-green-050;
+    border-color: $color-green-200;
+    color: $color-green-700;
   }
 
   &--success &__row {
-    border-color: $color-green--200;
+    border-color: $color-green-200;
   }
 
   &--warning {
-    border-color: $color-yellow--100;
+    border-color: $color-yellow-100;
   }
 
   &--warning &__header,
   &--warning &__footer {
-    background-color: $color-yellow--050;
-    border-color: $color-yellow--100;
-    color: $color-yellow--700;
+    background-color: $color-yellow-050;
+    border-color: $color-yellow-100;
+    color: $color-yellow-700;
   }
 
   &--warning &__row {
-    border-color: $color-yellow--100;
+    border-color: $color-yellow-100;
   }
 
   &--danger {
-    border-color: $color-orange--200;
+    border-color: $color-orange-200;
   }
 
   &--danger &__header,
   &--danger &__footer {
-    background-color: $color-orange--050;
-    border-color: $color-orange--200;
-    color: $color-orange--700;
+    background-color: $color-orange-050;
+    border-color: $color-orange-200;
+    color: $color-orange-700;
   }
 
   &--danger &__row {
-    border-color: $color-orange--200;
+    border-color: $color-orange-200;
   }
 
   &--card {
@@ -179,6 +179,6 @@
   }
 
   &--card &__footer {
-    border-top-color: $color-black--200;
+    border-top-color: $color-black-200;
   }
 }

--- a/src/sass/components/_box.scss
+++ b/src/sass/components/_box.scss
@@ -22,36 +22,36 @@
 
   &__row--selected,
   &__row[aria-current] {
-    background-color: $color-black-050;
+    background-color: $color-black-000;
     box-shadow: $xxs 0 0 0 $color-blue-600 inset;
   }
 
   &__row--info {
-    background-color: $color-blue-050;
+    background-color: $color-blue-000;
     box-shadow: $xxs 0 0 0 $color-blue-600 inset;
     color: $color-blue-700;
   }
 
   &__row--success {
-    background-color: $color-green-050;
+    background-color: $color-green-000;
     color: $color-green-700;
     box-shadow: $xxs 0 0 0 $color-green-500 inset;
   }
 
   &__row--warning {
-    background-color: $color-yellow-050;
+    background-color: $color-yellow-000;
     box-shadow: $xxs 0 0 0 $color-yellow-200 inset;
     color: $color-yellow-700;
   }
 
   &__row--danger {
-    background-color: $color-orange-050;
+    background-color: $color-orange-000;
     box-shadow: $xxs 0 0 0 $color-orange-500 inset;
     color: $color-orange-700;
   }
 
   &__footer {
-    background-color: $color-black-050;
+    background-color: $color-black-000;
     border-top: 1px solid $color-black-200;
     border-bottom-right-radius: $xxs; // Gets rid of border clipping
     border-bottom-left-radius: $xxs; // Gets rid of border clipping
@@ -60,7 +60,7 @@
 
   &__header {
     align-items: center;
-    background-color: $color-black-050;
+    background-color: $color-black-000;
     border-top: none;
     border-right: none;
     border-bottom: 1px solid $color-black-200;
@@ -119,7 +119,7 @@
 
   &--info &__header,
   &--info &__footer {
-    background-color: $color-blue-050;
+    background-color: $color-blue-000;
     border-color: $color-blue-200;
     color: $color-blue-700;
   }
@@ -134,7 +134,7 @@
 
   &--success &__header,
   &--success &__footer {
-    background-color: $color-green-050;
+    background-color: $color-green-000;
     border-color: $color-green-200;
     color: $color-green-700;
   }
@@ -149,7 +149,7 @@
 
   &--warning &__header,
   &--warning &__footer {
-    background-color: $color-yellow-050;
+    background-color: $color-yellow-000;
     border-color: $color-yellow-100;
     color: $color-yellow-700;
   }
@@ -164,7 +164,7 @@
 
   &--danger &__header,
   &--danger &__footer {
-    background-color: $color-orange-050;
+    background-color: $color-orange-000;
     border-color: $color-orange-200;
     color: $color-orange-700;
   }

--- a/src/sass/components/_breadcrumb.scss
+++ b/src/sass/components/_breadcrumb.scss
@@ -30,7 +30,7 @@
   }
 
   li:first-child {
-    color: $color-black--600;
+    color: $color-black-600;
 
     &::before {
       content: none;
@@ -38,16 +38,16 @@
   }
 
   li:last-child {
-    color: $color-black--700;
+    color: $color-black-700;
   }
 
   &--call-out {
-    background-color: $color-black--100;
+    background-color: $color-black-100;
     padding: $sm;
     border-radius: $xxs;
 
     li:last-child {
-      color: $color-black--700;
+      color: $color-black-700;
     }
   }
 }

--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -5,13 +5,13 @@
 
 %button-focus {
   outline: none;
-  box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue--600;
+  box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue-600;
 }
 /* stylelint-enable */
 
 .#{$prefix}-button {
-  background-color: $color-blue--600;
-  border: $xxs/2 solid $color-blue--600;
+  background-color: $color-blue-600;
+  border: $xxs/2 solid $color-blue-600;
   border-radius: $xxs;
   color: $color-white;
   cursor: pointer;
@@ -38,29 +38,29 @@
 
   &:hover,
   &--hover {
-    background-color: $color-blue--700;
-    border-color: $color-blue--700;
+    background-color: $color-blue-700;
+    border-color: $color-blue-700;
     color: $color-white;
   }
 
   &:active,
   &--active {
-    background-color: $color-blue--800;
-    border-color: $color-blue--800;
+    background-color: $color-blue-800;
+    border-color: $color-blue-800;
   }
 
   &:disabled,
   &:disabled:hover {
-    background-color: $color-black--100;
-    color: $color-black--700;
-    border-color: $color-black--400;
+    background-color: $color-black-100;
+    color: $color-black-700;
+    border-color: $color-black-400;
     cursor: not-allowed;
   }
 }
 
 .#{$prefix}-button--secondary {
   background-color: transparent;
-  color: $color-blue--600;
+  color: $color-blue-600;
 
   &:focus,
   &-focus {
@@ -69,21 +69,21 @@
 
   &:hover,
   &-hover {
-    background-color: $color-blue--100;
-    border-color: $color-blue--600;
-    color: $color-blue--800;
+    background-color: $color-blue-100;
+    border-color: $color-blue-600;
+    color: $color-blue-800;
   }
 
   &:active,
   &-active {
-    background-color: $color-blue--200;
-    color: $color-blue--800;
+    background-color: $color-blue-200;
+    color: $color-blue-800;
   }
 }
 
 .#{$prefix}-button--success {
-  background-color: $color-green--500;
-  border-color: $color-green--500;
+  background-color: $color-green-500;
+  border-color: $color-green-500;
 
   &:focus,
   &-focus {
@@ -92,22 +92,22 @@
 
   &:hover,
   &-hover {
-    background-color: $color-green--700;
-    border-color: $color-green--700;
+    background-color: $color-green-700;
+    border-color: $color-green-700;
     color: $color-white;
   }
 
   &:active,
   &-active {
-    background-color: $color-green--800;
-    border-color: $color-green--800;
+    background-color: $color-green-800;
+    border-color: $color-green-800;
   }
 }
 
 .#{$prefix}-button--success-secondary {
   background-color: transparent;
-  border-color: $color-green--500;
-  color: $color-green--500;
+  border-color: $color-green-500;
+  color: $color-green-500;
 
   &:focus,
   &-focus {
@@ -116,22 +116,22 @@
 
   &:hover,
   &-hover {
-    background-color: $color-green--050;
-    border-color: $color-green--500;
-    color: $color-green--700;
+    background-color: $color-green-050;
+    border-color: $color-green-500;
+    color: $color-green-700;
   }
 
   &:active,
   &-active {
-    background-color: $color-green--100;
-    border-color: $color-green--500;
-    color: $color-green--800;
+    background-color: $color-green-100;
+    border-color: $color-green-500;
+    color: $color-green-800;
   }
 }
 
 .#{$prefix}-button--danger {
-  background-color: $color-orange--500;
-  border-color: $color-orange--500;
+  background-color: $color-orange-500;
+  border-color: $color-orange-500;
 
   &:focus,
   &-focus {
@@ -140,22 +140,22 @@
 
   &:hover,
   &-hover {
-    background-color: $color-orange--700;
-    border-color: $color-orange--700;
+    background-color: $color-orange-700;
+    border-color: $color-orange-700;
     color: $color-white;
   }
 
   &:active,
   &-active {
-    background-color: $color-orange--800;
-    border-color: $color-orange--800;
+    background-color: $color-orange-800;
+    border-color: $color-orange-800;
   }
 }
 
 .#{$prefix}-button--danger-secondary {
   background-color: transparent;
-  border-color: $color-orange--500;
-  color: $color-orange--500;
+  border-color: $color-orange-500;
+  color: $color-orange-500;
 
   &:focus,
   &-focus {
@@ -164,16 +164,16 @@
 
   &:hover,
   &-hover {
-    background-color: $color-orange--050;
-    border-color: $color-orange--500;
-    color: $color-orange--700;
+    background-color: $color-orange-050;
+    border-color: $color-orange-500;
+    color: $color-orange-700;
   }
 
   &:active,
   &-active {
-    background-color: $color-orange--100;
-    border-color: $color-orange--500;
-    color: $color-orange--800;
+    background-color: $color-orange-100;
+    border-color: $color-orange-500;
+    color: $color-orange-800;
   }
 }
 
@@ -189,21 +189,21 @@
   }
 
   &-hover {
-    background-color: $color-blue--700;
-    border-color: $color-blue--700;
+    background-color: $color-blue-700;
+    border-color: $color-blue-700;
     color: $color-white;
   }
 
   &-active,
   &:active {
-    border-color: $color-blue--800;
+    border-color: $color-blue-800;
   }
 }
 
 .#{$prefix}-button--plain {
   border-color: transparent;
   background-color: transparent;
-  color: $color-blue--600;
+  color: $color-blue-600;
 
   &:focus,
   &-focus,
@@ -213,21 +213,21 @@
 
   &:hover,
   &-hover {
-    background-color: $color-blue--100;
+    background-color: $color-blue-100;
     border-color: transparent;
-    color: $color-blue--800;
+    color: $color-blue-800;
   }
 
   &:active,
   &-active {
-    background-color: $color-blue--200;
+    background-color: $color-blue-200;
     border-color: transparent;
-    color: $color-blue--800;
+    color: $color-blue-800;
   }
 
   &:disabled,
   &:disabled:hover {
-    border-color: $color-black--100;
+    border-color: $color-black-100;
   }
 }
 
@@ -264,16 +264,16 @@
 
 .#{$prefix}-button--loading,
 .#{$prefix}-button--loading[disabled] {
-  background-color: $color-black--100;
-  border-color: $color-black--400;
-  color: $color-black--700;
+  background-color: $color-black-100;
+  border-color: $color-black-400;
+  color: $color-black-700;
   justify-content: center;
   position: relative;
 
   &:hover {
-    background-color: $color-black--100;
-    border-color: $color-black--400;
-    color: $color-black--700;
+    background-color: $color-black-100;
+    border-color: $color-black-400;
+    color: $color-black-700;
   }
 
   .#{$prefix}-button__content {
@@ -281,9 +281,9 @@
   }
 
   .#{$prefix}-loader {
-    border-bottom-color: $color-black--400;
-    border-right-color: $color-black--400;
-    border-top-color: $color-black--400;
+    border-bottom-color: $color-black-400;
+    border-right-color: $color-black-400;
+    border-top-color: $color-black-400;
     display: block;
     position: absolute;
     left: 50%;

--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -116,7 +116,7 @@
 
   &:hover,
   &-hover {
-    background-color: $color-green-050;
+    background-color: $color-green-000;
     border-color: $color-green-500;
     color: $color-green-700;
   }
@@ -164,7 +164,7 @@
 
   &:hover,
   &-hover {
-    background-color: $color-orange-050;
+    background-color: $color-orange-000;
     border-color: $color-orange-500;
     color: $color-orange-700;
   }

--- a/src/sass/components/_checkboxes.scss
+++ b/src/sass/components/_checkboxes.scss
@@ -34,7 +34,7 @@ input[type='checkbox'] + label,
      *  make radios and checkboxes look optically closer the 1px border
      * used on other inputs like text inputs, textareas, and selects.
      */
-    box-shadow: 0 0 0 .08rem $color-black--400;
+    box-shadow: 0 0 0 .08rem $color-black-400;
 
     /**
      * This helps visually center the label with the pseudo
@@ -53,8 +53,8 @@ input[type='checkbox']:checked + label,
 .#{$prefix}-checkbox-wrapper input[type='checkbox']:checked ~ label {
   &::before {
     color: $color-white;
-    background-color: $color-blue--600;
-    box-shadow: 0 0 0 .08rem $color-blue--600;
+    background-color: $color-blue-600;
+    box-shadow: 0 0 0 .08rem $color-blue-600;
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij4KICAgIDxwYXRoIGZpbGw9IiNmZmZmZmYiIGQ9Ik02LjcyLDEzbC0uNDgtLjM2LTMtM0ExLDEsMCwwLDEsNC43MSw4LjI5bDIuMTEsMi4xMiw0LjMzLTYuOTRhMSwxLDAsMCwxLDEuNywxLjA2TDcuNjQsMTIuODdaIi8+Cjwvc3ZnPgo=');
     background-position: 50% 50%;
     background-repeat: no-repeat;
@@ -66,17 +66,17 @@ input[type='checkbox']:checked + label,
 input[type='checkbox']:focus + label::before,
 .#{$prefix}-checkbox-wrapper input[type='checkbox']:focus ~ label::before {
   box-shadow:
-    0 0 0 .08rem $color-black--700,
+    0 0 0 .08rem $color-black-700,
     0 0 0 .1875rem $color-white,
-    0 0 0 .3125rem $color-blue--600;
+    0 0 0 .3125rem $color-blue-600;
 }
 
 /* stylelint-enable */
 
 input[type='checkbox']:disabled + label::before,
 .#{$prefix}-checkbox-wrapper input[type='checkbox']:disabled ~ label::before {
-  background-color: $color-black--200;
-  box-shadow: 0 0 0 .08rem $color-black--300;
+  background-color: $color-black-200;
+  box-shadow: 0 0 0 .08rem $color-black-300;
 }
 
 /* stylelint-disable */
@@ -86,16 +86,16 @@ input[type='checkbox']:indeterminate:focus + label::before,
 .#{$prefix}-checkbox-wrapper input[type='checkbox']:checked:focus ~ label::before,
 .#{$prefix}-checkbox-wrapper input[type='checkbox']:indeterminate:focus ~ label::before {
   box-shadow:
-    0 0 0 .08rem $color-blue--600,
+    0 0 0 .08rem $color-blue-600,
     0 0 0 .1875rem $color-white,
-    0 0 0 .3125rem $color-blue--500;
+    0 0 0 .3125rem $color-blue-500;
 }
 
 /* stylelint-enable */
 
 input[type='checkbox']:disabled + label,
 .#{$prefix}-checkbox-wrapper input[type='checkbox']:disabled ~ label {
-  color: $color-black--700;
+  color: $color-black-700;
   cursor: default;
 }
 
@@ -108,14 +108,14 @@ input[type='checkbox']:disabled + label,
 input[type='checkbox']:indeterminate + label::before,
 .#{$prefix}-checkbox-wrapper input[type='checkbox']:indeterminate ~ label::before {
   background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij4KICAgIDxwYXRoIGZpbGw9IiNmZmZmZmYiIGQ9Ik0xNCw5SDJBMSwxLDAsMCwxLDIsN0gxNGExLDEsMCwwLDEsMCwyWiIvPgo8L3N2Zz4=');
-  background-color: $color-blue--600;
-  box-shadow: 0 0 0 .08rem $color-blue--600;
+  background-color: $color-blue-600;
+  box-shadow: 0 0 0 .08rem $color-blue-600;
 }
 
 /* stylelint-enable */
 
 input[type='checkbox']:indeterminate:disabled + label::before,
 .#{$prefix}-checkbox-wrapper input[type='checkbox']:indeterminate:disabled ~ label::before {
-  background-color: $color-black--200;
-  box-shadow: 0 0 0 .08rem $color-black--300;
+  background-color: $color-black-200;
+  box-shadow: 0 0 0 .08rem $color-black-300;
 }

--- a/src/sass/components/_dropdown.scss
+++ b/src/sass/components/_dropdown.scss
@@ -21,7 +21,7 @@
     padding: 0;
 
     &:focus {
-      outline: $xxs/2 solid $color-blue--600;
+      outline: $xxs/2 solid $color-blue-600;
       outline-offset: $xxs/2;
     }
 
@@ -88,39 +88,39 @@
       text-align: left;
 
       &:hover {
-        background-color: $color-blue--600;
+        background-color: $color-blue-600;
         color: $color-white;
         text-decoration: none;
       }
 
       &:focus {
         outline: none;
-        box-shadow: inset 0 0 0 $xxs/2 $color-blue--600;
+        box-shadow: inset 0 0 0 $xxs/2 $color-blue-600;
       }
 
       &.#{$prefix}-is-selected,
       &[aria-current],
       &[aria-checked='true'] {
-        box-shadow: inset $xxs 0 0 $color-blue--600;
+        box-shadow: inset $xxs 0 0 $color-blue-600;
 
         &:focus {
           /* stylelint-disable */
           box-shadow:
-            inset $xxs 0 0 $color-blue--600,
-            inset 0 0 0 $xxs/2 $color-blue--600 !important;
+            inset $xxs 0 0 $color-blue-600,
+            inset 0 0 0 $xxs/2 $color-blue-600 !important;
           /* stylelint-enable */
         }
       }
     }
 
     button:disabled {
-      color: $color-black--800;
-      background-color: $color-black--100;
+      color: $color-black-800;
+      background-color: $color-black-100;
     }
   }
 
   &__menu-heading {
-    color: $color-black--700;
+    color: $color-black-700;
     padding: $sm $sm $xxs;
     font-weight: $font-weight-bold;
     font-size: $ts-14;
@@ -132,13 +132,13 @@
 
   &__menu-divider,
   &__menu-separator {
-    border-top: 1px solid $color-black--200;
+    border-top: 1px solid $color-black-200;
     margin-top: $xs;
     margin-bottom: $xs;
   }
 
   [role='group'] {
-    border-top: 1px solid $color-black--200;
+    border-top: 1px solid $color-black-200;
     margin-top: $xs;
     padding-top: $xs;
 

--- a/src/sass/components/_feature.scss
+++ b/src/sass/components/_feature.scss
@@ -33,7 +33,7 @@
 
   &__meta {
     margin-top: $md;
-    color: $color-black--700;
+    color: $color-black-700;
   }
 
   &__title a,

--- a/src/sass/components/_file-input.scss
+++ b/src/sass/components/_file-input.scss
@@ -31,14 +31,14 @@
   input[type='file']:focus + label {
     outline: none;
     /* stylelint-disable */
-    box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue--600 !important;
+    box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue-600 !important;
     /* stylelint-enable */
   }
 
   input[type='file']:disabled + label {
-    background-color: $color-black--100;
-    color: $color-black--700;
-    border-color: $color-black--400;
+    background-color: $color-black-100;
+    color: $color-black-700;
+    border-color: $color-black-400;
     cursor: not-allowed;
   }
 

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -5,7 +5,7 @@
   align-items: center;
   font-size: ts(12);
   padding: $xs $md;
-  background-color: $color-black-050;
+  background-color: $color-black-000;
   border-top: 1px solid $color-black-100;
   width: 100%;
 

--- a/src/sass/components/_footer.scss
+++ b/src/sass/components/_footer.scss
@@ -5,8 +5,8 @@
   align-items: center;
   font-size: ts(12);
   padding: $xs $md;
-  background-color: $color-black--050;
-  border-top: 1px solid $color-black--100;
+  background-color: $color-black-050;
+  border-top: 1px solid $color-black-100;
   width: 100%;
 
   a {
@@ -39,7 +39,7 @@
 
     &:first-child::after {
       content: "|";
-      color: $color-black--500;
+      color: $color-black-500;
       margin: 0 $xs;
     }
 
@@ -57,7 +57,7 @@
   .#{$prefix}-footer {
     &__aux-item::after {
       content: "|";
-      color: $color-black--500;
+      color: $color-black-500;
       margin: 0 $xs;
     }
 

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -16,7 +16,7 @@
   display: flex;
   align-items: center;
   border-bottom: 1px solid $color-black-100;
-  background-color: $color-black-050;
+  background-color: $color-black-000;
   width: 100%;
 }
 
@@ -534,7 +534,7 @@
     padding-top: .35rem;
     font-size: .75rem;
     font-weight: $font-weight-bold;
-    color: $color-black-050;
+    color: $color-black-000;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -15,14 +15,14 @@
 .#{$prefix}-header {
   display: flex;
   align-items: center;
-  border-bottom: 1px solid $color-black--100;
-  background-color: $color-black--050;
+  border-bottom: 1px solid $color-black-100;
+  background-color: $color-black-050;
   width: 100%;
 }
 
 .#{$prefix}-header--light {
   background-color: $color-white;
-  border-bottom: 1px solid $color-black--100;
+  border-bottom: 1px solid $color-black-100;
 }
 
 .#{$prefix}-header__trident {
@@ -98,7 +98,7 @@
   height: 47px;
   padding: 0;
   border-radius: 0;
-  border-left: 1px solid $color-black--200;
+  border-left: 1px solid $color-black-200;
   vertical-align: middle;
   display: flex;
   align-items: center;
@@ -106,8 +106,8 @@
   color: $color-black;
 
   &:hover {
-    background-color: $color-black--200;
-    border-color: $color-black--200;
+    background-color: $color-black-200;
+    border-color: $color-black-200;
     color: $color-black;
   }
 
@@ -116,17 +116,17 @@
   }
 
   &:active:hover {
-    background-color: $color-blue--800;
+    background-color: $color-blue-800;
     color: $color-white;
   }
 
   &:focus {
-    box-shadow: inset 0 0 0 $xxs/2 $color-blue--600;
+    box-shadow: inset 0 0 0 $xxs/2 $color-blue-600;
     outline: none;
   }
 
   &[aria-expanded='true'] {
-    background-color: $color-black--100;
+    background-color: $color-black-100;
 
     &:hover {
       color: $color-black;
@@ -134,11 +134,11 @@
 
     &:active:hover {
       padding-top: 0;
-      background-color: $color-blue--800;
+      background-color: $color-blue-800;
     }
 
     &:focus {
-      background-color: $color-blue--600;
+      background-color: $color-blue-600;
       box-shadow: none;
       color: $color-white;
     }
@@ -233,7 +233,7 @@
     position: relative;
 
     &:focus {
-      outline: $xxs/2 solid $color-blue--600;
+      outline: $xxs/2 solid $color-blue-600;
       outline-offset: $xxs/2;
     }
 
@@ -249,7 +249,7 @@
     &::after {
       content: ' ';
       position: absolute;
-      background-color: $color-blue--600;
+      background-color: $color-blue-600;
       height: $xxs;
       width: 100%;
       top: 2.75rem;
@@ -324,11 +324,11 @@
   position: absolute;
   right: 0;
   top: 47px;
-  background-color: $color-black--100;
+  background-color: $color-black-100;
   width: 85%;
   max-width: 400px;
   min-height: 100%;
-  border-left: 1px solid $color-black--200;
+  border-left: 1px solid $color-black-200;
   padding: $sm;
   z-index: map-get($z-index, z-1000);
 
@@ -341,7 +341,7 @@
     }
 
     ul li {
-      border-bottom: 2px solid $color-black--100;
+      border-bottom: 2px solid $color-black-100;
       line-height: 1.5;
       margin-top: 0;
     }
@@ -351,7 +351,7 @@
     }
 
     ul li ul {
-      background-color: $color-black--200;
+      background-color: $color-black-200;
       margin: 0;
     }
 
@@ -383,14 +383,14 @@
       display: flex;
       width: inherit;
       margin-left: 0;
-      color: $color-blue--600;
+      color: $color-blue-600;
 
       &:hover {
-        color: $color-blue--900;
+        color: $color-blue-900;
       }
 
       &:focus {
-        outline: $xxs/2 solid $color-blue--600;
+        outline: $xxs/2 solid $color-blue-600;
         outline-offset: $xxs/2;
       }
     }
@@ -421,7 +421,7 @@
 
     ul li ul li a {
       padding: $sm;
-      background-color: $color-black--200;
+      background-color: $color-black-200;
     }
 
     /**
@@ -431,27 +431,27 @@
     ul li a[aria-current],
     ul li button[aria-current],
     ul li ul li a[aria-current] {
-      box-shadow: inset $xxs 0 0 $color-blue--600;
+      box-shadow: inset $xxs 0 0 $color-blue-600;
 
       &:focus {
         /* stylelint-disable */
         box-shadow:
-          inset $xxs 0 0 $color-blue--600,
+          inset $xxs 0 0 $color-blue-600,
           0 0 0 $xxs/2 $color-white,
-          0 0 0 $xxs $color-blue--600;
+          0 0 0 $xxs $color-blue-600;
         /* stylelint-enable */
       }
     }
   }
 
   &__nav--accent {
-    border-top: 1px solid $color-black--200;
+    border-top: 1px solid $color-black-200;
   }
 
   &__bottom-close {
     background-color: transparent;
     border: none;
-    color: $color-blue--600;
+    color: $color-blue-600;
     padding: 0;
     height: 1px;
     width: 1px;
@@ -461,7 +461,7 @@
 
     &:focus {
       outline: none;
-      box-shadow: 0 0 0 .125rem $color-blue--600;
+      box-shadow: 0 0 0 .125rem $color-blue-600;
       display: block;
       margin-top: $xs;
       width: 100%;
@@ -497,7 +497,7 @@
     display: flex;
     align-items: center;
     color: $color-black;
-    border-right: 1px solid $color-black--300;
+    border-right: 1px solid $color-black-300;
     padding-right: $sm;
   }
 
@@ -534,7 +534,7 @@
     padding-top: .35rem;
     font-size: .75rem;
     font-weight: $font-weight-bold;
-    color: $color-black--050;
+    color: $color-black-050;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
@@ -552,7 +552,7 @@
   }
 
   &__profile--drawer &__user {
-    border-right: 1px solid $color-black--200;
+    border-right: 1px solid $color-black-200;
     padding-right: $sm;
   }
 

--- a/src/sass/components/_input-group.scss
+++ b/src/sass/components/_input-group.scss
@@ -39,8 +39,8 @@
 
   &__append &__text,
   &__prepend &__text {
-    background-color: $color-black--100;
-    border: 1px solid $color-black--700;
+    background-color: $color-black-100;
+    border: 1px solid $color-black-700;
     display: flex;
     align-items: center;
     height: 100%;

--- a/src/sass/components/_inputs.scss
+++ b/src/sass/components/_inputs.scss
@@ -35,7 +35,7 @@ select {
    *
    * https://github.com/w3c/wcag21/issues/10
    */
-  border: 1px solid $color-black--400;
+  border: 1px solid $color-black-400;
   padding: $xs;
   height: $xl;
   line-height: 1;
@@ -93,7 +93,7 @@ input[type='week']:disabled,
 input:not([type]):disabled,
 textarea:disabled,
 select:disabled {
-  background-color: $color-black--100;
+  background-color: $color-black-100;
   cursor: not-allowed;
 }
 
@@ -116,7 +116,7 @@ textarea:focus,
 select:focus {
   outline: none;
   /* stylelint-disable */
-  box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue--600;
+  box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue-600;
   /* stylelint-enable */
   transition: box-shadow .2s ease;
 }

--- a/src/sass/components/_links.scss
+++ b/src/sass/components/_links.scss
@@ -3,14 +3,14 @@
 
 a,
 .#{$prefix}-link {
-  color: $color-blue--600;
+  color: $color-blue-600;
 
   &:hover {
-    color: $color-blue--900;
+    color: $color-blue-900;
   }
 
   &:focus {
-    outline: $xxs/2 solid $color-blue--600;
+    outline: $xxs/2 solid $color-blue-600;
     outline-offset: $xxs/2;
   }
 
@@ -18,7 +18,7 @@ a,
     /**
      * TODO: Come up with a better color for the :visited state.
      */
-    color: $color-blue--900;
+    color: $color-blue-900;
   }
 }
 

--- a/src/sass/components/_loading-indicator.scss
+++ b/src/sass/components/_loading-indicator.scss
@@ -7,9 +7,9 @@
   width: $sm * 1.25;
   height: $sm * 1.25;
   border: .2rem solid transparent;
-  border-top-color: $color-blue--600;
-  border-right-color: $color-blue--600;
-  border-bottom-color: $color-blue--600;
+  border-top-color: $color-blue-600;
+  border-right-color: $color-blue-600;
+  border-bottom-color: $color-blue-600;
   border-radius: 50%;
   position: relative;
 

--- a/src/sass/components/_menu.scss
+++ b/src/sass/components/_menu.scss
@@ -22,7 +22,7 @@
   }
 
   &__item a[aria-current] {
-    background-color: $color-black--100;
+    background-color: $color-black-100;
   }
 
   &__item a[aria-current]::after,
@@ -32,7 +32,7 @@
     display: block;
     width: $xxs;
     height: 100%;
-    background-color: $color-blue--600;
+    background-color: $color-blue-600;
     position: absolute;
     left: 0;
     top: 0;
@@ -42,7 +42,7 @@
 @mixin horizontal-menu($selector) {
   .#{$prefix}-menu {
     #{$selector} {
-      border-bottom: 1px solid $color-black--200;
+      border-bottom: 1px solid $color-black-200;
     }
 
     #{$selector} &__list {
@@ -73,7 +73,7 @@
 
     #{$selector} &__item a:hover::after,
     #{$selector} &__item button:hover::after {
-      background-color: $color-black--200;
+      background-color: $color-black-200;
     }
   }
 }

--- a/src/sass/components/_modals.scss
+++ b/src/sass/components/_modals.scss
@@ -52,21 +52,21 @@
     color: $color-black;
 
     &:hover {
-      background-color: $color-blue--600;
+      background-color: $color-blue-600;
       color: $color-white;
     }
 
     &:focus {
       outline: none;
       /* stylelint-disable */
-      box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue--600;
+      box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue-600;
       /* stylelint-enable */
     }
   }
 
   &__header {
     padding: $md $sm;
-    border-bottom: 1px solid $color-black--100;
+    border-bottom: 1px solid $color-black-100;
   }
 
   &--confirmation &__header {
@@ -90,8 +90,8 @@
   &__controls {
     padding: $sm;
     display: flex;
-    border-top: 1px solid $color-black--100;
-    background-color: $color-black--050;
+    border-top: 1px solid $color-black-100;
+    background-color: $color-black-050;
     flex-wrap: wrap;
 
     .#{$prefix}-button {

--- a/src/sass/components/_modals.scss
+++ b/src/sass/components/_modals.scss
@@ -91,7 +91,7 @@
     padding: $sm;
     display: flex;
     border-top: 1px solid $color-black-100;
-    background-color: $color-black-050;
+    background-color: $color-black-000;
     flex-wrap: wrap;
 
     .#{$prefix}-button {

--- a/src/sass/components/_pagination.scss
+++ b/src/sass/components/_pagination.scss
@@ -20,7 +20,7 @@
     margin-top: 0;
 
     a {
-      border: 1px solid $color-black--300;
+      border: 1px solid $color-black-300;
       display: inline-block;
 
       /**
@@ -42,13 +42,13 @@
     }
 
     a:hover {
-      background-color: $color-black--100;
+      background-color: $color-black-100;
     }
 
     a:focus {
       border-radius: inherit;
       /* stylelint-disable */
-      box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue--600;
+      box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue-600;
       /* stylelint-enable */
       outline: none;
       z-index: map-get($z-index, z-1000);
@@ -80,8 +80,8 @@
    */
 
   &__item.is-active a {
-    background-color: $color-blue--600;
-    border-color: $color-blue--600;
+    background-color: $color-blue-600;
+    border-color: $color-blue-600;
     color: $color-white;
 
     /**
@@ -95,11 +95,11 @@
    */
 
   &__item.is-disabled a {
-    color: $color-black--700;
-    background-color: $color-black--100;
+    color: $color-black-700;
+    background-color: $color-black-100;
 
     &:hover {
-      border-color: $color-black--200;
+      border-color: $color-black-200;
       cursor: default;
     }
 

--- a/src/sass/components/_radios.scss
+++ b/src/sass/components/_radios.scss
@@ -26,7 +26,7 @@ input[type='radio'] + label,
      *  make radios and checkboxes look optically closer the 1px border
      * used on other inputs like text inputs, textareas, and selects.
      */
-    box-shadow: 0 0 0 .08rem $color-black--400;
+    box-shadow: 0 0 0 .08rem $color-black-400;
     content: ' ';
     line-height: 1;
     vertical-align: middle;
@@ -54,19 +54,19 @@ input[type='radio'] + label,
 input[type='radio']:checked + label,
 .#{$prefix}-radio-wrapper input[type='radio']:checked ~ label {
   &::before {
-    background-color: $color-blue--600;
+    background-color: $color-blue-600;
     box-shadow:
       inset 0 0 0 .125rem $color-white,
-      0 0 0 .125rem $color-blue--600;
+      0 0 0 .125rem $color-blue-600;
   }
 }
 
 input[type='radio']:focus + label::before,
 .#{$prefix}-radio-wrapper input[type='radio']:focus ~ label::before {
   box-shadow:
-    0 0 0 .08rem $color-black--700,
+    0 0 0 .08rem $color-black-700,
     0 0 0 .1875rem $color-white,
-    0 0 0 .3125rem $color-blue--600;
+    0 0 0 .3125rem $color-blue-600;
 }
 
 /**
@@ -79,26 +79,26 @@ input[type='radio']:checked:focus + label::before,
 .#{$prefix}-radio-wrapper input[type='radio']:checked:focus ~ label::before {
   box-shadow:
     inset 0 0 0 .125rem $color-white,
-    0 0 0 .125rem $color-blue--600,
-    0 0 0 .3125rem $color-blue--500;
+    0 0 0 .125rem $color-blue-600,
+    0 0 0 .3125rem $color-blue-500;
 }
 
 input[type='radio']:disabled + label::before,
 .#{$prefix}-radio-wrapper input[type='radio']:disabled ~ label::before {
-  background-color: $color-black--200;
-  box-shadow: 0 0 0 .08rem $color-black--300;
+  background-color: $color-black-200;
+  box-shadow: 0 0 0 .08rem $color-black-300;
 }
 
 /* stylelint-enable */
 
 input[type='radio']:checked:disabled + label::before,
 .#{$prefix}-radio-wrapper input[type='radio']:checked:disabled ~ label::before {
-  background-color: $color-black--600;
-  box-shadow: inset 0 0 0 .125rem $color-black--200, 0 0 0 .08rem $color-black--600;
+  background-color: $color-black-600;
+  box-shadow: inset 0 0 0 .125rem $color-black-200, 0 0 0 .08rem $color-black-600;
 }
 
 input[type='radio']:disabled + label,
 .#{$prefix}-radio-wrapper input[type='radio']:disabled ~ label {
   cursor: default;
-  color: $color-black--600;
+  color: $color-black-600;
 }

--- a/src/sass/components/_sidenav.scss
+++ b/src/sass/components/_sidenav.scss
@@ -83,7 +83,7 @@ $shade-selector: '.#{$item} > .#{$list}';
 
 // Set up level indent/background shade map
 $level-styles: (
-  20: $color-black-050,
+  20: $color-black-000,
   40: $color-black-100,
   60: $color-black-200
 );

--- a/src/sass/components/_sidenav.scss
+++ b/src/sass/components/_sidenav.scss
@@ -12,7 +12,7 @@
 
   &__item {
     align-items: center;
-    border-top: 1px solid $color-black--100;
+    border-top: 1px solid $color-black-100;
     display: flex;
     flex-wrap: wrap;
     margin-top: 0; // resets Rivet default margin-top
@@ -83,9 +83,9 @@ $shade-selector: '.#{$item} > .#{$list}';
 
 // Set up level indent/background shade map
 $level-styles: (
-  20: $color-black--050,
-  40: $color-black--100,
-  60: $color-black--200
+  20: $color-black-050,
+  40: $color-black-100,
+  60: $color-black-200
 );
 
 /* TODO: Adjust stylelint rules to handle nested Sass */
@@ -104,11 +104,11 @@ $level-styles: (
   // Set border-top color per nested level
   #{$indent-selector} {
     @if $index == 1 {
-      border-color: $color-black--100;
+      border-color: $color-black-100;
     } @else if $index == 2 {
-      border-color: $color-black--200;
+      border-color: $color-black-200;
     } @else if $index == 3 {
-      border-color: $color-black--300;
+      border-color: $color-black-300;
     }
   }
 

--- a/src/sass/components/_step-indicator.scss
+++ b/src/sass/components/_step-indicator.scss
@@ -19,7 +19,7 @@
       content: "";
       display: block;
       width: 100%;
-      box-shadow: 0 $sm*2.75 0 $xxs/2 $color-black--100;
+      box-shadow: 0 $sm*2.75 0 $xxs/2 $color-black-100;
       z-index: 0;
     }
 
@@ -56,7 +56,7 @@
   }
 
   &__item-content:focus &__indicator {
-    box-shadow: 0 0 0 $xxs $color-blue--300;
+    box-shadow: 0 0 0 $xxs $color-blue-300;
   }
 
   &__label {
@@ -71,7 +71,7 @@
   &__indicator {
     align-items: center;
     background-color: $color-white;
-    border: $xxs solid $color-black--200;
+    border: $xxs solid $color-black-200;
     border-radius: 999rem;
     box-shadow: 0 0 0 $xxs $color-white;
     display: inline-flex;
@@ -83,20 +83,20 @@
   }
 
   &__indicator--success {
-    background-color: $color-green--500;
-    border-color: $color-green--400;
+    background-color: $color-green-500;
+    border-color: $color-green-400;
     color: $color-white;
   }
 
   &__indicator--warning {
-    background-color: $color-yellow--200;
-    border-color: $color-yellow--100;
-    color: $color-black--900;
+    background-color: $color-yellow-200;
+    border-color: $color-yellow-100;
+    color: $color-black-900;
   }
 
   &__indicator--danger {
-    background-color: $color-orange--500;
-    border-color: $color-orange--400;
+    background-color: $color-orange-500;
+    border-color: $color-orange-400;
     color: $color-white;
   }
 
@@ -120,7 +120,7 @@
   }
 
   &--vertical &__item::before {
-    box-shadow: -$xxs 0 0 0 $color-black--100;
+    box-shadow: -$xxs 0 0 0 $color-black-100;
     height: 100%;
     position: absolute;
     top: 0;

--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -17,7 +17,7 @@ tr th {
 
 thead {
   border-bottom: 1px solid $color-black-200;
-  background-color: $color-black-050;
+  background-color: $color-black-000;
 
   th,
   tr th {
@@ -48,7 +48,7 @@ tr td {
 
 .#{$prefix}-table-stripes {
   tr:nth-child(even) {
-    background-color: $color-black-050;
+    background-color: $color-black-000;
   }
 }
 

--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -16,8 +16,8 @@ tr th {
 }
 
 thead {
-  border-bottom: 1px solid $color-black--200;
-  background-color: $color-black--050;
+  border-bottom: 1px solid $color-black-200;
+  background-color: $color-black-050;
 
   th,
   tr th {
@@ -28,7 +28,7 @@ thead {
 }
 
 tr {
-  border-bottom: 1px solid $color-black--200;
+  border-bottom: 1px solid $color-black-200;
 }
 
 tr td {
@@ -48,7 +48,7 @@ tr td {
 
 .#{$prefix}-table-stripes {
   tr:nth-child(even) {
-    background-color: $color-black--050;
+    background-color: $color-black-050;
   }
 }
 
@@ -62,15 +62,15 @@ tr td {
 }
 
 .#{$prefix}-table-cells {
-  border-top: 1px solid $color-black--200;
+  border-top: 1px solid $color-black-200;
 
   tr td,
   tr th {
-    border-right: 1px solid $color-black--200;
+    border-right: 1px solid $color-black-200;
   }
 
   tr td:first-child,
   tr th:first-child {
-    border-left: 1px solid $color-black--200;
+    border-left: 1px solid $color-black-200;
   }
 }

--- a/src/sass/components/_tabs.scss
+++ b/src/sass/components/_tabs.scss
@@ -3,13 +3,13 @@
 
 .#{$prefix}-tabs {
   &__tab {
-    background-color: $color-black--100;
-    border-top: 1px solid $color-black--300;
-    border-right: 1px solid $color-black--300;
-    border-left: 1px solid $color-black--300;
+    background-color: $color-black-100;
+    border-top: 1px solid $color-black-300;
+    border-right: 1px solid $color-black-300;
+    border-left: 1px solid $color-black-300;
     border-bottom: none;
     border-radius: 0;
-    color: $color-black--700;
+    color: $color-black-700;
     display: block;
     line-height: 1;
     margin-right: $xs;
@@ -21,7 +21,7 @@
     z-index: map-get($z-index, z-100);
 
     &:last-child {
-      border-bottom: 1px solid $color-black--300;
+      border-bottom: 1px solid $color-black-300;
       margin-right: 0;
     }
 
@@ -32,8 +32,8 @@
 
     &:focus,
     &:hover {
-      background-color: $color-blue--600;
-      border-color: $color-blue--600;
+      background-color: $color-blue-600;
+      border-color: $color-blue-600;
       color: $color-white;
     }
 
@@ -41,7 +41,7 @@
       /* stylelint-disable */
       box-shadow:
         0 0 0 $xxs/2 $color-white,
-        0 0 0 $xxs $color-blue--600;
+        0 0 0 $xxs $color-blue-600;
       /* stylelint-enable */
       outline: none;
       z-index: map-get($z-index, z-1000);
@@ -49,13 +49,13 @@
   }
 
   &__tab[aria-selected='true'] {
-    background-color: $color-blue--600;
-    border-color: $color-blue--600;
+    background-color: $color-blue-600;
+    border-color: $color-blue-600;
     color: $color-white;
   }
 
   &__panel {
-    border: 1px solid $color-black--300;
+    border: 1px solid $color-black-300;
     border-bottom-right-radius: $xxs;
     border-bottom-left-radius: $xxs;
     margin-top: -1px;
@@ -63,7 +63,7 @@
     transition: box-shadow .2s ease;
 
     &:focus {
-      box-shadow: inset 0 0 0 $xxs/2 $color-blue--600;
+      box-shadow: inset 0 0 0 $xxs/2 $color-blue-600;
       outline: none;
     }
   }
@@ -77,7 +77,7 @@
       display: inline-block;
       text-align: center;
       width: auto;
-      border-bottom: 1px solid $color-black--300;
+      border-bottom: 1px solid $color-black-300;
     }
 
     &__tablist {
@@ -95,13 +95,13 @@
  */
 @include mq($breakpoint-md) {
   .#{$prefix}-tabs--vertical {
-    border: 1px solid $color-black--300;
+    border: 1px solid $color-black-300;
     border-radius: $xxs;
     display: flex;
     justify-content: space-between;
 
     .#{$prefix}-tabs__tablist {
-      border-right: 1px solid $color-black--300;
+      border-right: 1px solid $color-black-300;
       display: block;
       flex-basis: 250px;
       flex-grow: 0;
@@ -112,7 +112,7 @@
       border-right: none;
       border-radius: 0;
       border-top: none;
-      border-bottom: 1px solid $color-black--300;
+      border-bottom: 1px solid $color-black-300;
       border-left: none;
       width: 100%;
 

--- a/src/sass/components/_timeline.scss
+++ b/src/sass/components/_timeline.scss
@@ -13,7 +13,7 @@
     left: 0;
     height: 100%;
     width: $xxs;
-    background: $color-black--100;
+    background: $color-black-100;
   }
 
   &__item::after {
@@ -24,7 +24,7 @@
     width: 0;
     position: absolute;
     pointer-events: none;
-    border-right-color: $color-black--100;
+    border-right-color: $color-black-100;
     border-width: $sm;
     top: .4rem;
   }
@@ -43,9 +43,9 @@
     height: $sm*.75;
     position: absolute;
     color: $color-white;
-    background: $color-blue--600;
+    background: $color-blue-600;
     border-radius: 50%;
-    box-shadow: 0 0 0 $xxs $color-black--100;
+    box-shadow: 0 0 0 $xxs $color-black-100;
     margin-top: $sm;
   }
 
@@ -65,7 +65,7 @@
 
   &__date {
     font-size: $ts-14;
-    color: $color-black--700;
+    color: $color-black-700;
   }
 }
 
@@ -78,7 +78,7 @@
   .#{$prefix}-timeline__item::after {
     margin-left: 0;
     right: 0;
-    border-left-color: $color-black--100;
+    border-left-color: $color-black-100;
     border-right-color: transparent;
   }
 
@@ -151,14 +151,14 @@
     .#{$prefix}-timeline__item::after {
       margin-left: -$md;
       left: 100%;
-      border-left-color: $color-black--100;
+      border-left-color: $color-black-100;
       border-right-color: transparent;
     }
 
     .#{$prefix}-timeline__item--right::after {
       margin-left: -$sm;
       left: auto;
-      border-right-color: $color-black--100;
+      border-right-color: $color-black-100;
       border-left-color: transparent;
     }
 

--- a/src/sass/components/_validation.scss
+++ b/src/sass/components/_validation.scss
@@ -3,60 +3,60 @@
 
 @include all-inputs('.#{$prefix}-validation-info') {
   transition: box-shadow .2s ease;
-  border-color: $color-blue--600;
-  box-shadow: 0 0 0 .125rem $color-blue--600;
+  border-color: $color-blue-600;
+  box-shadow: 0 0 0 .125rem $color-blue-600;
 
   &:focus {
-    border-color: $color-black--700;
+    border-color: $color-black-700;
     /* stylelint-disable */
     box-shadow:
       0 0 0 .125rem $color-white,
-      0 0 0 .2875rem $color-blue--600;
+      0 0 0 .2875rem $color-blue-600;
     /* stylelint-enable */
   }
 }
 
 @include all-inputs('.#{$prefix}-validation-warning') {
   transition: box-shadow .2s ease;
-  border-color: $color-yellow--200;
-  box-shadow: 0 0 0 .125rem $color-yellow--200;
+  border-color: $color-yellow-200;
+  box-shadow: 0 0 0 .125rem $color-yellow-200;
 
   &:focus {
-    border-color: $color-black--700;
+    border-color: $color-black-700;
     /* stylelint-disable */
     box-shadow:
       0 0 0 .125rem $color-white,
-      0 0 0 .2875rem $color-yellow--200;
+      0 0 0 .2875rem $color-yellow-200;
     /* stylelint-enable */
   }
 }
 
 @include all-inputs('.#{$prefix}-validation-danger') {
   transition: box-shadow .2s ease;
-  border-color: $color-orange--500;
-  box-shadow: 0 0 0 .125rem $color-orange--500;
+  border-color: $color-orange-500;
+  box-shadow: 0 0 0 .125rem $color-orange-500;
 
   &:focus {
-    border-color: $color-black--700;
+    border-color: $color-black-700;
     /* stylelint-disable */
     box-shadow:
       0 0 0 .125rem $color-white,
-      0 0 0 .2875rem $color-orange--500;
+      0 0 0 .2875rem $color-orange-500;
     /* stylelint-enable */
   }
 }
 
 @include all-inputs('.#{$prefix}-validation-success') {
   transition: box-shadow .2s ease;
-  border-color: $color-green--500;
-  box-shadow: 0 0 0 .125rem $color-green--500;
+  border-color: $color-green-500;
+  box-shadow: 0 0 0 .125rem $color-green-500;
 
   &:focus {
-    border-color: $color-black--700;
+    border-color: $color-black-700;
     /* stylelint-disable */
     box-shadow:
       0 0 0 .125rem $color-white,
-      0 0 0 .2875rem $color-green--500;
+      0 0 0 .2875rem $color-green-500;
     /* stylelint-enable */
   }
 }
@@ -80,28 +80,28 @@
 
   &__message {
     margin-left: $xs;
-    color: $color-black--700;
+    color: $color-black-700;
     line-height: 1;
   }
 
   &--is-valid,
   &--success {
-    color: $color-green--500;
+    color: $color-green-500;
   }
 
   &--has-warning,
   &--warning {
-    color: $color-yellow--200;
+    color: $color-yellow-200;
   }
 
   &--is-invalid,
   &--danger {
-    color: $color-orange--500;
+    color: $color-orange-500;
   }
 
   &--has-info,
   &--info {
-    color: $color-blue--600;
+    color: $color-blue-600;
   }
 
   /**
@@ -114,39 +114,39 @@
 
     &.#{$prefix}-inline-alert--is-invalid,
     &.#{$prefix}-inline-alert--danger {
-      border-left: $xxs solid $color-orange--500;
-      background-color: $color-orange--050;
+      border-left: $xxs solid $color-orange-500;
+      background-color: $color-orange-050;
 
       .#{$prefix}-inline-alert__message {
-        color: $color-orange--700;
+        color: $color-orange-700;
       }
     }
 
     &.#{$prefix}-inline-alert--success {
-      border-left: $xxs solid $color-green--500;
-      background-color: $color-green--050;
+      border-left: $xxs solid $color-green-500;
+      background-color: $color-green-050;
 
       .#{$prefix}-inline-alert__message {
-        color: $color-green--700;
+        color: $color-green-700;
       }
     }
 
     &.#{$prefix}-inline-alert--warning {
-      border-left: $xxs solid $color-yellow--200;
-      background-color: $color-yellow--050;
+      border-left: $xxs solid $color-yellow-200;
+      background-color: $color-yellow-050;
 
       .#{$prefix}-inline-alert__message {
-        color: $color-yellow--700;
+        color: $color-yellow-700;
       }
     }
 
     &.#{$prefix}-inline-alert--has-info,
     &.#{$prefix}-inline-alert--info {
-      border-left: $xxs solid $color-blue--600;
-      background-color: $color-blue--050;
+      border-left: $xxs solid $color-blue-600;
+      background-color: $color-blue-050;
 
       .#{$prefix}-inline-alert__message {
-        color: $color-blue--700;
+        color: $color-blue-700;
       }
     }
   }

--- a/src/sass/components/_validation.scss
+++ b/src/sass/components/_validation.scss
@@ -115,7 +115,7 @@
     &.#{$prefix}-inline-alert--is-invalid,
     &.#{$prefix}-inline-alert--danger {
       border-left: $xxs solid $color-orange-500;
-      background-color: $color-orange-050;
+      background-color: $color-orange-000;
 
       .#{$prefix}-inline-alert__message {
         color: $color-orange-700;
@@ -124,7 +124,7 @@
 
     &.#{$prefix}-inline-alert--success {
       border-left: $xxs solid $color-green-500;
-      background-color: $color-green-050;
+      background-color: $color-green-000;
 
       .#{$prefix}-inline-alert__message {
         color: $color-green-700;
@@ -133,7 +133,7 @@
 
     &.#{$prefix}-inline-alert--warning {
       border-left: $xxs solid $color-yellow-200;
-      background-color: $color-yellow-050;
+      background-color: $color-yellow-000;
 
       .#{$prefix}-inline-alert__message {
         color: $color-yellow-700;
@@ -143,7 +143,7 @@
     &.#{$prefix}-inline-alert--has-info,
     &.#{$prefix}-inline-alert--info {
       border-left: $xxs solid $color-blue-600;
-      background-color: $color-blue-050;
+      background-color: $color-blue-000;
 
       .#{$prefix}-inline-alert__message {
         color: $color-blue-700;

--- a/src/sass/core/_base.scss
+++ b/src/sass/core/_base.scss
@@ -39,7 +39,7 @@ strong {
 }
 
 hr {
-  border-top: 1px solid $color-black--100;
+  border-top: 1px solid $color-black-100;
   border-right: none;
   border-bottom: none;
   border-left: none;
@@ -47,10 +47,10 @@ hr {
 
 code {
   font-family: monospace;
-  background-color: $color-black--100;
+  background-color: $color-black-100;
   display: inline-block;
   padding: .125rem .25rem;
-  color: $color-blue--600;
+  color: $color-blue-600;
   border-radius: $xxs;
 }
 

--- a/src/sass/core/_variables.scss
+++ b/src/sass/core/_variables.scss
@@ -109,10 +109,10 @@ $colors: (
   yellow: #f5bb17,
   yellow-000: #ffeecd,
   yellow-100: #ffdd9b,
-  yellow-200: #d6a31a,
-  yellow-300: #b58a1b,
-  yellow-400: #94721b,
-  yellow-500: #f5bb17, //color-yellow
+  yellow-200: #f5bb17, // color-yellow
+  yellow-300: #d6a31a,
+  yellow-400: #b58a1b,
+  yellow-500: #94721b,
   yellow-600: #765a19,
   yellow-700: #584416,
   yellow-800: #3c2e13,
@@ -123,7 +123,7 @@ $colors: (
   orange-200: #ffb49a,
   orange-300: #fa8e6b,
   orange-400: #ef663c,
-  orange-500: #df3603, //color-orange
+  orange-500: #df3603, // color-orange
   orange-600: #b02f0a,
   orange-700: #82270d,
   orange-800: #571e0c,

--- a/src/sass/core/_variables.scss
+++ b/src/sass/core/_variables.scss
@@ -74,7 +74,7 @@ $colors: (
   cream: #edebeb,
   crimson: #990000,
   black: #243142,
-  black-050: #f7f7f8,
+  black-000: #f7f7f8,
   black-100: #ebecee,
   black-200: #c4c7cc,
   black-300: #a7abb3,
@@ -85,7 +85,7 @@ $colors: (
   black-800: #243142, //color-black
   black-900: #161c24,
   blue: #006298,
-  blue-050: #edf1f6,
+  blue-000: #edf1f6,
   blue-100: #dce3ee,
   blue-200: #b8c8dc,
   blue-300: #95adcb,
@@ -96,7 +96,7 @@ $colors: (
   blue-800: #16324b,
   blue-900: #121c28,
   green: #008a28,
-  green-050: #eaf3e8,
+  green-000: #eaf3e8,
   green-100: #d4e8d2,
   green-200: #aad1a7,
   green-300: #7eb97c,
@@ -107,7 +107,7 @@ $colors: (
   green-800: #153717,
   green-900: #111f0f,
   yellow: #f5bb17,
-  yellow-050: #ffeecd,
+  yellow-000: #ffeecd,
   yellow-100: #ffdd9b,
   yellow-200: #d6a31a,
   yellow-300: #b58a1b,
@@ -118,7 +118,7 @@ $colors: (
   yellow-800: #3c2e13,
   yellow-900: #221b0c,
   orange: #df3603,
-  orange-050: #ffece5,
+  orange-000: #ffece5,
   orange-100: #ffd9cc,
   orange-200: #ffb49a,
   orange-300: #fa8e6b,
@@ -140,7 +140,7 @@ $color-crimson: map-get($colors, crimson) !default;
 // Black variants
 
 $color-black: map-get($colors, black) !default;
-$color-black-050: map-get($colors, black-050) !default; // Lightened slightly to use for backgrounds
+$color-black-000: map-get($colors, black-000) !default; // Lightened slightly to use for backgrounds
 $color-black-100: map-get($colors, black-100) !default; // Lightened slightly
 $color-black-200: map-get($colors, black-200) !default;
 $color-black-300: map-get($colors, black-300) !default;
@@ -159,7 +159,7 @@ $color-black-900: map-get($colors, black-900) !default;
 
 $color-blue: map-get($colors, blue) !default; // Luminosity 604
 
-$color-blue-050:  map-get($colors, blue-050) !default;
+$color-blue-000:  map-get($colors, blue-000) !default;
 $color-blue-100:  map-get($colors, blue-100) !default;
 $color-blue-200:  map-get($colors, blue-200) !default;
 $color-blue-300:  map-get($colors, blue-300) !default;
@@ -180,7 +180,7 @@ $color-blue-900: map-get($colors, blue-900) !default;
 
 $color-green: map-get($colors, green) !default; // Luminosity 501
 
-$color-green-050: map-get($colors, green-050) !default;
+$color-green-000: map-get($colors, green-000) !default;
 $color-green-100: map-get($colors, green-100) !default;
 $color-green-200: map-get($colors, green-200) !default;
 $color-green-300: map-get($colors, green-300) !default;
@@ -201,7 +201,7 @@ $color-green-900: map-get($colors, green-900) !default;
 
 $color-yellow: map-get($colors, yellow) !default; // Luminosity 209
 
-$color-yellow-050: map-get($colors, yellow-050) !default;
+$color-yellow-000: map-get($colors, yellow-000) !default;
 $color-yellow-100: map-get($colors, yellow-100) !default;
 // Replacing generated color here with base brand color since they are
 // perceivably the same. Generated value was #f7be29
@@ -222,7 +222,7 @@ $color-yellow-900: map-get($colors, yellow-900) !default;
 
 $color-orange: map-get($colors, orange) !default; // Luminosity 501
 
-$color-orange-050: map-get($colors, orange-050) !default;
+$color-orange-000: map-get($colors, orange-000) !default;
 $color-orange-100: map-get($colors, orange-100) !default;
 $color-orange-200: map-get($colors, orange-200) !default;
 $color-orange-300: map-get($colors, orange-300) !default;

--- a/src/sass/core/_variables.scss
+++ b/src/sass/core/_variables.scss
@@ -74,60 +74,60 @@ $colors: (
   cream: #edebeb,
   crimson: #990000,
   black: #243142,
-  black--050: #f7f7f8,
-  black--100: #ebecee,
-  black--200: #c4c7cc,
-  black--300: #a7abb3,
-  black--400: #8b919b,
-  black--500: #707784,
-  black--600: #565f6d,
-  black--700: #3d4757,
-  black--800: #243142, //color-black
-  black--900: #161c24,
+  black-050: #f7f7f8,
+  black-100: #ebecee,
+  black-200: #c4c7cc,
+  black-300: #a7abb3,
+  black-400: #8b919b,
+  black-500: #707784,
+  black-600: #565f6d,
+  black-700: #3d4757,
+  black-800: #243142, //color-black
+  black-900: #161c24,
   blue: #006298,
-  blue--050: #edf1f6,
-  blue--100: #dce3ee,
-  blue--200: #b8c8dc,
-  blue--300: #95adcb,
-  blue--400: #7194ba,
-  blue--500: #497ba9,
-  blue--600: #006298, // color-blue
-  blue--700: #134a71,
-  blue--800: #16324b,
-  blue--900: #121c28,
+  blue-050: #edf1f6,
+  blue-100: #dce3ee,
+  blue-200: #b8c8dc,
+  blue-300: #95adcb,
+  blue-400: #7194ba,
+  blue-500: #497ba9,
+  blue-600: #006298, // color-blue
+  blue-700: #134a71,
+  blue-800: #16324b,
+  blue-900: #121c28,
   green: #008a28,
-  green--050: #eaf3e8,
-  green--100: #d4e8d2,
-  green--200: #aad1a7,
-  green--300: #7eb97c,
-  green--400: #50a253,
-  green--500: #008a28, // color-green
-  green--600: #116d23,
-  green--700: #16521d,
-  green--800: #153717,
-  green--900: #111f0f,
+  green-050: #eaf3e8,
+  green-100: #d4e8d2,
+  green-200: #aad1a7,
+  green-300: #7eb97c,
+  green-400: #50a253,
+  green-500: #008a28, // color-green
+  green-600: #116d23,
+  green-700: #16521d,
+  green-800: #153717,
+  green-900: #111f0f,
   yellow: #f5bb17,
-  yellow--050: #ffeecd,
-  yellow--100: #ffdd9b,
-  yellow--200: #d6a31a,
-  yellow--300: #b58a1b,
-  yellow--400: #94721b,
-  yellow--500: #f5bb17, //color-yellow
-  yellow--600: #765a19,
-  yellow--700: #584416,
-  yellow--800: #3c2e13,
-  yellow--900: #221b0c,
+  yellow-050: #ffeecd,
+  yellow-100: #ffdd9b,
+  yellow-200: #d6a31a,
+  yellow-300: #b58a1b,
+  yellow-400: #94721b,
+  yellow-500: #f5bb17, //color-yellow
+  yellow-600: #765a19,
+  yellow-700: #584416,
+  yellow-800: #3c2e13,
+  yellow-900: #221b0c,
   orange: #df3603,
-  orange--050: #ffece5,
-  orange--100: #ffd9cc,
-  orange--200: #ffb49a,
-  orange--300: #fa8e6b,
-  orange--400: #ef663c,
-  orange--500: #df3603, //color-orange
-  orange--600: #b02f0a,
-  orange--700: #82270d,
-  orange--800: #571e0c,
-  orange--900: #2f1407
+  orange-050: #ffece5,
+  orange-100: #ffd9cc,
+  orange-200: #ffb49a,
+  orange-300: #fa8e6b,
+  orange-400: #ef663c,
+  orange-500: #df3603, //color-orange
+  orange-600: #b02f0a,
+  orange-700: #82270d,
+  orange-800: #571e0c,
+  orange-900: #2f1407
 ) !default;
 
 // Base colors
@@ -140,100 +140,100 @@ $color-crimson: map-get($colors, crimson) !default;
 // Black variants
 
 $color-black: map-get($colors, black) !default;
-$color-black--050: map-get($colors, black--050) !default; // Lightened slightly to use for backgrounds
-$color-black--100: map-get($colors, black--100) !default; // Lightened slightly
-$color-black--200: map-get($colors, black--200) !default;
-$color-black--300: map-get($colors, black--300) !default;
-$color-black--400: map-get($colors, black--400) !default; //Meets 3.5 contrast ratio for non-text interactive elements (form borders)
-$color-black--500: map-get($colors, black--500) !default;
-$color-black--600: map-get($colors, black--600) !default;
-$color-black--700: map-get($colors, black--700) !default;
-$color-black--800: map-get($colors, black--800) !default;
-$color-black--900: map-get($colors, black--900) !default;
+$color-black-050: map-get($colors, black-050) !default; // Lightened slightly to use for backgrounds
+$color-black-100: map-get($colors, black-100) !default; // Lightened slightly
+$color-black-200: map-get($colors, black-200) !default;
+$color-black-300: map-get($colors, black-300) !default;
+$color-black-400: map-get($colors, black-400) !default; //Meets 3.5 contrast ratio for non-text interactive elements (form borders)
+$color-black-500: map-get($colors, black-500) !default;
+$color-black-600: map-get($colors, black-600) !default;
+$color-black-700: map-get($colors, black-700) !default;
+$color-black-800: map-get($colors, black-800) !default;
+$color-black-900: map-get($colors, black-900) !default;
 
-// Blue variants (See note above about "Midnight") $color-blue--600 = new Midnight
+// Blue variants (See note above about "Midnight") $color-blue-600 = new Midnight
 
 // Base color from brand palette. All color scale colors generated from this.
-// Internal use only: Use $color-blue--600 in all components to reference
+// Internal use only: Use $color-blue-600 in all components to reference
 // the base blue.
 
 $color-blue: map-get($colors, blue) !default; // Luminosity 604
 
-$color-blue--050:  map-get($colors, blue--050) !default;
-$color-blue--100:  map-get($colors, blue--100) !default;
-$color-blue--200:  map-get($colors, blue--200) !default;
-$color-blue--300:  map-get($colors, blue--300) !default;
-$color-blue--400:  map-get($colors, blue--400) !default;
-$color-blue--500:  map-get($colors, blue--500) !default;
+$color-blue-050:  map-get($colors, blue-050) !default;
+$color-blue-100:  map-get($colors, blue-100) !default;
+$color-blue-200:  map-get($colors, blue-200) !default;
+$color-blue-300:  map-get($colors, blue-300) !default;
+$color-blue-400:  map-get($colors, blue-400) !default;
+$color-blue-500:  map-get($colors, blue-500) !default;
 // Replacing generated color here with base brand color since they are
 // perceivably the same. Generated value was #076399
-$color-blue--600:  map-get($colors, blue--600) !default;
-$color-blue--700: map-get($colors, blue--700) !default;
-$color-blue--800: map-get($colors, blue--800) !default;
-$color-blue--900: map-get($colors, blue--900) !default;
+$color-blue-600:  map-get($colors, blue-600) !default;
+$color-blue-700: map-get($colors, blue-700) !default;
+$color-blue-800: map-get($colors, blue-800) !default;
+$color-blue-900: map-get($colors, blue-900) !default;
 
 // Green variants
 
 // Base color from brand palette. All color scale colors generated from this.
-// Internal use only: Use $color-green--500 in all components to reference
+// Internal use only: Use $color-green-500 in all components to reference
 // the base green.
 
 $color-green: map-get($colors, green) !default; // Luminosity 501
 
-$color-green--050: map-get($colors, green--050) !default;
-$color-green--100: map-get($colors, green--100) !default;
-$color-green--200: map-get($colors, green--200) !default;
-$color-green--300: map-get($colors, green--300) !default;
-$color-green--400: map-get($colors, green--400) !default;
+$color-green-050: map-get($colors, green-050) !default;
+$color-green-100: map-get($colors, green-100) !default;
+$color-green-200: map-get($colors, green-200) !default;
+$color-green-300: map-get($colors, green-300) !default;
+$color-green-400: map-get($colors, green-400) !default;
 // Replacing generated color here with base brand color since they are
 // perceivably the same. Generated value was #028a28
-$color-green--500: map-get($colors, green) !default;
-$color-green--600: map-get($colors, green--600) !default;
-$color-green--700: map-get($colors, green--700) !default;
-$color-green--800: map-get($colors, green--800) !default;
-$color-green--900: map-get($colors, green--900) !default;
+$color-green-500: map-get($colors, green) !default;
+$color-green-600: map-get($colors, green-600) !default;
+$color-green-700: map-get($colors, green-700) !default;
+$color-green-800: map-get($colors, green-800) !default;
+$color-green-900: map-get($colors, green-900) !default;
 
 // Yellow variants
 
 // Base color from brand palette. All color scale colors generated from this.
-// Internal use only: Use $color-yellow--200 in all components to reference
+// Internal use only: Use $color-yellow-200 in all components to reference
 // the base yellow.
 
 $color-yellow: map-get($colors, yellow) !default; // Luminosity 209
 
-$color-yellow--050: map-get($colors, yellow--050) !default;
-$color-yellow--100: map-get($colors, yellow--100) !default;
+$color-yellow-050: map-get($colors, yellow-050) !default;
+$color-yellow-100: map-get($colors, yellow-100) !default;
 // Replacing generated color here with base brand color since they are
 // perceivably the same. Generated value was #f7be29
-$color-yellow--200: map-get($colors, yellow--200) !default;
-$color-yellow--300: map-get($colors, yellow--300) !default;
-$color-yellow--400: map-get($colors, yellow--400) !default;
-$color-yellow--500: map-get($colors, yellow--500) !default;
-$color-yellow--600: map-get($colors, yellow--600) !default;
-$color-yellow--700: map-get($colors, yellow--700) !default;
-$color-yellow--800: map-get($colors, yellow--800) !default;
-$color-yellow--900: map-get($colors, yellow--900) !default;
+$color-yellow-200: map-get($colors, yellow-200) !default;
+$color-yellow-300: map-get($colors, yellow-300) !default;
+$color-yellow-400: map-get($colors, yellow-400) !default;
+$color-yellow-500: map-get($colors, yellow-500) !default;
+$color-yellow-600: map-get($colors, yellow-600) !default;
+$color-yellow-700: map-get($colors, yellow-700) !default;
+$color-yellow-800: map-get($colors, yellow-800) !default;
+$color-yellow-900: map-get($colors, yellow-900) !default;
 
 // Orange variants
 
 // Base color from brand palette. All color scale colors generated from this.
-// Internal use only: Use $color-orange--500 in all components to reference
+// Internal use only: Use $color-orange-500 in all components to reference
 // the base orange.
 
 $color-orange: map-get($colors, orange) !default; // Luminosity 501
 
-$color-orange--050: map-get($colors, orange--050) !default;
-$color-orange--100: map-get($colors, orange--100) !default;
-$color-orange--200: map-get($colors, orange--200) !default;
-$color-orange--300: map-get($colors, orange--300) !default;
-$color-orange--400: map-get($colors, orange--400) !default;
+$color-orange-050: map-get($colors, orange-050) !default;
+$color-orange-100: map-get($colors, orange-100) !default;
+$color-orange-200: map-get($colors, orange-200) !default;
+$color-orange-300: map-get($colors, orange-300) !default;
+$color-orange-400: map-get($colors, orange-400) !default;
 // Replacing generated color here with base brand color since they are
 // perceivably the same. Generated value was #df3704
-$color-orange--500: map-get($colors, orange) !default;
-$color-orange--600: map-get($colors, orange--600) !default;
-$color-orange--700: map-get($colors, orange--700) !default;
-$color-orange--800: map-get($colors, orange--800) !default;
-$color-orange--900: map-get($colors, orange--900) !default;
+$color-orange-500: map-get($colors, orange) !default;
+$color-orange-600: map-get($colors, orange-600) !default;
+$color-orange-700: map-get($colors, orange-700) !default;
+$color-orange-800: map-get($colors, orange-800) !default;
+$color-orange-900: map-get($colors, orange-900) !default;
 
 // Global spacing units
 

--- a/src/sass/utilities/_utilities-border.scss
+++ b/src/sass/utilities/_utilities-border.scss
@@ -2,23 +2,23 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 .#{$prefix}-border-all {
-  border: 1px solid $color-black--200 !important;
+  border: 1px solid $color-black-200 !important;
 }
 
 .#{$prefix}-border-top {
-  border-top: 1px solid $color-black--200 !important;
+  border-top: 1px solid $color-black-200 !important;
 }
 
 .#{$prefix}-border-right {
-  border-right: 1px solid $color-black--200 !important;
+  border-right: 1px solid $color-black-200 !important;
 }
 
 .#{$prefix}-border-bottom {
-  border-bottom: 1px solid $color-black--200 !important;
+  border-bottom: 1px solid $color-black-200 !important;
 }
 
 .#{$prefix}-border-left {
-  border-left: 1px solid $color-black--200 !important;
+  border-left: 1px solid $color-black-200 !important;
 }
 
 .#{$prefix}-border-radius {


### PR DESCRIPTION
In this PR:

- Changed double dashes (`color-black--100`) to single dashes (`color-black-100`)
- Changed `050` base value to `000` (`color-black-050` changes to `color-black-000`)
- Fixed incorrect hexadecimal values in the yellow color scale

See issue #234 for more details.