### PR TITLE
Added logic for folds expanded in markup

### DIFF
--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -92,14 +92,6 @@ export default class Sidenav {
     // Add click handler
     this.element.addEventListener('click', this._handleClick, false);
 
-    // Expand all if openAllOnInit option is set
-    if (this.openAllOnInit) {
-      menuToggles.forEach(menuToggle => menuToggle.setAttribute('aria-expanded', 'true'));
-      childMenus.forEach(childMenu => childMenu.removeAttribute('hidden', ''));
-
-      return;
-    }
-
     // Get all the necessary DOM elements and convert to Arrays.
     const menuToggles = nodeListToArray(
       this.element.querySelectorAll(this.toggleSelector)
@@ -107,6 +99,14 @@ export default class Sidenav {
     const childMenus = nodeListToArray(
       this.element.querySelectorAll(this.listSelector)
     );
+
+    // Expand all if openAllOnInit option is set
+    if (this.openAllOnInit) {
+      menuToggles.forEach(menuToggle => menuToggle.setAttribute('aria-expanded', 'true'));
+      childMenus.forEach(childMenu => childMenu.removeAttribute('hidden', ''));
+
+      return;
+    }
 
     // Hide all child menus
     childMenus.forEach(childMenu => childMenu.setAttribute('hidden', ''));

--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -89,6 +89,17 @@ export default class Sidenav {
   }
   
   init() {
+    // Add click handler
+    this.element.addEventListener('click', this._handleClick, false);
+
+    // Expand all if openAllOnInit option is set
+    if (this.openAllOnInit) {
+      menuToggles.forEach(menuToggle => menuToggle.setAttribute('aria-expanded', 'true'));
+      childMenus.forEach(childMenu => childMenu.removeAttribute('hidden', ''));
+
+      return;
+    }
+
     // Get all the necessary DOM elements and convert to Arrays.
     const menuToggles = nodeListToArray(
       this.element.querySelectorAll(this.toggleSelector)
@@ -96,24 +107,25 @@ export default class Sidenav {
     const childMenus = nodeListToArray(
       this.element.querySelectorAll(this.listSelector)
     );
-    
+
+    // Hide all child menus
+    childMenus.forEach(childMenu => childMenu.setAttribute('hidden', ''));
+
     menuToggles.forEach(menuToggle => {
       // Since JavaScript is available add popup semantics to toggles
       menuToggle.setAttribute('aria-haspopup', 'true');
 
-      // If the user has set openAllOnInit to false, set up aria-semantics
-      if (!this.openAllOnInit) {
+      // Check if any toggles have been set to expanded in markup
+      if (menuToggle.getAttribute('aria-expanded') === 'true') {
+        const toggleValue = menuToggle.getAttribute('data-sidenav-toggle');
+        const list = this.element.querySelector(`[data-sidenav-list="${toggleValue}"]`);
+
+        // Open list matching this toggle
+        list.removeAttribute('hidden');
+      } else {
         menuToggle.setAttribute('aria-expanded', 'false');
       }
     });
-    
-    // If openAllOnInit is set to false, hide all child menus
-    if (!this.openAllOnInit) {
-      childMenus.forEach(childMenu => childMenu.setAttribute('hidden', ''));
-    }
-
-    // Add click handlers
-    this.element.addEventListener('click', this._handleClick, false);
   }
   
   destroy() {

--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -87,7 +87,7 @@ export default class Sidenav {
     toggleButton.setAttribute('aria-expanded', 'false');
     targetList.setAttribute('hidden', '');
   }
-  
+
   init() {
     // Add click handler
     this.element.addEventListener('click', this._handleClick, false);
@@ -100,30 +100,38 @@ export default class Sidenav {
       this.element.querySelectorAll(this.listSelector)
     );
 
-    // Expand all if openAllOnInit option is set
-    if (this.openAllOnInit) {
-      menuToggles.forEach(menuToggle => menuToggle.setAttribute('aria-expanded', 'true'));
-      childMenus.forEach(childMenu => childMenu.removeAttribute('hidden', ''));
+    childMenus.forEach((element) => {
+      // Display all child menus if everything is open on init
+      if (this.openAllOnInit) {
+        element.removeAttribute('hidden');
 
-      return;
-    }
+        return;
+      }
 
-    // Hide all child menus
-    childMenus.forEach(childMenu => childMenu.setAttribute('hidden', ''));
+      // Hide all child menus
+      element.setAttribute('hidden', '');
+    });
 
-    menuToggles.forEach(menuToggle => {
+    menuToggles.forEach((element) => {
       // Since JavaScript is available add popup semantics to toggles
-      menuToggle.setAttribute('aria-haspopup', 'true');
+      element.setAttribute('aria-haspopup', 'true');
 
-      // Check if any toggles have been set to expanded in markup
-      if (menuToggle.getAttribute('aria-expanded') === 'true') {
-        const toggleValue = menuToggle.getAttribute('data-sidenav-toggle');
+      // Aria-expand all toggles if everything is open on init
+      if (this.openAllOnInit) {
+        element.setAttribute('aria-expanded', 'true');
+
+        return;
+      }
+
+      // Check if this toggle been manually set to expanded in markup
+      if (element.getAttribute('aria-expanded') === 'true') {
+        const toggleValue = element.getAttribute('data-sidenav-toggle');
         const list = this.element.querySelector(`[data-sidenav-list="${toggleValue}"]`);
 
         // Open list matching this toggle
         list.removeAttribute('hidden');
       } else {
-        menuToggle.setAttribute('aria-expanded', 'false');
+        element.setAttribute('aria-expanded', 'false');
       }
     });
   }

--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -92,7 +92,7 @@ export default class Sidenav {
     // Add click handler
     this.element.addEventListener('click', this._handleClick, false);
 
-    // Get all the necessary DOM elements and convert to Arrays.
+    // Get all of the toggle buttons and menu lists and convert to Arrays.
     const menuToggles = nodeListToArray(
       this.element.querySelectorAll(this.toggleSelector)
     );
@@ -100,38 +100,31 @@ export default class Sidenav {
       this.element.querySelectorAll(this.listSelector)
     );
 
-    childMenus.forEach((element) => {
-      // Display all child menus if everything is open on init
-      if (this.openAllOnInit) {
-        element.removeAttribute('hidden');
+    menuToggles.forEach((element, index) => {
+      /**
+       * Toggle button/menu list pairings
+       * element: toggle button
+       * childMenus[index]: menu list
+       */
 
-        return;
-      }
-
-      // Hide all child menus
-      element.setAttribute('hidden', '');
-    });
-
-    menuToggles.forEach((element) => {
       // Since JavaScript is available add popup semantics to toggles
       element.setAttribute('aria-haspopup', 'true');
 
       // Aria-expand all toggles if everything is open on init
       if (this.openAllOnInit) {
         element.setAttribute('aria-expanded', 'true');
+        childMenus[index].removeAttribute('hidden');
 
         return;
       }
 
       // Check if this toggle been manually set to expanded in markup
       if (element.getAttribute('aria-expanded') === 'true') {
-        const toggleValue = element.getAttribute('data-sidenav-toggle');
-        const list = this.element.querySelector(`[data-sidenav-list="${toggleValue}"]`);
-
         // Open list matching this toggle
-        list.removeAttribute('hidden');
+        childMenus[index].removeAttribute('hidden');
       } else {
         element.setAttribute('aria-expanded', 'false');
+        childMenus[index].setAttribute('hidden', '');
       }
     });
   }


### PR DESCRIPTION
In this PR:

- The `addEventListener` was moved to the beginning of the `init()` so it's run before any `return`s are called
- Logic for `this.openAllOnInit` was moved up front so the rest of the code can be skipped if it's enabled
- Added logic to handle toggle/menu pairs whenever a toggle is set to `aria-expanded="true"` in the markup before any JS is run. Any toggle that has `aria-expanded="true"` added in the markup will initialize opened on page load, and the rest will remain closed.

It would be good to have some feedback on this line in `sidenav.js`–

`childMenus.forEach(childMenu => childMenu.setAttribute('hidden', ''));`

–since this is closing all of the childMenus, and then later on some might be getting re-opened if the toggle is set to open within the markup.