### PR TITLE
Added CSS to display buttons if JS loads

### DIFF
--- a/src/sass/components/_sidenav.scss
+++ b/src/sass/components/_sidenav.scss
@@ -39,11 +39,16 @@
     align-items: center;
     background: transparent;
     border: none;
+    display: none; // Hide by default if JS doesn't load
     justify-content: center;
     padding: $sm*.875;
 
     svg {
       vertical-align: middle;
+    }
+
+    &[aria-expanded] {
+      display: block;
     }
 
     &[aria-expanded="true"] {


### PR DESCRIPTION
This hides the Sidenav toggle buttons with `display: none` on page load, and then displays them with `display: block` once JavaScript has been loaded. This will prevent the buttons from displaying if JavaScript fails to load on the page.