### PR TITLE
Added fix for text improperly wrapping in sidenav

### DIFF
--- a/src/components/sidenav/sidenav.njk
+++ b/src/components/sidenav/sidenav.njk
@@ -4,20 +4,24 @@
       <a href="#" class="rvt-sidenav__link">Section nav one</a>
     </li>
     <li class="rvt-sidenav__item">
-      <a href="#" class="rvt-sidenav__link" aria-current="page">Section nav two</a>
-      <button href="#" class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-1">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-            <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
-        </svg>
-      </button>
+      <div class="rvt-sidenav__item-wrapper">
+        <a href="#" class="rvt-sidenav__link" aria-current="page">Section nav two (with some extra text for wrapping)</a>
+        <button href="#" class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-1">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+              <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
+          </svg>
+        </button>
+      </div>
       <ul class="rvt-sidenav__list" data-sidenav-list="toggle-1" role="menu">
         <li class="rvt-sidenav__item">
-          <a href="#" class="rvt-sidenav__link">Level two</a>
-          <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-2">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-                <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
-            </svg>
-          </button>
+          <div class="rvt-sidenav__item-wrapper">
+            <a href="#" class="rvt-sidenav__link">Level two</a>
+            <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-2">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                  <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
+              </svg>
+            </button>
+          </div>
           <ul class="rvt-sidenav__list" data-sidenav-list="toggle-2" role="menu">
             <li class="rvt-sidenav__item">
               <a href="#" class="rvt-sidenav__link">Level three</a>
@@ -25,14 +29,16 @@
           </ul>
         </li>
         <li class="rvt-sidenav__item">
-          <a href="#" class="rvt-sidenav__link">
-            <span>Level two</span>
-          </a>
-          <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-3">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-                <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
-            </svg>
-          </button>
+          <div class="rvt-sidenav__item-wrapper">
+            <a href="#" class="rvt-sidenav__link">
+              <span>Level two</span>
+            </a>
+            <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-3">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                  <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
+              </svg>
+            </button>
+          </div>
           <ul class="rvt-sidenav__list" data-sidenav-list="toggle-3" role="menu">
             <li class="rvt-sidenav__item">
               <a href="#" class="rvt-sidenav__link">Level three</a>
@@ -51,45 +57,53 @@
           <a href="#" class="rvt-sidenav__link">Level two</a>
         </li>
         <li class="rvt-sidenav__item">
-          <a href="#" class="rvt-sidenav__link">
-            <span>Level two</span>
-          </a>
-          <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-4">
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-                <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
-            </svg>
-          </button>
+          <div class="rvt-sidenav__item-wrapper">
+            <a href="#" class="rvt-sidenav__link">
+              <span>Level two</span>
+            </a>
+            <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-4">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                  <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
+              </svg>
+            </button>
+          </div>
           <ul class="rvt-sidenav__list" data-sidenav-list="toggle-4" role="menu">
             <li class="rvt-sidenav__item">
-              <a href="#" class="rvt-sidenav__link">
-                <span>Level three</span>
-              </a>
-              <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-5">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-                    <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
-                </svg>
-              </button>
+              <div class="rvt-sidenav__item-wrapper">
+                <a href="#" class="rvt-sidenav__link">
+                  <span>Level three</span>
+                </a>
+                <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-5">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                      <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
+                  </svg>
+                </button>
+              </div>
               <ul class="rvt-sidenav__list" data-sidenav-list="toggle-5" role="menu">
                 <li class="rvt-sidenav__item">
                   <a href="#" class="rvt-sidenav__link">Level four</a>
                 </li>
                 <li class="rvt-sidenav__item">
-                  <a href="#" class="rvt-sidenav__link">
-                    <span>Level four</span>
-                  </a>
-                  <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-6">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-                        <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
-                    </svg>
-                  </button>
+                  <div class="rvt-sidenav__item-wrapper">
+                    <a href="#" class="rvt-sidenav__link">
+                      <span>Level four</span>
+                    </a>
+                    <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-6">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                          <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
+                      </svg>
+                    </button>
+                  </div>
                   <ul class="rvt-sidenav__list" data-sidenav-list="toggle-6" role="menu">
                     <li class="rvt-sidenav__item">
-                      <a href="#" class="rvt-sidenav__link">Level five</a>
-                      <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-7">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-                            <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
-                        </svg>
-                      </button>
+                      <div class="rvt-sidenav__item-wrapper">
+                        <a href="#" class="rvt-sidenav__link">Level five</a>
+                        <button class="rvt-sidenav__toggle" data-sidenav-toggle="toggle-7">
+                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+                              <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
+                          </svg>
+                        </button>
+                      </div>
                       <ul class="rvt-sidenav__list" data-sidenav-list="toggle-7" role="menu">
                         <li class="rvt-sidenav__item">
                           <a href="#" class="rvt-sidenav__link">Level six</a>

--- a/src/sass/components/_sidenav.scss
+++ b/src/sass/components/_sidenav.scss
@@ -18,6 +18,11 @@
     margin-top: 0; // resets Rivet default margin-top
   }
 
+  &__item-wrapper {
+    display: flex;
+    flex-basis: 100%;
+  }
+
   &__link {
     color: $color-black;
     flex-grow: 1;
@@ -97,6 +102,7 @@ $level-styles: (
   $index: index(($level-styles), ($indent $shade));
 
   // Indent the link text
+  #{$indent-selector} > .rvt-sidenav__item-wrapper > .rvt-sidenav__link,
   #{$indent-selector} > .rvt-sidenav__link {
     text-indent: $indent + px;
   }


### PR DESCRIPTION
If the link label was longer than the container, the button would wrap to the next line along with the text.

![Screen Shot 2020-01-16 at 11 40 29 AM](https://user-images.githubusercontent.com/1396192/72544275-0bd36380-3855-11ea-9a33-351d879cadcf.png)

This fix adds a `div` around the `rvt-sidenav__link` and `rvt-sidenav__toggle` to contain them to one line and prevent wrapping.

The Sass `@each` loop was also updated to reflect this new markup structure.
