### PR TITLE
Refactored IIFE/ESM module transpiling process

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -151,20 +151,24 @@ function watchJS(callback) {
   callback();
 }
 
+function distJS() {
+  return src([
+    './static/js/rivet-esm.js',
+    './static/js/rivet-iife.js'
+  ], {base: './static/js'})
+    .pipe(dest('./js'));
+}
+
 function stripJS(callback) {
   src('./js/rivet-iife.js')
     .pipe(strip())
     .pipe(dest('./js'));
 
   src('./js/rivet-esm.js')
-  .pipe(strip())
-  .pipe(dest('./js'));
+    .pipe(strip())
+    .pipe(dest('./js'));
 
   callback();
-}
-
-function distJS() {
-  return src("static/js/rivet*.js").pipe(dest("./js"));
 }
 
 function headerJS(callback) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,29 +123,23 @@ function prefixReleaseCSS() {
  * JS tasks
  */
 
-async function compileJS() {
+async function compileIife() {
   const bundle = await rollup.rollup({
     input: './src/js/index.js',
     plugins: [ eslint({ throwOnError: false }), babel({ runtimeHelpers: true })]
   });
 
   await bundle.write({
-    file: './js/rivet.js',
+    file: './static/js/rivet-iife.js',
     format: 'iife',
     name: 'Rivet'
   });
 }
 
-async function compileDevJS() {
+async function compileESM() {
   const bundle = await rollup.rollup({
     input: './src/js/index.js',
     plugins: [ eslint({ throwOnError: false })]
-  });
-
-  await bundle.write({
-    file: './static/js/rivet-iife.js',
-    format: 'iife',
-    name: 'Rivet'
   });
 
   await bundle.write({
@@ -156,7 +150,7 @@ async function compileDevJS() {
 }
 
 function watchJS(callback) {
-  watch("src/js/**/*.js", { ignoreInitial: false }, series(compileJS, compileDevJS, vendorJS));
+  watch("src/js/**/*.js", { ignoreInitial: false }, series(compileIife, compileESM, vendorJS));
   callback();
 }
 
@@ -169,11 +163,8 @@ function distJS() {
     .pipe(dest('./js'));
 }
 
+// Strip out comments from JS files
 function stripJS(callback) {
-  src('./js/rivet.js')
-    .pipe(strip())
-    .pipe(dest('./js'));
-
   src('./js/rivet-iife.js')
     .pipe(strip())
     .pipe(dest('./js'));
@@ -186,7 +177,7 @@ function stripJS(callback) {
 }
 
 function minifyJS() {
-  return src('./js/rivet.js')
+  return src('./js/rivet-iife.js')
     .pipe(uglify())
     .pipe(rename({ basename: 'rivet', suffix: '.min' }))
     .pipe(dest('./js'));
@@ -265,8 +256,8 @@ exports.release = series(
   prefixReleaseCSS,
   headerCSS,
   minifyCSS,
-  compileJS,
-  compileDevJS,
+  compileIife,
+  compileESM,
   distJS,
   stripJS,
   minifyJS,
@@ -279,8 +270,8 @@ exports.release = series(
 exports.build = series(
   lintSassBuild,
   compileSass,
-  compileJS,
-  compileDevJS,
+  compileIife,
+  compileESM,
   distJS,
   stripJS,
   minifyJS,
@@ -294,8 +285,8 @@ exports.fractalBuild = fractalBuild;
 
 exports.headless = series(compileSass,
   lintSassWatch,
-  compileJS,
-  compileDevJS,
+  compileIife,
+  compileESM,
   fractalHeadless,
   watchSass,
   watchJS
@@ -304,8 +295,8 @@ exports.headless = series(compileSass,
 exports.default = series(
   compileSass,
   lintSassWatch,
-  compileJS,
-  compileDevJS,
+  compileIife,
+  compileESM,
   fractalStart,
   watchSass,
   watchJS

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,7 +123,7 @@ function prefixReleaseCSS() {
  * JS tasks
  */
 
-async function compileIife() {
+async function compileIIFE() {
   const bundle = await rollup.rollup({
     input: './src/js/index.js',
     plugins: [ eslint({ throwOnError: false }), babel({ runtimeHelpers: true })]
@@ -150,7 +150,7 @@ async function compileESM() {
 }
 
 function watchJS(callback) {
-  watch("src/js/**/*.js", { ignoreInitial: false }, series(compileIife, compileESM, vendorJS));
+  watch("src/js/**/*.js", { ignoreInitial: false }, series(compileIIFE, compileESM, vendorJS));
   callback();
 }
 
@@ -256,7 +256,7 @@ exports.release = series(
   prefixReleaseCSS,
   headerCSS,
   minifyCSS,
-  compileIife,
+  compileIIFE,
   compileESM,
   distJS,
   stripJS,
@@ -270,7 +270,7 @@ exports.release = series(
 exports.build = series(
   lintSassBuild,
   compileSass,
-  compileIife,
+  compileIIFE,
   compileESM,
   distJS,
   stripJS,
@@ -285,7 +285,7 @@ exports.fractalBuild = fractalBuild;
 
 exports.headless = series(compileSass,
   lintSassWatch,
-  compileIife,
+  compileIIFE,
   compileESM,
   fractalHeadless,
   watchSass,
@@ -295,7 +295,7 @@ exports.headless = series(compileSass,
 exports.default = series(
   compileSass,
   lintSassWatch,
-  compileIife,
+  compileIIFE,
   compileESM,
   fractalStart,
   watchSass,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,6 +130,19 @@ async function compileJS() {
   });
 
   await bundle.write({
+    file: './js/rivet.js',
+    format: 'iife',
+    name: 'Rivet'
+  });
+}
+
+async function compileDevJS() {
+  const bundle = await rollup.rollup({
+    input: './src/js/index.js',
+    plugins: [ eslint({ throwOnError: false })]
+  });
+
+  await bundle.write({
     file: './static/js/rivet-iife.js',
     format: 'iife',
     name: 'Rivet'
@@ -143,7 +156,7 @@ async function compileJS() {
 }
 
 function watchJS(callback) {
-  watch("src/js/**/*.js", { ignoreInitial: false }, series(compileJS, vendorJS));
+  watch("src/js/**/*.js", { ignoreInitial: false }, series(compileJS, compileDevJS, vendorJS));
   callback();
 }
 
@@ -157,6 +170,10 @@ function distJS() {
 }
 
 function stripJS(callback) {
+  src('./js/rivet.js')
+    .pipe(strip())
+    .pipe(dest('./js'));
+
   src('./js/rivet-iife.js')
     .pipe(strip())
     .pipe(dest('./js'));
@@ -169,7 +186,7 @@ function stripJS(callback) {
 }
 
 function minifyJS() {
-  return src('./js/rivet-iife.js')
+  return src('./js/rivet.js')
     .pipe(uglify())
     .pipe(rename({ basename: 'rivet', suffix: '.min' }))
     .pipe(dest('./js'));
@@ -249,6 +266,7 @@ exports.release = series(
   headerCSS,
   minifyCSS,
   compileJS,
+  compileDevJS,
   distJS,
   stripJS,
   minifyJS,
@@ -262,6 +280,7 @@ exports.build = series(
   lintSassBuild,
   compileSass,
   compileJS,
+  compileDevJS,
   distJS,
   stripJS,
   minifyJS,
@@ -276,6 +295,7 @@ exports.fractalBuild = fractalBuild;
 exports.headless = series(compileSass,
   lintSassWatch,
   compileJS,
+  compileDevJS,
   fractalHeadless,
   watchSass,
   watchJS
@@ -285,6 +305,7 @@ exports.default = series(
   compileSass,
   lintSassWatch,
   compileJS,
+  compileDevJS,
   fractalStart,
   watchSass,
   watchJS

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -142,15 +142,12 @@ async function compileJS() {
   });
 }
 
-function vendorJS() {
-  return src("src/js/vendor.js").pipe(dest("./static/js"));
-}
-
 function watchJS(callback) {
   watch("src/js/**/*.js", { ignoreInitial: false }, series(compileJS, vendorJS));
   callback();
 }
 
+// Copy JS files from 'static' to 'js'
 function distJS() {
   return src([
     './static/js/rivet-esm.js',
@@ -171,6 +168,13 @@ function stripJS(callback) {
   callback();
 }
 
+function minifyJS() {
+  return src('./js/rivet-iife.js')
+    .pipe(uglify())
+    .pipe(rename({ basename: 'rivet', suffix: '.min' }))
+    .pipe(dest('./js'));
+}
+
 function headerJS(callback) {
   src("./js/rivet-iife.js")
     .pipe(header(bannerText, { package: pkg }))
@@ -187,11 +191,9 @@ function headerJS(callback) {
   callback();
 }
 
-function minifyJS() {
-  return src('./js/rivet-iife.js')
-    .pipe(uglify())
-    .pipe(rename({ basename: 'rivet', suffix: '.min' }))
-    .pipe(dest('./js'));
+// Copy vendor.js from 'src/js' to 'static/js' for Fractal to use
+function vendorJS() {
+  return src("src/js/vendor.js").pipe(dest("./static/js"));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "url": "https://github.com/indiana-university/rivet-source/issues",
     "email": "rivet@iu.edu"
   },
+  "main": "js/rivet-esm.js",
+  "module": "js/rivet-esm.js",
   "scripts": {
     "start": "gulp",
     "build": "npm run clean && gulp release && zip -r rivet.zip css js sass index.html",

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -15,4 +15,4 @@ import Modal from './components/modal';
 import Sidenav from './components/sidenav';
 import Tabs from './components/tabs';
 
-export default { Alert, Dropdown, FileInput, Modal, Sidenav, Tabs };
+export { Alert, Dropdown, FileInput, Modal, Sidenav, Tabs };


### PR DESCRIPTION
In this PR:
- Set sources in `distJS` task to be explicit files, rather than all of the files in the `static/js` directory
- Reordered `gulp` JS tasks to reflect build processes
- Renamed JS compiling/transpiling tasks to `compileIIFE()` and `compileESM()`
- Updated `index.js` to export components separately, instead of within one `default`
- Added `main` and `module` values to `package.json`

See #254 for more details.

Thanks to @illusivesunrae for helping me differentiate between the different JS build processes in the `gulpfile.js`.