### PR TITLE
Added customEvents to dropdown component

### DIFF
--- a/src/components/dropdown/dropdown.njk
+++ b/src/components/dropdown/dropdown.njk
@@ -49,4 +49,14 @@
 <script>
   const dropdownWrapper{{ id }} = document.querySelector('[data-dropdown="{{ id }}"]');
   window.new{{ id }} = new Rivet.Dropdown(dropdownWrapper{{ id }});
+
+  dropdownWrapper{{ id }}.querySelector('button').addEventListener('rvt:dropdownOpen', function(event) {
+    // event.preventDefault();
+    // console.log('Opened:', event.detail.id);
+  });
+
+  dropdownWrapper{{ id }}.querySelector('button').addEventListener('rvt:dropdownClose', function(event) {
+    // event.preventDefault();
+    // console.log('Closed:', event.detail.id);
+  });
 </script>

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -85,7 +85,7 @@ export default class Dropdown {
     this.activeToggle.setAttribute('aria-expanded', 'false');
     this.activeMenu.setAttribute('hidden', '');
 
-    // Unset currently active elements
+    // Resets the state variables
     this.activeToggle = null;
     this.activeMenu = null;
   }
@@ -222,10 +222,10 @@ export default class Dropdown {
       }
 
       case keyCodes.escape: {
+        if (!this.activeToggle) return;
+
         // If there's an open menu, close it.
-        if (this.activeToggle) {
-          this.close();
-        }
+        this.close();
 
         this.toggleElement.focus();
 


### PR DESCRIPTION
In this PR:

- Added `dropdownOpen` and `dropdownClose` customEvents
- Added logic for `open()` and `close()` to execute on only one targeted dropdown at a time. This will prevent `close()` from getting fired multiple times on dropdowns that are already closed.
- Refactored logic for the `esc` keyboard functionality