### PR TITLE
Refactored dropdown JS

### DIFF
--- a/cypress/integration/dropdown_spec.js
+++ b/cypress/integration/dropdown_spec.js
@@ -1,0 +1,85 @@
+const DROPDOWN_TOGGLE = '[data-dropdown-toggle="dropdownNavigation"]';
+const DROPDOWN_MENU = '[data-dropdown-menu]';
+const DEV_SERVER = "http://localhost:3000";
+const DOWN = 40;
+const UP = 38;
+const ENTER = 13;
+const ESC = 27;
+
+describe('Dropdown Interaction', function() {
+  it('Visits the dropdown page', function() {
+    cy.visit(DEV_SERVER + '/components/preview/dropdown');
+  });
+
+  it('Should see the dropdown toggle', function() {
+    cy.get(DROPDOWN_TOGGLE).should('have.attr', 'aria-expanded', 'false');
+
+    cy.get(DROPDOWN_MENU)
+      .should('have.attr', 'aria-hidden', 'true')
+      .and('not.be.visible');
+  });
+
+  it('Should be able to open the dropdown', function() {
+    cy.get(DROPDOWN_TOGGLE)
+      .click()
+      .should('have.attr', 'aria-expanded', 'true');
+
+    cy.get(DROPDOWN_MENU)
+      .should('be.visible')
+      .and('have.attr', 'aria-hidden', 'false');
+  });
+
+  it('Should be able to close the dropdown', function() {
+    cy.get(DROPDOWN_TOGGLE)
+      .click()
+      .should('have.attr', 'aria-expanded', 'false');
+
+    cy.get(DROPDOWN_MENU)
+      .should('not.be.visible')
+      .and('have.attr', 'aria-hidden', 'true');
+  });
+
+  it('Should be able to open the dropdown with keys', function() {
+    cy.get(DROPDOWN_TOGGLE).click();
+
+    cy.focused().trigger('keydown', { keyCode: DOWN, which: DOWN });
+
+    cy.focused().should('have.text', 'Item one');
+
+    cy.focused().trigger('keydown', { keyCode: UP, which: UP });
+
+    cy.focused().should('have.text', 'Related item two');
+  });
+
+  it('Should be able to close with esc key', function() {
+    cy.get(DROPDOWN_TOGGLE).click();
+
+    cy.focused().trigger('keydown', { keyCode: ESC, which: ESC });
+
+    cy.get(DROPDOWN_MENU).should('not.be.visible');
+  });
+
+  it('Should be able to close with .closeMenu() method', function() {
+    cy.window().then(win => {
+      win.newdropdownNavigation.closeMenu();
+    });
+
+    cy.get(DROPDOWN_TOGGLE).should('have.attr', 'aria-expanded', 'false');
+
+    cy.get(DROPDOWN_MENU)
+      .should('have.attr', 'aria-hidden', 'true')
+      .and('not.be.visible');
+  });
+
+  it('Should be able to open with .open() method', function() {
+    cy.window().then(win => {
+      win.newdropdownNavigation.openMenu();
+    });
+
+    cy.get(DROPDOWN_TOGGLE).should('have.attr', 'aria-expanded', 'true');
+
+    cy.get(DROPDOWN_MENU)
+      .should('have.attr', 'aria-hidden', 'false')
+      .and('be.visible');
+  });
+});

--- a/cypress/integration/dropdown_spec.js
+++ b/cypress/integration/dropdown_spec.js
@@ -15,7 +15,7 @@ describe('Dropdown Interaction', function() {
     cy.get(DROPDOWN_TOGGLE).should('have.attr', 'aria-expanded', 'false');
 
     cy.get(DROPDOWN_MENU)
-      .should('have.attr', 'aria-hidden', 'true')
+      .should('have.attr', 'hidden')
       .and('not.be.visible');
   });
 
@@ -26,7 +26,7 @@ describe('Dropdown Interaction', function() {
 
     cy.get(DROPDOWN_MENU)
       .should('be.visible')
-      .and('have.attr', 'aria-hidden', 'false');
+      .and('not.have.attr', 'hidden');
   });
 
   it('Should be able to close the dropdown', function() {
@@ -36,7 +36,7 @@ describe('Dropdown Interaction', function() {
 
     cy.get(DROPDOWN_MENU)
       .should('not.be.visible')
-      .and('have.attr', 'aria-hidden', 'true');
+      .and('have.attr', 'hidden');
   });
 
   it('Should be able to open the dropdown with keys', function() {
@@ -59,27 +59,27 @@ describe('Dropdown Interaction', function() {
     cy.get(DROPDOWN_MENU).should('not.be.visible');
   });
 
-  it('Should be able to close with .closeMenu() method', function() {
+  it('Should be able to close with .close() method', function() {
     cy.window().then(win => {
-      win.newdropdownNavigation.closeMenu();
+      win.newdropdownNavigation.close();
     });
 
     cy.get(DROPDOWN_TOGGLE).should('have.attr', 'aria-expanded', 'false');
 
     cy.get(DROPDOWN_MENU)
-      .should('have.attr', 'aria-hidden', 'true')
+      .should('have.attr', 'hidden')
       .and('not.be.visible');
   });
 
   it('Should be able to open with .open() method', function() {
     cy.window().then(win => {
-      win.newdropdownNavigation.openMenu();
+      win.newdropdownNavigation.open();
     });
 
     cy.get(DROPDOWN_TOGGLE).should('have.attr', 'aria-expanded', 'true');
 
     cy.get(DROPDOWN_MENU)
-      .should('have.attr', 'aria-hidden', 'false')
-      .and('be.visible');
+      .should('be.visible')
+      .and('not.have.attr', 'hidden');
   });
 });

--- a/src/components/dropdown/dropdown.config.yml
+++ b/src/components/dropdown/dropdown.config.yml
@@ -4,7 +4,7 @@ status: "ready"
 collated: true
 context:
     title: "Navigation menu"
-    id: "dropdown-navigation"
+    id: "dropdownNavigation"
     items:
       - text: "Item one"
       - text: "Item two"
@@ -19,17 +19,17 @@ variants:
   - name: "secondary"
     context:
         title: "Secondary menu"
-        id: "dropdown-secondary"
+        id: "dropdownSecondary"
         modifier: "-secondary"
   - name: "right-align"
     context:
         title: "Right-aligned menu"
-        id: "dropdown-right"
+        id: "dropdownRight"
         class: "rvt-dropdown__menu--right"
   - name: "buttons"
     context:
         title: "Dropdown with buttons"
-        id: "dropdown-buttons"
+        id: "dropdownButtons"
         buttons: true
         items:
           - text: "Notify all"
@@ -52,7 +52,7 @@ variants:
   - name: "heading"
     context:
         title: "Dropdown with heading"
-        id: "dropdown-heading"
+        id: "dropdownHeading"
         items:
           - text: "Notify all"
             attributes:
@@ -75,7 +75,7 @@ variants:
   - name: "heading"
     context:
         title: "Heading and buttons"
-        id: "dropdown-heading-buttons"
+        id: "dropdownHeadingButtons"
         buttons: true
         items:
           - text: "Notify all"

--- a/src/components/dropdown/dropdown.njk
+++ b/src/components/dropdown/dropdown.njk
@@ -6,7 +6,7 @@
   {% else %}
     {% render '@button--dropdown', { special: "true", content: title, initials: initials, username: username, attributes: [{ label: "class", value: "rvt-dropdown__toggle" }, { label: "data-dropdown-toggle", value: id }, { label: "aria-haspopup", value: "true"}, { label: "aria-expanded", value: "false"}] }, true %}
   {% endif %}
-  <div class="rvt-dropdown__menu{% if class %} {{ class }}{% endif %}" id="{{ id }}"{% if not identityModule %} role="menu"{% endif %} aria-hidden="true">
+  <div class="rvt-dropdown__menu{% if class %} {{ class }}{% endif %}" id="{{ id }}"{% if not identityModule %} role="menu"{% endif %} aria-hidden="true" data-dropdown-menu>
   {% if buttons %}
     {% for item in items %}
       {% if item.relatedLinks %}

--- a/src/components/dropdown/dropdown.njk
+++ b/src/components/dropdown/dropdown.njk
@@ -1,4 +1,4 @@
-<div class="rvt-dropdown">
+<div class="rvt-dropdown" data-dropdown="{{ id }}">
   {% if not special %}
     {% render '@button--dropdown', { content: title, modifier: modifier, attributes: [{ label: "data-dropdown-toggle", value: id }, { label: "aria-haspopup", value: "true"}, { label: "aria-expanded", value: "false"}] }, true %}
   {% elif identityModule %}
@@ -47,11 +47,6 @@
 </div>
 
 <script>
-    // Callback function that puts focus on the button that was toggled.
-    function focusTheToggle(id) {
-        document
-            .querySelector('[data-dropdown-toggle="' + id + '"]')
-            .focus();
-    }
-
+  const dropdownWrapper{{ id }} = document.querySelector('[data-dropdown="{{ id }}"]');
+  window.newDropdown{{ id }} = new Rivet.Dropdown(dropdownWrapper{{ id }});
 </script>

--- a/src/components/dropdown/dropdown.njk
+++ b/src/components/dropdown/dropdown.njk
@@ -48,5 +48,5 @@
 
 <script>
   const dropdownWrapper{{ id }} = document.querySelector('[data-dropdown="{{ id }}"]');
-  window.newDropdown{{ id }} = new Rivet.Dropdown(dropdownWrapper{{ id }});
+  window.new{{ id }} = new Rivet.Dropdown(dropdownWrapper{{ id }});
 </script>

--- a/src/components/dropdown/dropdown.njk
+++ b/src/components/dropdown/dropdown.njk
@@ -6,7 +6,7 @@
   {% else %}
     {% render '@button--dropdown', { special: "true", content: title, initials: initials, username: username, attributes: [{ label: "class", value: "rvt-dropdown__toggle" }, { label: "data-dropdown-toggle", value: id }, { label: "aria-haspopup", value: "true"}, { label: "aria-expanded", value: "false"}] }, true %}
   {% endif %}
-  <div class="rvt-dropdown__menu{% if class %} {{ class }}{% endif %}" id="{{ id }}"{% if not identityModule %} role="menu"{% endif %} aria-hidden="true" data-dropdown-menu>
+  <div class="rvt-dropdown__menu{% if class %} {{ class }}{% endif %}" id="{{ id }}"{% if not identityModule %} role="menu"{% endif %} hidden data-dropdown-menu>
   {% if buttons %}
     {% for item in items %}
       {% if item.relatedLinks %}

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -6,6 +6,12 @@
 export default class Dropdown {
   constructor(element) {
     this.element = element;
+    this.focusableElements = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]';
+    this.toggleAttribute = '[data-dropdown-toggle]';
+    this.menuSelector = '[data-dropdown-menu]';
+
+    // Bind methods
+    this._handleClick = this._handleClick.bind(this);
 
     this.init();
   }
@@ -35,10 +41,10 @@ export default class Dropdown {
   }
 
   init() {
-
+    this.element.addEventListener('click', this._handleClick, false);
   }
 
   destroy() {
-
+    this.element.removeEventListener('click', this._handleClick, false);
   }
 }

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2018 The Trustees of Indiana University
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+export default class Dropdown {
+  constructor(element) {
+    this.element = element;
+
+    this.init();
+  }
+
+  openMenu() {
+
+  }
+
+  closeMenu() {
+
+  }
+
+  toggle() {
+
+  }
+
+  _setUpMenu() {
+
+  }
+
+  _handleClick() {
+
+  }
+
+  _handleKeydown() {
+
+  }
+
+  init() {
+
+  }
+
+  destroy() {
+
+  }
+}

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -18,14 +18,12 @@ export default class Dropdown {
     this.menuAttribute = '[data-dropdown-menu]';
     this.menuElement = this.element.querySelector(this.menuAttribute);
 
-    // Keyboard Codes
-    this.keys = keyCodes;
-
     // Keeps track of the currently active dropdown and helps with focus management
     this.activeDropdown = null;
 
     // Bind methods
     this._handleClick = this._handleClick.bind(this);
+    this._handleKeydown = this._handleKeydown.bind(this);
 
     this.init();
   }
@@ -64,8 +62,24 @@ export default class Dropdown {
     menuList.setAttribute('aria-hidden', 'true');
   }
 
-  _setUpMenu() {
+  _setUpMenu(menu) {
+    const menuObject = {};
 
+    // Create a real Array of all the focusable elements in the menu
+    const menuFocusables = Array.prototype.slice.call(
+      menu.querySelectorAll(this.focusableElements)
+    );
+
+    // Create a property to hold an array of all focusables
+    menuObject.all = menuFocusables;
+
+    // Create a property with a reference to the first focusable
+    menuObject.first = menuFocusables[0];
+
+    // Create a property with a reference to the last focusable
+    menuObject.last = menuFocusables[menuFocusables.length - 1];
+
+    return menuObject;
   }
 
   _handleClick(event) {
@@ -103,15 +117,90 @@ export default class Dropdown {
     }
   }
 
-  _handleKeydown() {
+  _handleKeydown(event) {
+    const dropdown = event.target.closest(this.dropdownAttribute);
 
+    if (!dropdown) return;
+
+    const toggleButton = dropdown.querySelector(this.toggleAttribute);
+    const menuList = dropdown.querySelector(this.menuAttribute);
+
+    // Delegate event to only this instance of the dropdown
+    if (dropdown === this.element) {
+      switch (event.keyCode) {
+        case keyCodes.down: {
+          event.preventDefault();
+
+          const toggle = event.target.closest(this.toggleAttribute);
+
+          /**
+           * If you were focused on the dropdown toggle
+           */
+          if (toggle && toggle !== null) {
+            // If you're focused on the toggle button and the menu is open.
+            if (toggle.getAttribute('aria-expanded') === 'true') {
+              const currentMenu = this._setUpMenu(this.menuElement);
+  
+              currentMenu.first.focus();
+            }
+  
+            this.openMenu(toggleButton, menuList);
+          }
+
+          /**
+           * Handle down arrow key when inside the open menu.
+           */
+
+          if (event.target.closest(this.menuAttribute) !== null) {
+            const currentMenu = this._setUpMenu(this.menuElement);
+
+            let currentIndex;
+
+            /**
+             * This keeps track of which button/focusable is focused in the open menu
+             */
+            for (let i = 0; i < currentMenu.all.length; i++) {
+              if (event.target == currentMenu.all[i]) {
+                currentIndex = i;
+              }
+            }
+
+            const nextItem = currentMenu.all[currentIndex + 1];
+
+            if (!nextItem) {
+              currentMenu.first.focus();
+
+              return;
+            }
+
+            nextItem.focus();
+          }
+  
+          break;
+        }
+  
+        case keyCodes.up: {
+          break;
+        }
+  
+        case keyCodes.escape: {
+          break;
+        }
+  
+        case keyCodes.tab: {
+          break;
+        }
+      }
+    }
   }
 
   init() {
     document.addEventListener('click', this._handleClick, false);
+    document.addEventListener('keydown', this._handleKeydown, false);
   }
 
   destroy() {
     document.removeEventListener('click', this._handleClick, false);
+    document.removeEventListener('keydown', this._handleKeydown, false);
   }
 }

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -100,11 +100,11 @@ export default class Dropdown {
   }
 
   _handleKeydown(event) {
-    const dropdown = event.target.closest(this.dropdownAttribute);
-
-    if (!dropdown) return;
+    // If the keydown didn't come from within dropdown component, then bail.
+    if (!this.element.contains(event.target)) return;
 
     // Delegate event to only this instance of the dropdown
+    const dropdown = event.target.closest(this.dropdownAttribute);
     if (dropdown !== this.element) return;
 
     switch (event.keyCode) {
@@ -127,12 +127,10 @@ export default class Dropdown {
         // If the event didn't come from within the menu, then bail.
         if (!this.menuElement.contains(event.target)) break;
 
-        const currentMenu = this._setUpMenu(this.menuElement);
-
         /**
          * This keeps track of which button/focusable is focused in the open menu
          */
-
+        const currentMenu = this._setUpMenu(this.menuElement);
         let currentIndex;
 
         for (let i = 0; i < currentMenu.all.length; i++) {
@@ -164,13 +162,12 @@ export default class Dropdown {
         // If the event didn't come from within the menu, then bail.
         if (!this.menuElement.contains(event.target)) break;
 
-        const currentMenu = this._setUpMenu(this.menuElement);
-
-        let currentIndex;
-
         /**
          * This keeps track of which button/focusable is focused in the open menu
          */
+        const currentMenu = this._setUpMenu(this.menuElement);
+        let currentIndex;
+
         for (let i = 0; i < currentMenu.all.length; i++) {
           if (event.target == currentMenu.all[i]) {
             currentIndex = i;

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -70,7 +70,11 @@ export default class Dropdown {
 
   _handleClick(event) {
     const dropdown = event.target.closest(this.dropdownAttribute);
+
     if (!dropdown) return;
+
+    const toggleButton = dropdown.querySelector(this.toggleAttribute);
+    const menuList = dropdown.querySelector(this.menuAttribute);
 
     // Delegate event to only this instance of the dropdown
     if (dropdown === this.element) {
@@ -80,10 +84,7 @@ export default class Dropdown {
       if (menuTarget && menuTarget !== null) {
         event.clickedWithinMenu = true;
       }
-  
-      const toggleButton = dropdown.querySelector(this.toggleAttribute);
-      const menuList = dropdown.querySelector(this.menuAttribute);
-  
+
       if (!toggleButton || toggleButton.getAttribute('aria-expanded') === 'true') {
         /**
          * Otherwise close the currently open menu unless the click
@@ -97,6 +98,8 @@ export default class Dropdown {
       }
   
       this.openMenu(toggleButton, menuList);
+    } else {
+      this.closeMenu();
     }
   }
 

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -3,12 +3,17 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import keyCodes from '../utilities/keyCodes';
+
 export default class Dropdown {
   constructor(element) {
     this.element = element;
     this.focusableElements = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]';
     this.toggleAttribute = '[data-dropdown-toggle]';
     this.menuSelector = '[data-dropdown-menu]';
+
+    // Keyboard Codes
+    this.keys = keyCodes;
 
     // Bind methods
     this._handleClick = this._handleClick.bind(this);

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -6,16 +6,7 @@
 import keyCodes from '../utilities/keyCodes';
 
 export default class Dropdown {
-  constructor(element, options) {
-    const defaultOptions = {
-      preventPageScrollOnArrow: true
-    };
-
-    const settings = {
-      ...defaultOptions,
-      ...options
-    };
-
+  constructor(element) {
     this.element = element;
     this.focusableElements = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]';
 
@@ -33,9 +24,6 @@ export default class Dropdown {
     // Bind methods
     this._handleClick = this._handleClick.bind(this);
     this._handleKeydown = this._handleKeydown.bind(this);
-
-    // Bind default and imported settings
-    this.preventPageScrollOnArrow = settings.preventPageScrollOnArrow;
 
     this.init();
   }
@@ -162,9 +150,7 @@ export default class Dropdown {
     if (dropdown === this.element) {
       switch (event.keyCode) {
         case keyCodes.down: {
-          if (this.preventPageScrollOnArrow) {
-            event.preventDefault();
-          }
+          event.preventDefault();
 
           const toggle = event.target.closest(this.toggleAttribute);
 
@@ -215,9 +201,7 @@ export default class Dropdown {
         }
   
         case keyCodes.up: {
-          if (this.preventPageScrollOnArrow) {
-            event.preventDefault();
-          }
+          event.preventDefault();
 
           /**
            * Handle up arrow key when inside the open menu.

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -4,6 +4,7 @@
  */
 
 import keyCodes from '../utilities/keyCodes';
+import { nodeListToArray } from '../utilities/domHelpers';
 
 export default class Dropdown {
   constructor(element) {
@@ -67,9 +68,7 @@ export default class Dropdown {
     const menuObject = {};
 
     // Create a real Array of all the focusable elements in the menu
-    const menuFocusables = Array.prototype.slice.call(
-      menu.querySelectorAll(this.focusableElements)
-    );
+    const menuFocusables = nodeListToArray(menu.querySelectorAll(this.focusableElements));
 
     // Create a property to hold an array of all focusables
     menuObject.all = menuFocusables;

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -180,6 +180,37 @@ export default class Dropdown {
         }
   
         case keyCodes.up: {
+          event.preventDefault();
+
+          /**
+           * Handle up arrow key when inside the open menu.
+           */
+
+          if (event.target.closest(this.menuAttribute) !== null) {
+            const currentMenu = this._setUpMenu(this.menuElement);
+
+            let currentIndex;
+
+            /**
+             * This keeps track of which button/focusable is focused in the open menu
+             */
+            for (let i = 0; i < currentMenu.all.length; i++) {
+              if (event.target == currentMenu.all[i]) {
+                currentIndex = i;
+              }
+            }
+
+            const previousItem = currentMenu.all[currentIndex - 1];
+
+            if (!previousItem && currentMenu.last !== undefined) {
+              currentMenu.last.focus();
+
+              return;
+            }
+
+            previousItem.focus();
+          }
+  
           break;
         }
   

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -48,7 +48,7 @@ export default class Dropdown {
     }
 
     // Remove the 'hidden' attribute to show the menu
-    menuList.setAttribute('aria-hidden', 'false');
+    menuList.removeAttribute('hidden');
 
     this.activeDropdown = this.element;
   }
@@ -71,7 +71,7 @@ export default class Dropdown {
       toggleButton.setAttribute('aria-expanded', 'false');
     }
 
-    menuList.setAttribute('aria-hidden', 'true');
+    menuList.setAttribute('hidden', '');
   }
 
   /**

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -54,6 +54,8 @@ export default class Dropdown {
     this.toggleElement.setAttribute('aria-expanded', 'false');
 
     this.menuElement.setAttribute('hidden', '');
+
+    this.activeDropdown = null;
   }
 
   /**

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -20,12 +20,14 @@ export default class Dropdown {
 
     // Keeps track of the currently active dropdown and helps with focus management
     this.activeDropdown = null;
-
     this.isOpen = false;
 
     // Bind methods
     this._handleClick = this._handleClick.bind(this);
     this._handleKeydown = this._handleKeydown.bind(this);
+
+    // Make sure icons don't receive focus
+    this.element.querySelector('svg').setAttribute('focusable', 'false');
 
     this.init();
   }

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -44,6 +44,8 @@ export default class Dropdown {
 
     // Remove the 'hidden' attribute to show the menu
     menuList.setAttribute('aria-hidden', 'false');
+
+    this.activeDropdown = this.element;
   }
 
   closeMenu(toggle, menu) {
@@ -215,6 +217,21 @@ export default class Dropdown {
         }
   
         case keyCodes.escape: {
+          // If there's an open menu, close it.
+          if (this.activeDropdown) {
+            this.closeMenu(this.toggleElement, this.menuElement);
+          }
+
+          if (this.toggleElement && this.toggleElement !== null) {
+            this.toggleElement.focus();
+          }
+
+          /**
+           * Resets the state variables so as not to interfere with other
+           * Escape key handlers/interactions
+           */
+          this.activeDropdown = null;
+
           break;
         }
   

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -87,9 +87,6 @@ export default class Dropdown {
       return;
     }
 
-    const toggleButton = dropdown.querySelector(this.toggleAttribute);
-    const menuList = dropdown.querySelector(this.menuAttribute);
-
     // Delegate event to only this instance of the dropdown
     if (dropdown === this.element) {
       const menuTarget = event.target.closest(this.menuAttribute);
@@ -99,19 +96,19 @@ export default class Dropdown {
         event.clickedWithinMenu = true;
       }
 
-      if (!toggleButton || toggleButton.getAttribute('aria-expanded') === 'true') {
+      if (!this.toggleElement || this.toggleElement.getAttribute('aria-expanded') === 'true') {
         /**
          * Close the menu if there is a click outside of the menu, but within 
          * the dropdown component
          */
         if (!event.clickedWithinMenu) {
-          this.close(toggleButton, menuList);
+          this.close(this.toggleElement, this.menuElement);
         }
 
         return;
       }
   
-      this.open(toggleButton, menuList);
+      this.open();
     } else {
       this.close();
     }
@@ -122,30 +119,20 @@ export default class Dropdown {
 
     if (!dropdown) return;
 
-    const toggleButton = dropdown.querySelector(this.toggleAttribute);
-    const menuList = dropdown.querySelector(this.menuAttribute);
-
     // Delegate event to only this instance of the dropdown
     if (dropdown === this.element) {
       switch (event.keyCode) {
         case keyCodes.down: {
           event.preventDefault();
 
-          const toggle = event.target.closest(this.toggleAttribute);
+          // If you're focused on the toggle button and the menu is open.
+          if (this.toggleElement.getAttribute('aria-expanded') === 'true') {
+            const currentMenu = this._setUpMenu(this.menuElement);
 
-          /**
-           * If you were focused on the dropdown toggle
-           */
-          if (toggle && toggle !== null) {
-            // If you're focused on the toggle button and the menu is open.
-            if (toggle.getAttribute('aria-expanded') === 'true') {
-              const currentMenu = this._setUpMenu(this.menuElement);
-  
-              currentMenu.first.focus();
-            }
-  
-            this.open(toggleButton, menuList);
+            currentMenu.first.focus();
           }
+
+          this.open();
 
           /**
            * Handle down arrow key when inside the open menu.
@@ -219,9 +206,7 @@ export default class Dropdown {
             this.close(this.toggleElement, this.menuElement);
           }
 
-          if (this.toggleElement && this.toggleElement !== null) {
-            this.toggleElement.focus();
-          }
+          this.toggleElement.focus();
 
           /**
            * Resets the state variables so as not to interfere with other

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -114,7 +114,11 @@ export default class Dropdown {
   _handleClick(event) {
     const dropdown = event.target.closest(this.dropdownAttribute);
 
-    if (!dropdown) return;
+    // If click didn't come from within dropdown component, close all open menus
+    if (!dropdown) {
+      this.closeMenu();
+      return;
+    }
 
     const toggleButton = dropdown.querySelector(this.toggleAttribute);
     const menuList = dropdown.querySelector(this.menuAttribute);
@@ -130,13 +134,13 @@ export default class Dropdown {
 
       if (!toggleButton || toggleButton.getAttribute('aria-expanded') === 'true') {
         /**
-         * Otherwise close the currently open menu unless the click
-         * happened inside of it.
+         * Close the menu if there is a click outside of the menu, but within 
+         * the dropdown component
          */
         if (!event.clickedWithinMenu) {
           this.closeMenu(toggleButton, menuList);
         }
-  
+
         return;
       }
   

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -10,6 +10,8 @@ export default class Dropdown {
     this.element = element;
     this.focusableElements = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]';
 
+    this.dropdownAttribute = '[data-dropdown]';
+
     this.toggleAttribute = '[data-dropdown-toggle]';
     this.toggleElement = this.element.querySelector(this.toggleAttribute);
 
@@ -28,32 +30,38 @@ export default class Dropdown {
     this.init();
   }
 
-  openMenu() {
+  openMenu(toggle, menu) {
+    const toggleButton = toggle || this.toggleElement;
+    const menuList = menu || this.menuElement;
+
     // Return if disabled dropdown is being opened programmatically
-    if (this.toggleElement.hasAttribute('disabled')) {
+    if (toggleButton.hasAttribute('disabled')) {
       return;
     }
 
     // If the menu was opened by clicking an associated toggle
-    if (this.toggleElement && this.toggleElement !== null) {
-      this.toggleElement.setAttribute('aria-expanded', 'true');
+    if (toggleButton && toggleButton !== null) {
+      toggleButton.setAttribute('aria-expanded', 'true');
     }
 
     // Remove the 'hidden' attribute to show the menu
-    this.menuElement.setAttribute('aria-hidden', 'false');
+    menuList.setAttribute('aria-hidden', 'false');
   }
 
-  closeMenu() {
+  closeMenu(toggle, menu) {
+    const toggleButton = toggle || this.toggleElement;
+    const menuList = menu || this.menuElement;
+
     // Return if disabled dropdown is being closed programmatically
-    if (this.toggleElement.hasAttribute('disabled')) {
+    if (toggleButton.hasAttribute('disabled')) {
       return;
     }
 
-    if (this.toggleElement && this.toggleElement !== undefined) {
-      this.toggleElement.setAttribute('aria-expanded', 'false');
+    if (toggleButton && toggleButton !== undefined) {
+      toggleButton.setAttribute('aria-expanded', 'false');
     }
 
-    this.menuElement.setAttribute('aria-hidden', 'true');
+    menuList.setAttribute('aria-hidden', 'true');
   }
 
   _setUpMenu() {
@@ -61,28 +69,35 @@ export default class Dropdown {
   }
 
   _handleClick(event) {
-    const menu = event.target.closest(this.menuAttribute);
+    const dropdown = event.target.closest(this.dropdownAttribute);
+    if (!dropdown) return;
 
-    // Use this boolean on the event object in place of stopPropagation()
-    if (menu && menu !== null) {
-      event.clickedWithinMenu = true;
-    }
+    // Delegate event to only this instance of the dropdown
+    if (dropdown === this.element) {
+      const menuTarget = event.target.closest(this.menuAttribute);
 
-    if (!this.toggleElement || this.toggleElement.getAttribute('aria-expanded') === 'true') {
-      /**
-       * Otherwise close the currently open menu unless the click
-       * happened inside of it.
-       */
-      if (!event.clickedWithinMenu) {
-        this.closeMenu();
+      // Use this boolean on the event object in place of stopPropagation()
+      if (menuTarget && menuTarget !== null) {
+        event.clickedWithinMenu = true;
       }
-
-      return;
+  
+      const toggleButton = dropdown.querySelector(this.toggleAttribute);
+      const menuList = dropdown.querySelector(this.menuAttribute);
+  
+      if (!toggleButton || toggleButton.getAttribute('aria-expanded') === 'true') {
+        /**
+         * Otherwise close the currently open menu unless the click
+         * happened inside of it.
+         */
+        if (!event.clickedWithinMenu) {
+          this.closeMenu(toggleButton, menuList);
+        }
+  
+        return;
+      }
+  
+      this.openMenu(toggleButton, menuList);
     }
-
-    const dropdownId = this.element;
-
-    this.openMenu(dropdownId);
   }
 
   _handleKeydown() {
@@ -90,10 +105,10 @@ export default class Dropdown {
   }
 
   init() {
-    this.element.addEventListener('click', this._handleClick, false);
+    document.addEventListener('click', this._handleClick, false);
   }
 
   destroy() {
-    this.element.removeEventListener('click', this._handleClick, false);
+    document.removeEventListener('click', this._handleClick, false);
   }
 }

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -40,6 +40,11 @@ export default class Dropdown {
     this.init();
   }
 
+  /**
+   * Opens a dropdown menu
+   * @param {HTMLButtonElement} toggle - a button element which toggles the dropdown
+   * @param {HTMLDivElement} menu - a div containing the dropdown menu items
+   */
   openMenu(toggle, menu) {
     const toggleButton = toggle || this.toggleElement;
     const menuList = menu || this.menuElement;
@@ -60,6 +65,11 @@ export default class Dropdown {
     this.activeDropdown = this.element;
   }
 
+  /**
+   * Closes a dropdown menu
+   * @param {HTMLButtonElement} toggle - a button element which toggles the dropdown
+   * @param {HTMLDivElement} menu - a div containing the dropdown menu items
+   */
   closeMenu(toggle, menu) {
     const toggleButton = toggle || this.toggleElement;
     const menuList = menu || this.menuElement;
@@ -76,6 +86,11 @@ export default class Dropdown {
     menuList.setAttribute('aria-hidden', 'true');
   }
 
+  /**
+   * Creates an object of menu items within a dropdown
+   * @param {HTMLDivElement} menu - a div containing the dropdown menu items
+   * @returns {Object} An object of menu item anchor elements
+   */
   _setUpMenu(menu) {
     const menuObject = {};
 

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -28,50 +28,29 @@ export default class Dropdown {
     this.init();
   }
 
-  /**
-   * Opens a dropdown menu
-   * @param {HTMLButtonElement} toggle - a button element which toggles the dropdown
-   * @param {HTMLDivElement} menu - a div containing the dropdown menu items
-   */
-  open(toggle, menu) {
-    const toggleButton = toggle || this.toggleElement;
-    const menuList = menu || this.menuElement;
-
+  open() {
     // Return if disabled dropdown is being opened programmatically
-    if (toggleButton.hasAttribute('disabled')) {
+    if (this.toggleElement.hasAttribute('disabled')) {
       return;
     }
 
-    // If the menu was opened by clicking an associated toggle
-    if (toggleButton && toggleButton !== null) {
-      toggleButton.setAttribute('aria-expanded', 'true');
-    }
+    this.toggleElement.setAttribute('aria-expanded', 'true');
 
     // Remove the 'hidden' attribute to show the menu
-    menuList.removeAttribute('hidden');
+    this.menuElement.removeAttribute('hidden');
 
     this.activeDropdown = this.element;
   }
 
-  /**
-   * Closes a dropdown menu
-   * @param {HTMLButtonElement} toggle - a button element which toggles the dropdown
-   * @param {HTMLDivElement} menu - a div containing the dropdown menu items
-   */
-  close(toggle, menu) {
-    const toggleButton = toggle || this.toggleElement;
-    const menuList = menu || this.menuElement;
-
+  close() {
     // Return if disabled dropdown is being closed programmatically
-    if (toggleButton.hasAttribute('disabled')) {
+    if (this.toggleElement.hasAttribute('disabled')) {
       return;
     }
 
-    if (toggleButton && toggleButton !== undefined) {
-      toggleButton.setAttribute('aria-expanded', 'false');
-    }
+    this.toggleElement.setAttribute('aria-expanded', 'false');
 
-    menuList.setAttribute('hidden', '');
+    this.menuElement.setAttribute('hidden', '');
   }
 
   /**

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -6,7 +6,16 @@
 import keyCodes from '../utilities/keyCodes';
 
 export default class Dropdown {
-  constructor(element) {
+  constructor(element, options) {
+    const defaultOptions = {
+      preventPageScrollOnArrow: true
+    };
+
+    const settings = {
+      ...defaultOptions,
+      ...options
+    };
+
     this.element = element;
     this.focusableElements = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]';
 
@@ -24,6 +33,9 @@ export default class Dropdown {
     // Bind methods
     this._handleClick = this._handleClick.bind(this);
     this._handleKeydown = this._handleKeydown.bind(this);
+
+    // Bind default and imported settings
+    this.preventPageScrollOnArrow = settings.preventPageScrollOnArrow;
 
     this.init();
   }
@@ -131,7 +143,9 @@ export default class Dropdown {
     if (dropdown === this.element) {
       switch (event.keyCode) {
         case keyCodes.down: {
-          event.preventDefault();
+          if (this.preventPageScrollOnArrow) {
+            event.preventDefault();
+          }
 
           const toggle = event.target.closest(this.toggleAttribute);
 
@@ -182,12 +196,13 @@ export default class Dropdown {
         }
   
         case keyCodes.up: {
-          event.preventDefault();
+          if (this.preventPageScrollOnArrow) {
+            event.preventDefault();
+          }
 
           /**
            * Handle up arrow key when inside the open menu.
            */
-
           if (event.target.closest(this.menuAttribute) !== null) {
             const currentMenu = this._setUpMenu(this.menuElement);
 
@@ -236,6 +251,20 @@ export default class Dropdown {
         }
   
         case keyCodes.tab: {
+          /**
+           * Handle tab key when inside the open menu.
+           */
+          if (event.target.closest(this.menuAttribute) !== null) {
+            const currentMenu = this._setUpMenu(this.menuElement);
+
+            // Close the dropdown when the user tabs out of the menu.
+            if (document.activeElement == currentMenu.last && !event.shiftKey) {
+              this.closeMenu(this.toggleElement, this.menuElement);
+
+              return;
+            }
+          }
+
           break;
         }
       }

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -9,11 +9,19 @@ export default class Dropdown {
   constructor(element) {
     this.element = element;
     this.focusableElements = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]';
+
     this.toggleAttribute = '[data-dropdown-toggle]';
-    this.menuSelector = '[data-dropdown-menu]';
+    this.toggleElement = this.element.querySelector(this.toggleAttribute);
+
+    this.menuAttribute = '[data-dropdown-menu]';
+    this.menuElement = this.element.querySelector(this.menuAttribute);
 
     // Keyboard Codes
     this.keys = keyCodes;
+
+    // Keeps track of the currently active toggle and helps with focus management
+    this.activeToggle = null;
+    this.activeMenu = null;
 
     // Bind methods
     this._handleClick = this._handleClick.bind(this);
@@ -21,8 +29,34 @@ export default class Dropdown {
     this.init();
   }
 
-  openMenu() {
+  openMenu(id, callback) {
+    // If there's an open menu, close it.
+    if (this.activeMenu) {
+      this.closeMenu(this.activeMenu);
+    }
 
+    // Set the current active menu the menu we're about to open
+    this.activeMenu = id;
+
+    // Return if disabled dropdown is being opened programmatically
+    if (this.toggleElement.hasAttribute('disabled')) {
+      return;
+    }
+
+    // If the menu was opened by clicking an associated toggle
+    if (this.toggleElement && this.toggleElement !== null) {
+      this.toggleElement.setAttribute('aria-expanded', 'true');
+
+      this.activeToggle = this.toggleElement;
+    }
+
+    // Remove the 'hidden' attribute to show the menu
+    this.menuElement.setAttribute('aria-hidden', 'false');
+
+    // Execute supplied callback function if it exists
+    if (callback && typeof callback === 'function') {
+      callback();
+    }
   }
 
   closeMenu() {
@@ -37,8 +71,25 @@ export default class Dropdown {
 
   }
 
-  _handleClick() {
+  _handleClick(event) {
+    if (!this.toggleElement || this.toggleElement.getAttribute('aria-expanded') === 'true') {
+      // No menu has been opened yet and the event target was not a toggle, so bail.
+      if (!this.activeMenu) return;
 
+      /**
+       * Otherwise close the currently open menu unless the click
+       * happened inside of it.
+       */
+      if (!event.clickedWithinMenu) {
+        this.closeMenu(this.activeMenu);
+      }
+
+      return;
+    }
+
+    var dropdownId = this.toggleElement.getAttribute(this.toggleAttribute);
+
+    this.openMenu(dropdownId);
   }
 
   _handleKeydown() {

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -19,9 +19,8 @@ export default class Dropdown {
     // Keyboard Codes
     this.keys = keyCodes;
 
-    // Keeps track of the currently active toggle and helps with focus management
-    this.activeToggle = null;
-    this.activeMenu = null;
+    // Keeps track of the currently active dropdown and helps with focus management
+    this.activeDropdown = null;
 
     // Bind methods
     this._handleClick = this._handleClick.bind(this);
@@ -29,15 +28,7 @@ export default class Dropdown {
     this.init();
   }
 
-  openMenu(id, callback) {
-    // If there's an open menu, close it.
-    if (this.activeMenu) {
-      this.closeMenu(this.activeMenu);
-    }
-
-    // Set the current active menu the menu we're about to open
-    this.activeMenu = id;
-
+  openMenu() {
     // Return if disabled dropdown is being opened programmatically
     if (this.toggleElement.hasAttribute('disabled')) {
       return;
@@ -46,25 +37,23 @@ export default class Dropdown {
     // If the menu was opened by clicking an associated toggle
     if (this.toggleElement && this.toggleElement !== null) {
       this.toggleElement.setAttribute('aria-expanded', 'true');
-
-      this.activeToggle = this.toggleElement;
     }
 
     // Remove the 'hidden' attribute to show the menu
     this.menuElement.setAttribute('aria-hidden', 'false');
-
-    // Execute supplied callback function if it exists
-    if (callback && typeof callback === 'function') {
-      callback();
-    }
   }
 
   closeMenu() {
+    // Return if disabled dropdown is being closed programmatically
+    if (this.toggleElement.hasAttribute('disabled')) {
+      return;
+    }
 
-  }
+    if (this.toggleElement && this.toggleElement !== undefined) {
+      this.toggleElement.setAttribute('aria-expanded', 'false');
+    }
 
-  toggle() {
-
+    this.menuElement.setAttribute('aria-hidden', 'true');
   }
 
   _setUpMenu() {
@@ -72,22 +61,26 @@ export default class Dropdown {
   }
 
   _handleClick(event) {
-    if (!this.toggleElement || this.toggleElement.getAttribute('aria-expanded') === 'true') {
-      // No menu has been opened yet and the event target was not a toggle, so bail.
-      if (!this.activeMenu) return;
+    const menu = event.target.closest(this.menuAttribute);
 
+    // Use this boolean on the event object in place of stopPropagation()
+    if (menu && menu !== null) {
+      event.clickedWithinMenu = true;
+    }
+
+    if (!this.toggleElement || this.toggleElement.getAttribute('aria-expanded') === 'true') {
       /**
        * Otherwise close the currently open menu unless the click
        * happened inside of it.
        */
       if (!event.clickedWithinMenu) {
-        this.closeMenu(this.activeMenu);
+        this.closeMenu();
       }
 
       return;
     }
 
-    var dropdownId = this.toggleElement.getAttribute(this.toggleAttribute);
+    const dropdownId = this.element;
 
     this.openMenu(dropdownId);
   }

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -33,7 +33,7 @@ export default class Dropdown {
    * @param {HTMLButtonElement} toggle - a button element which toggles the dropdown
    * @param {HTMLDivElement} menu - a div containing the dropdown menu items
    */
-  openMenu(toggle, menu) {
+  open(toggle, menu) {
     const toggleButton = toggle || this.toggleElement;
     const menuList = menu || this.menuElement;
 
@@ -58,7 +58,7 @@ export default class Dropdown {
    * @param {HTMLButtonElement} toggle - a button element which toggles the dropdown
    * @param {HTMLDivElement} menu - a div containing the dropdown menu items
    */
-  closeMenu(toggle, menu) {
+  close(toggle, menu) {
     const toggleButton = toggle || this.toggleElement;
     const menuList = menu || this.menuElement;
 
@@ -104,7 +104,7 @@ export default class Dropdown {
 
     // If click didn't come from within dropdown component, close all open menus
     if (!dropdown) {
-      this.closeMenu();
+      this.close();
       return;
     }
 
@@ -126,15 +126,15 @@ export default class Dropdown {
          * the dropdown component
          */
         if (!event.clickedWithinMenu) {
-          this.closeMenu(toggleButton, menuList);
+          this.close(toggleButton, menuList);
         }
 
         return;
       }
   
-      this.openMenu(toggleButton, menuList);
+      this.open(toggleButton, menuList);
     } else {
-      this.closeMenu();
+      this.close();
     }
   }
 
@@ -165,7 +165,7 @@ export default class Dropdown {
               currentMenu.first.focus();
             }
   
-            this.openMenu(toggleButton, menuList);
+            this.open(toggleButton, menuList);
           }
 
           /**
@@ -237,7 +237,7 @@ export default class Dropdown {
         case keyCodes.escape: {
           // If there's an open menu, close it.
           if (this.activeDropdown) {
-            this.closeMenu(this.toggleElement, this.menuElement);
+            this.close(this.toggleElement, this.menuElement);
           }
 
           if (this.toggleElement && this.toggleElement !== null) {
@@ -262,7 +262,7 @@ export default class Dropdown {
 
             // Close the dropdown when the user tabs out of the menu.
             if (document.activeElement == currentMenu.last && !event.shiftKey) {
-              this.closeMenu(this.toggleElement, this.menuElement);
+              this.close(this.toggleElement, this.menuElement);
 
               return;
             }

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -21,6 +21,8 @@ export default class Dropdown {
     // Keeps track of the currently active dropdown and helps with focus management
     this.activeDropdown = null;
 
+    this.isOpen = false;
+
     // Bind methods
     this._handleClick = this._handleClick.bind(this);
     this._handleKeydown = this._handleKeydown.bind(this);
@@ -34,6 +36,8 @@ export default class Dropdown {
       return;
     }
 
+    this.isOpen = true;
+
     this.toggleElement.setAttribute('aria-expanded', 'true');
 
     // Remove the 'hidden' attribute to show the menu
@@ -43,10 +47,7 @@ export default class Dropdown {
   }
 
   close() {
-    // Return if disabled dropdown is being closed programmatically
-    if (this.toggleElement.hasAttribute('disabled')) {
-      return;
-    }
+    this.isOpen = false;
 
     this.toggleElement.setAttribute('aria-expanded', 'false');
 
@@ -79,38 +80,22 @@ export default class Dropdown {
   }
 
   _handleClick(event) {
-    const dropdown = event.target.closest(this.dropdownAttribute);
+    const toggle = event.target.closest(this.toggleAttribute);
 
-    // If click didn't come from within dropdown component, close all open menus
-    if (!dropdown) {
+    // Did it come from inside open menu?
+    if (this.menuElement.contains(event.target)) return;
+
+    // If it came from outside component, close all open dropdowns
+    if (!toggle) {
       this.close();
       return;
     }
 
-    // Delegate event to only this instance of the dropdown
-    if (dropdown === this.element) {
-      const menuTarget = event.target.closest(this.menuAttribute);
-
-      // Use this boolean on the event object in place of stopPropagation()
-      if (menuTarget && menuTarget !== null) {
-        event.clickedWithinMenu = true;
-      }
-
-      if (!this.toggleElement || this.toggleElement.getAttribute('aria-expanded') === 'true') {
-        /**
-         * Close the menu if there is a click outside of the menu, but within 
-         * the dropdown component
-         */
-        if (!event.clickedWithinMenu) {
-          this.close(this.toggleElement, this.menuElement);
-        }
-
-        return;
-      }
-  
-      this.open();
-    } else {
+    // Check which toggle the click came from, and whether it's already opened
+    if (toggle !== this.toggleElement || this.isOpen) {
       this.close();
+    } else {
+      this.open();
     }
   }
 

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -105,120 +105,125 @@ export default class Dropdown {
     if (!dropdown) return;
 
     // Delegate event to only this instance of the dropdown
-    if (dropdown === this.element) {
-      switch (event.keyCode) {
-        case keyCodes.down: {
-          event.preventDefault();
+    if (dropdown !== this.element) return;
 
-          // If you're focused on the toggle button and the menu is open.
-          if (this.toggleElement.getAttribute('aria-expanded') === 'true') {
-            const currentMenu = this._setUpMenu(this.menuElement);
+    switch (event.keyCode) {
+      case keyCodes.down: {
+        event.preventDefault();
 
-            currentMenu.first.focus();
-          }
+        // The menu is open when the down arrow is pressed.
+        if (this.isOpen) {
+          const currentMenu = this._setUpMenu(this.menuElement);
 
-          this.open();
-
-          /**
-           * Handle down arrow key when inside the open menu.
-           */
-
-          if (event.target.closest(this.menuAttribute) !== null) {
-            const currentMenu = this._setUpMenu(this.menuElement);
-
-            let currentIndex;
-
-            /**
-             * This keeps track of which button/focusable is focused in the open menu
-             */
-            for (let i = 0; i < currentMenu.all.length; i++) {
-              if (event.target == currentMenu.all[i]) {
-                currentIndex = i;
-              }
-            }
-
-            const nextItem = currentMenu.all[currentIndex + 1];
-
-            if (!nextItem) {
-              currentMenu.first.focus();
-
-              return;
-            }
-
-            nextItem.focus();
-          }
-  
-          break;
+          currentMenu.first.focus();
         }
-  
-        case keyCodes.up: {
-          event.preventDefault();
 
-          /**
-           * Handle up arrow key when inside the open menu.
-           */
-          if (event.target.closest(this.menuAttribute) !== null) {
-            const currentMenu = this._setUpMenu(this.menuElement);
+        this.open();
 
-            let currentIndex;
+        /**
+         * Handle down arrow key when inside the open menu.
+         */
 
-            /**
-             * This keeps track of which button/focusable is focused in the open menu
-             */
-            for (let i = 0; i < currentMenu.all.length; i++) {
-              if (event.target == currentMenu.all[i]) {
-                currentIndex = i;
-              }
-            }
+        // If the event didn't come from within the menu, then bail.
+        if (!this.menuElement.contains(event.target)) break;
 
-            const previousItem = currentMenu.all[currentIndex - 1];
+        const currentMenu = this._setUpMenu(this.menuElement);
 
-            if (!previousItem && currentMenu.last !== undefined) {
-              currentMenu.last.focus();
+        /**
+         * This keeps track of which button/focusable is focused in the open menu
+         */
 
-              return;
-            }
+        let currentIndex;
 
-            previousItem.focus();
+        for (let i = 0; i < currentMenu.all.length; i++) {
+          if (event.target == currentMenu.all[i]) {
+            currentIndex = i;
           }
-  
-          break;
         }
-  
-        case keyCodes.escape: {
-          // If there's an open menu, close it.
-          if (this.activeDropdown) {
-            this.close(this.toggleElement, this.menuElement);
+
+        const nextItem = currentMenu.all[currentIndex + 1];
+
+        if (!nextItem) {
+          currentMenu.first.focus();
+
+          return;
+        }
+
+        nextItem.focus();
+
+        break;
+      }
+
+      case keyCodes.up: {
+        event.preventDefault();
+
+        /**
+         * Handle up arrow key when inside the open menu.
+         */
+
+        // If the event didn't come from within the menu, then bail.
+        if (!this.menuElement.contains(event.target)) break;
+
+        const currentMenu = this._setUpMenu(this.menuElement);
+
+        let currentIndex;
+
+        /**
+         * This keeps track of which button/focusable is focused in the open menu
+         */
+        for (let i = 0; i < currentMenu.all.length; i++) {
+          if (event.target == currentMenu.all[i]) {
+            currentIndex = i;
           }
-
-          this.toggleElement.focus();
-
-          /**
-           * Resets the state variables so as not to interfere with other
-           * Escape key handlers/interactions
-           */
-          this.activeDropdown = null;
-
-          break;
         }
-  
-        case keyCodes.tab: {
-          /**
-           * Handle tab key when inside the open menu.
-           */
-          if (event.target.closest(this.menuAttribute) !== null) {
-            const currentMenu = this._setUpMenu(this.menuElement);
 
-            // Close the dropdown when the user tabs out of the menu.
-            if (document.activeElement == currentMenu.last && !event.shiftKey) {
-              this.close(this.toggleElement, this.menuElement);
+        const previousItem = currentMenu.all[currentIndex - 1];
 
-              return;
-            }
-          }
+        if (!previousItem && currentMenu.last !== undefined) {
+          currentMenu.last.focus();
 
-          break;
+          return;
         }
+
+        previousItem.focus();
+
+        break;
+      }
+
+      case keyCodes.escape: {
+        // If there's an open menu, close it.
+        if (this.activeDropdown) {
+          this.close();
+        }
+
+        this.toggleElement.focus();
+
+        /**
+         * Resets the state variables so as not to interfere with other
+         * Escape key handlers/interactions
+         */
+        this.activeDropdown = null;
+
+        break;
+      }
+
+      case keyCodes.tab: {
+        /**
+         * Handle tab key when inside the open menu.
+         */
+
+        if (!this.menuElement.contains(event.target)) break;
+
+        const currentMenu = this._setUpMenu(this.menuElement);
+
+        // Close the dropdown when the user tabs out of the menu.
+        if (document.activeElement == currentMenu.last && !event.shiftKey) {
+          this.close();
+
+          return;
+        }
+
+        break;
       }
     }
   }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -9,7 +9,8 @@ import './polyfills/remove';
 
 // Components
 import Alert from './components/alert';
+import Dropdown from './components/dropdown';
 import FileInput from './components/fileInput';
 import Sidenav from './components/sidenav';
 
-export default { Alert, FileInput, Sidenav };
+export default { Alert, Dropdown, FileInput, Sidenav };

--- a/src/js/utilities/keyCodes.js
+++ b/src/js/utilities/keyCodes.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) 2019 The Trustees of Indiana University
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+const keyCodes = {
+  up: 38,
+  down: 40,
+  left: 37,
+  right: 39,
+  tab: 9,
+  escape: 27
+}
+
+export default keyCodes;

--- a/src/js/utilities/keyCodes.js
+++ b/src/js/utilities/keyCodes.js
@@ -8,8 +8,15 @@ const keyCodes = {
   down: 40,
   left: 37,
   right: 39,
+
   tab: 9,
-  escape: 27
+  enter: 13,
+  escape: 27,
+
+  home: 36,
+  end: 35,
+  pageUp: 33,
+  pageDown: 34
 }
 
 export default keyCodes;


### PR DESCRIPTION
**In this PR:**
- Refactored component JS to ES6
- Set eventListener to the `document` so multiple instances of the dropdown can be managed within a page
- Close all other dropdowns when a new one is opened
- Added option to enable/disable "prevent page scroll" when the up and down arrows are pressed

**Development checklist:**
- [x] Component should be an ES6 `class`
- [x] Component should be able to be programmatically controlled via "public" methods
- [ ] Component should emit `customEvent`s as hooks when appropriate
- [ ] Public component methods should have callback functions where appropriate (let's talk more about this as we get started)
- [x] Components should use data attributes as hooks for functionality and follow the format `data-[component-name]`
- [ ] `customEvent`s should be cancelable by the developer using them
- [x] Should be tested and function all evergreen modern browsers and IE11
- [x] All methods should be documented using [JSDoc-style comments](https://jsdoc.app/index.html)
- [x] Component should have end-to-end (Cypress) tests that cover the functionality of all public methods, interactions e.g. open/close, show/hide, and any `customEvent`s the component emits.
- [x] Prevent page from scrolling/jumping when the arrow keys are used #136 