### PR TITLE
Added CSS namespacing for wysiwyg sections

### DIFF
--- a/src/components/example-layouts/example-layouts--wysiwyg.njk
+++ b/src/components/example-layouts/example-layouts--wysiwyg.njk
@@ -1,0 +1,25 @@
+<div class="rvt-wysiwyg" style="background-color: #f7f7f7">
+  <em>A light background was added to this section to better illustrate padding.</em>
+  <p>Just below this paragraph is an empty <code>p</code>. Any empty selectors are set to <code>display: none</code>.</p>
+  <p></p>
+  <p>&nbsp;</p>
+  <p>Above this paragraph text is a <code>p</code> with a non-breaking space (<code>nbsp</code>) inside to illustrate that these are not being overridden.</p>
+  <p>A long paragraph: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam dapibus turpis id consequat malesuada. Donec fermentum libero commodo ultrices elementum. Quisque aliquam, ante nec consequat ornare, tortor ipsum elementum mauris, ac posuere risus nunc vitae orci.</p>
+  <p>There is a (hidden) empty <code>span</code> below this paragraph text.</p>
+  <span></span>
+  <h2>Heading 2</h2>
+  <p>A paragraph following a heading</p>
+  <div>
+    <span>Here is some text within a <code>div > span</code>.</span>
+    <p>Lorem ipsum text.</p>
+  </div>
+</div>
+
+<div class="rvt-wysiwyg">
+  <p>Another instance of <code>rvt-wysiwyg</code>.</p>
+  <p>A paragraph below.</p>
+  <p>Some text here. Some is <strong>strong importance</strong>, and some is <em>emphasized</em>.</p>
+  <br />
+  <p>Above this paragraph is a <code>br</code> tag, which is being set to be hidden since it's empty.</p>
+  <p>If there is more than one instance of <code>code</code>, the <code>second one's</code> margin-top is zeroed out, because the <code>code</code> element is <code>display: inline-block</code>.</p>
+</div>

--- a/src/sass/rivet.scss
+++ b/src/sass/rivet.scss
@@ -15,6 +15,7 @@
 @import "utilities/utilities-type-scale";
 @import "utilities/utilities-visibility";
 @import "utilities/utilities-width";
+@import "utilities/utilities-wysiwyg";
 @import "utilities/utilities-z-index";
 @import "components/action";
 @import "components/alerts";

--- a/src/sass/utilities/_utilities-wysiwyg.scss
+++ b/src/sass/utilities/_utilities-wysiwyg.scss
@@ -1,0 +1,13 @@
+.#{$prefix}-wysiwyg {
+  * + * {
+    margin-top: $sm;
+  }
+
+  *:empty { // Hides any empty elements (as well as <br />)
+    display: none;
+  }
+
+  code + code {
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
In this PR:

- Adds CSS namespacing class `rvt-wysiwyg` for handling extra code created by a WYSIWYG
- Uses the "lobotomized owl selector" (https://alistapart.com/article/axiomatic-css-and-lobotomized-owls/) to set a base `margin-top` value for all sibling elements
- Sets all empty elements to `display: none`. This includes `<br />`, since it is technically an empty element.
- Zeroes out the `margin-top` for multiple `code` elements within a paragraph (or within other inline elements) because the `code` element is `display: inline-block`
- Paragraphs including a non-breaking space `&nbsp;` are not being overridden, nor are paragraphs with only white space. If we choose to override these, we'll have to include some JavaScript to target those contents.