### PR TITLE
Added alpha release workflow

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -1,4 +1,4 @@
-name: Alpha Package
+name: Publish alpha release
 
 on:
   push:
@@ -15,6 +15,8 @@ jobs:
           node-version: 12
       - run: npm ci
       - run: npm test
+      - name: Create artifact
+        run: npm build
 
   publish-npm:
     needs: build
@@ -29,3 +31,35 @@ jobs:
       - run: npm publish --tag alpha
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
+  create-release:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - name: Create artifact
+        run: npm build
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+          prerelease: true
+      - name: Upload release asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./rivet.zip
+          asset_name: rivet.zip
+          asset_content_type: application/zip

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,16 +1,18 @@
-name: Node CI
+name: Test build
 
-on: [push]
+on: 
+  push:
+    branches:
+    - 'feature/**'
+    - '2.0.0-dev'
+    - '!2.0.0-master'
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [8.x, 10.x, 12.x]
-
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
In this PR:

- Added alpha release workflow for GitHub actions
- Refactored `nodeCI.yml` and renamed to `test-build.yml`

**Notes about the alpha release workflow:**
- The workflow begins when a tag including `v**-alpha**` has been pushed
- Once started, it tests the build, publishes the package to npmjs.com, and then creates a release
- When the release is created, it is set up as a `draft` and `prerelease` and a copy of the build (`rivet.zip`) is attached

Thanks to @illusivesunrae for helping me work through this!

See issue #247 for more details.