### PR TITLE
Added workflow for publishing packages to the alpha tag

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -1,0 +1,31 @@
+name: Alpha Package
+
+on:
+  push:
+    tags: 
+      - 'v**-alpha**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --tag alpha
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "rivet-uits",
+  "name": "rivet-core",
   "version": "1.7.2",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rivet-uits",
+  "name": "rivet-core",
   "description": "Indiana University design system",
   "homepage": "https://rivet.iu.edu",
   "version": "1.7.2",


### PR DESCRIPTION
In this PR:

- Created `.github/workflows/alpha.yml` for handling the publishing of alpha packages
- Updated package name to reflect preferred npm repo for 2.0.0+