### PR TITLE
Alpha Release 2.0.0-alpha

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rivet-core",
   "description": "Indiana University design system",
   "homepage": "https://rivet.iu.edu",
-  "version": "1.7.2",
+  "version": "2.0.0-alpha",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Ok, for real this time. This PR will release the first early alpha of Rivet 2. As we move to 2.0.0 we'll be publishing to a new npm repository named `rivet-core`. We'll make sure to highlight this in any migration guides/docs.

This release includes:
- New _Sidenav_ component
- New _Action_ component
- New _Feature_ component
- Revised black color scale
- Update to Sass color variable names e.g. `$color-black--050` becomes `$color-black-000` and color scales now begin at `-000` instead of `--050`. [See this PR for more detail](https://github.com/indiana-university/rivet-source/pull/236)
- Refactored the Alert component