### PR TITLE
Refactored file input component

### DIFF
--- a/src/components/file-input/file-input.config.yml
+++ b/src/components/file-input/file-input.config.yml
@@ -3,14 +3,14 @@ label: File Input
 status: "ready"
 collated: true
 context:
-    id: "my-file-input"
+    id: "singleFileInput"
     buttonText: Upload a file
     previewText: No file selected
     fileDescription: "file-description"
 variants:
   - name: "secondary"
     context:
-        id: "my-file-input-two"
+        id: "multipleFilesInput"
         buttonText: Upload multiple files
         multiple: true
         secondary: true

--- a/src/components/file-input/file-input.njk
+++ b/src/components/file-input/file-input.njk
@@ -12,4 +12,14 @@
 <script>
   const fileInputWrapper{{ id }} = document.querySelector('[data-upload-wrapper="{{ id }}"]');
   const newFileInput{{ id }} = new Rivet.FileInput(fileInputWrapper{{ id }});
+
+  document.addEventListener('rvt:buildSingleFile', function(event) {
+    // event.preventDefault();
+    console.log(event.detail);
+  });
+
+  document.addEventListener('rvt:buildMultipleFiles', function(event) {
+    // event.preventDefault();
+    console.log(event.detail);
+  });
 </script>

--- a/src/components/file-input/file-input.njk
+++ b/src/components/file-input/file-input.njk
@@ -4,7 +4,7 @@
         <span>{{ buttonText }}</span>
         {% include "@includes--file-upload" %}
     </label>
-    <div class="rvt-file__preview" data-file-preview="{{ id }}" id="{{ fileDescription }}">
+    <div class="rvt-file__preview" data-upload-preview="{{ id }}" id="{{ fileDescription }}">
         {{ previewText }}
     </div>
 </div>

--- a/src/components/file-input/file-input.njk
+++ b/src/components/file-input/file-input.njk
@@ -15,11 +15,9 @@
 
   document.addEventListener('rvt:buildSingleFile', function(event) {
     // event.preventDefault();
-    console.log(event.detail);
   });
 
   document.addEventListener('rvt:buildMultipleFiles', function(event) {
     // event.preventDefault();
-    console.log(event.detail);
   });
 </script>

--- a/src/components/file-input/file-input.njk
+++ b/src/components/file-input/file-input.njk
@@ -1,5 +1,5 @@
-<div class="rvt-file" data-upload="{{ id }}">
-    <input type="file" id="{{ id }}" aria-describedby="{{ fileDescription }}" {% if multiple %} multiple{% endif %}>
+<div class="rvt-file" data-upload-wrapper="{{ id }}">
+    <input type="file" data-upload-input="{{ id }}" id="{{ id }}" aria-describedby="{{ fileDescription }}" {% if multiple %} multiple{% endif %}>
     <label for="{{ id }}" class="rvt-button{% if secondary %} rvt-button--secondary{% endif %}">
         <span>{{ buttonText }}</span>
         {% include "@includes--file-upload" %}
@@ -10,9 +10,6 @@
 </div>
 
 <script>
-    document.addEventListener('fileAttached', function(event) {
-        if (event.detail.name() == 'my-file-input-two') {
-            alert('File was attached! 💌');
-        }
-    });
+  const fileInputWrapper{{ id }} = document.querySelector('[data-upload-wrapper="{{ id }}"]');
+  const newFileInput{{ id }} = new Rivet.FileInput(fileInputWrapper{{ id }});
 </script>

--- a/src/js/components/fileInput.js
+++ b/src/js/components/fileInput.js
@@ -73,11 +73,6 @@ export default class FileInput {
     return fileCount;
   }
 
-  /**
-   *
-   * @param {Event} event - Handles the main 'change' event emitted when
-   * file(s) are attached to the file input
-   */
   _handleChange() {
     // The actual input element
     const uploadInput = this.element.querySelector(`[${ this.inputAttribute }]`);
@@ -107,23 +102,10 @@ export default class FileInput {
     }
   }
 
-  /**
-   * @param {HTMLElement} context - An optional DOM element that the
-   * file input can be initialized on. All event listeners will be attached
-   * to this element. Usually best to just leave it to default
-   * to the document.
-   */
   init() {
     this.element.addEventListener('change', this._handleChange, false);
   }
 
-  /**
-   * @param {HTMLElement} context - An optional DOM element. This only
-   * needs to be passed in if a DOM element was passed to the init()
-   * function. If so, the element passed in must be the same element
-   * that was passed in at initialization so that the event listeners can
-   * be properly removed.
-   */
   destroy() {
     this.element.removeEventListener('change', this._handleChange, false);
   }

--- a/src/js/components/fileInput.js
+++ b/src/js/components/fileInput.js
@@ -1,0 +1,135 @@
+/**
+ * Copyright (C) 2018 The Trustees of Indiana University
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export default class FileInput {
+  constructor(element, options) {
+    const defaultOptions = {
+      previewText: 'No file selected'
+    };
+
+    const settings = {
+      ...defaultOptions,
+      ...options
+    };
+
+    this.element = element;
+    this.wrapperAttribute = 'data-upload-wrapper';
+    this.inputAttribute = 'data-upload-input';
+    this.previewAttribute = 'data-file-preview';
+    this.previewText = settings.previewText;
+
+    this._handleChange = this._handleChange.bind(this);
+
+    this.init();
+  }
+
+  /*!
+   * Sanitize and encode all HTML in a user-submitted string
+   * (c) 2018 Chris Ferdinandi, MIT License, https://gomakethings.com
+   * @param  {String} str  The user-submitted string
+   * @return {String} str  The sanitized string
+   */
+  _sanitizeHTML(str) {
+    const temp = document.createElement('div');
+    temp.textContent = str;
+    return temp.innerHTML;
+  }
+
+  /**
+   *
+   * @param {HTMLInputElement} input - HTML file input
+   * @return {HTMLSpanElement} - A span containing the file name that was
+   * attached to the file input
+   */
+  _buildSingleFile(input) {
+    // Create <span> element to display our file name
+    const singleFileItem = document.createElement('span');
+
+    /**
+     * Sanitize use input here just incase someone would make the
+     * name of their file a malicious script.
+     */
+    const singleFileName = this._sanitizeHTML(input.files[0].name);
+
+    // Add the file name as the text content
+    singleFileItem.textContent = singleFileName;
+
+    // Returns our built <span> element.
+    return singleFileItem;
+  }
+
+  /**
+   *
+   * @param {HTMLInputElement} input - HTML file input
+   * @return {HTMLSpanElement} - A span containing the a description
+   * of the number of files attached to file input
+   */
+  _buildMultipleFiles(input) {
+    const fileCount = document.createElement('span');
+    fileCount.textContent = input.files.length + ' files selected';
+    return fileCount;
+  }
+
+  /**
+   *
+   * @param {Event} event - Handles the main 'change' event emitted when
+   * file(s) are attached to the file input
+   */
+  _handleChange() {
+    // Store a reference to the file input wrapper (data-upload) element
+    const uploadWrapper = event.target.closest(`[${ this.wrapperAttribute }]`);
+
+    // If the change event was on the file input, bail.
+    if (!uploadWrapper) return;
+
+    // The actual input element
+    const uploadInput = uploadWrapper.querySelector(`[${ this.inputAttribute }]`);
+
+    // The preview element where we'll inject file count, etc.
+    const uploadPreview = uploadWrapper.querySelector(`[${ this.previewAttribute }]`);
+
+    // Check to make sure that at least one file was attached
+    if (uploadInput.files.length > 0) {
+      // Set remove the preview element placeholder text
+      uploadPreview.innerHTML = '';
+
+      /**
+       * If there is more than one file attached, build up a span
+       * that shows the file count to insert into the preview element,
+       * otherwise show the file name that was uploaded.
+       */
+      uploadInput.files.length > 1 ?
+        uploadPreview.appendChild(this._buildMultipleFiles(uploadInput)) :
+        uploadPreview.appendChild(this._buildSingleFile(uploadInput));
+    } else {
+      /**
+       * If no files were attached set the placeholder text back
+       * to the default
+       */
+      uploadPreview.innerHTML = this.previewText;
+    }
+  }
+
+  /**
+   * @param {HTMLElement} context - An optional DOM element that the
+   * file input can be initialized on. All event listeners will be attached
+   * to this element. Usually best to just leave it to default
+   * to the document.
+   */
+  init() {
+    this.element.addEventListener('change', this._handleChange, false);
+  }
+
+  /**
+   * @param {HTMLElement} context - An optional DOM element. This only
+   * needs to be passed in if a DOM element was passed to the init()
+   * function. If so, the element passed in must be the same element
+   * that was passed in at initialization so that the event listeners can
+   * be properly removed.
+   */
+  destroy() {
+    this.element.removeEventListener('change', this._handleChange, false);
+  }
+}

--- a/src/js/components/fileInput.js
+++ b/src/js/components/fileInput.js
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import dispatchCustomEvent from '../utilities/dispatchCustomEvent';
-
 export default class FileInput {
   constructor(element, options) {
     const defaultOptions = {
@@ -58,18 +56,6 @@ export default class FileInput {
     // Add the file name as the text content
     singleFileItem.textContent = singleFileName;
 
-    const singleFileEvent = dispatchCustomEvent(
-      'buildSingleFile',
-      this.element,
-      {
-        type: 'single',
-        fileName: singleFileName,
-        fileInputWrapper: this.element.dataset.uploadWrapper
-      }
-    );
-
-    if (!singleFileEvent) return;
-
     // Returns our built <span> element.
     return singleFileItem;
   }
@@ -83,18 +69,6 @@ export default class FileInput {
   _buildMultipleFiles(input) {
     const fileCount = document.createElement('span');
     fileCount.textContent = input.files.length + ' files selected';
-
-    const multipleFilesEvent = dispatchCustomEvent(
-      'buildMultipleFiles',
-      this.element,
-      {
-        type: 'multiple',
-        numberOfFiles: input.files.length,
-        fileInputWrapper: this.element.dataset.uploadWrapper
-      }
-    );
-
-    if (!multipleFilesEvent) return;
 
     return fileCount;
   }

--- a/src/js/components/fileInput.js
+++ b/src/js/components/fileInput.js
@@ -105,17 +105,11 @@ export default class FileInput {
    * file(s) are attached to the file input
    */
   _handleChange() {
-    // Store a reference to the file input wrapper (data-upload) element
-    const uploadWrapper = event.target.closest(`[${ this.wrapperAttribute }]`);
-
-    // If the change event was on the file input, bail.
-    if (!uploadWrapper) return;
-
     // The actual input element
-    const uploadInput = uploadWrapper.querySelector(`[${ this.inputAttribute }]`);
+    const uploadInput = this.element.querySelector(`[${ this.inputAttribute }]`);
 
     // The preview element where we'll inject file count, etc.
-    const uploadPreview = uploadWrapper.querySelector(`[${ this.previewAttribute }]`);
+    const uploadPreview = this.element.querySelector(`[${ this.previewAttribute }]`);
 
     // Check to make sure that at least one file was attached
     if (uploadInput.files.length > 0) {

--- a/src/js/components/fileInput.js
+++ b/src/js/components/fileInput.js
@@ -19,7 +19,7 @@ export default class FileInput {
     this.element = element;
     this.wrapperAttribute = 'data-upload-wrapper';
     this.inputAttribute = 'data-upload-input';
-    this.previewAttribute = 'data-file-preview';
+    this.previewAttribute = 'data-upload-preview';
     this.previewText = settings.previewText;
 
     this._handleChange = this._handleChange.bind(this);

--- a/src/js/components/fileInput.js
+++ b/src/js/components/fileInput.js
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import dispatchCustomEvent from '../utilities/dispatchCustomEvent';
+
 export default class FileInput {
   constructor(element, options) {
     const defaultOptions = {
@@ -56,6 +58,18 @@ export default class FileInput {
     // Add the file name as the text content
     singleFileItem.textContent = singleFileName;
 
+    const singleFileEvent = dispatchCustomEvent(
+      'buildSingleFile',
+      this.element,
+      {
+        type: 'single',
+        fileName: singleFileName,
+        fileInputWrapper: this.element.dataset.uploadWrapper
+      }
+    );
+
+    if (!singleFileEvent) return;
+
     // Returns our built <span> element.
     return singleFileItem;
   }
@@ -69,6 +83,19 @@ export default class FileInput {
   _buildMultipleFiles(input) {
     const fileCount = document.createElement('span');
     fileCount.textContent = input.files.length + ' files selected';
+
+    const multipleFilesEvent = dispatchCustomEvent(
+      'buildMultipleFiles',
+      this.element,
+      {
+        type: 'multiple',
+        numberOfFiles: input.files.length,
+        fileInputWrapper: this.element.dataset.uploadWrapper
+      }
+    );
+
+    if (!multipleFilesEvent) return;
+
     return fileCount;
   }
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -8,6 +8,7 @@ import './polyfills/CustomEvent';
 
 // Components
 import Alert from './components/alert';
+import FileInput from './components/fileInput';
 import Sidenav from './components/sidenav';
 
-export default { Alert, Sidenav };
+export default { Alert, FileInput, Sidenav };


### PR DESCRIPTION
This one isn't quite ready to be merged in, but I would still like some initial feedback on it. I'm mainly looking for feedback about:
- where to place the custom events - I can see value for developers to have a custom event fire _before_ and _after_ the file upload change even happens, since there will be different data for each. So, should it be placed at the beginning or end of the "build" methods, or maybe both?
- whether the `_handleChange` method needs to be broken down further to other methods for better readability and organization
- how we can best provide the ability to completely disabling the file input event using a custom event, similar to `event.preventDefault()` in other components. Without any JavaScript, the browser's file selection modal still appears when the matching input/label is clicked

- [x] Component should be an ES6 `class`
- [x] Component should be able to be programmatically controlled via "public" methods
- [x] Components should use data attributes as hooks for functionality and follow the format `data-[component-name]`
- [x] Should be tested and function all evergreen modern browsers and IE11
- [x] All methods should be documented using [JSDoc-style comments](https://jsdoc.app/index.html)