### PR TITLE
Added logic to change eslint options based on environment when compiling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -129,7 +129,9 @@ function prefixReleaseCSS() {
 
 let eslintOptionsIIFE, eslintOptionsESM;
 
-// Set compile options for IIFE and ESM based on current environment
+/**
+ * Set eslint options for IIFE and ESM if environment is set to 'production'
+ */
 switch (process.env.NODE_ENV) {
   case 'production':
     eslintOptionsIIFE = eslint({ throwOnError: true });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,12 +37,14 @@ var bannerText = `/*!
 
 `;
 
-function setDevNodeEnv() {
-  return (process.env.NODE_ENV = 'development');
+function setDevNodeEnv(callback) {
+  process.env.NODE_ENV = 'development';
+  callback();
 }
 
-function setProdNodeEnv() {
-  return (process.env.NODE_ENV = 'production');
+function setProdNodeEnv(callback) {
+  process.env.NODE_ENV = 'production';
+  callback();
 }
 
 function compileSass() {
@@ -129,24 +131,19 @@ function prefixReleaseCSS() {
  * JS tasks
  */
 
-let IIFEpluginOptions, ESMpluginOptions;
+let eslintOptionsIIFE, eslintOptionsESM;
 
 // Set compile options for IIFE and ESM based on current environment
 switch (process.env.NODE_ENV) {
-  case 'development':
-    IIFEpluginOptions = [
-      eslint({ throwOnError: false }),
-      babel({ runtimeHelpers: true })
-    ];
-    ESMpluginOptions = [eslint({ throwOnError: false })];
+  case 'production':
+    eslintOptionsIIFE = eslint({ throwOnError: true });
+    eslintOptionsESM = eslint({ throwOnError: false });
 
     break;
-  case 'production':
-    IIFEpluginOptions = [
-      eslint({ throwOnError: true }),
-      babel({ runtimeHelpers: true })
-    ];
-    ESMpluginOptions = [eslint({ throwOnError: true })];
+
+  default:
+    eslintOptionsIIFE = eslint({ throwOnError: false });
+    eslintOptionsESM = eslint({ throwOnError: false });
 
     break;
 }
@@ -154,7 +151,7 @@ switch (process.env.NODE_ENV) {
 async function compileIIFE() {
   const bundle = await rollup.rollup({
     input: './src/js/index.js',
-    plugins: IIFEpluginOptions
+    plugins: [eslintOptionsIIFE, babel({ runtimeHelpers: true })]
   });
 
   await bundle.write({
@@ -167,7 +164,7 @@ async function compileIIFE() {
 async function compileESM() {
   const bundle = await rollup.rollup({
     input: './src/js/index.js',
-    plugins: ESMpluginOptions
+    plugins: [eslintOptionsESM]
   });
 
   await bundle.write({

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -134,35 +134,50 @@ let eslintOptionsIIFE = { throwOnError: false },
 /**
  * Set new eslint options for compiling IIFE/ESM if env is set to 'production'
  */
-if (process.env.NODE_ENV === 'production') {
-  eslintOptionsIIFE = { throwOnError: true };
-  eslintOptionsESM = { throwOnError: true };
+
+function checkEnv() {
+  if (process.env.NODE_ENV === 'production') {
+    eslintOptionsIIFE = { throwOnError: true };
+    eslintOptionsESM = { throwOnError: true };
+  }
 }
 
 async function compileIIFE() {
-  const bundle = await rollup.rollup({
-    input: './src/js/index.js',
-    plugins: [eslint(eslintOptionsIIFE), babel({ runtimeHelpers: true })]
-  });
+  checkEnv();
 
-  await bundle.write({
-    file: './static/js/rivet-iife.js',
-    format: 'iife',
-    name: 'Rivet'
-  });
+  try {
+    const bundle = await rollup.rollup({
+      input: './src/js/index.js',
+      plugins: [eslint(eslintOptionsIIFE), babel({ runtimeHelpers: true })]
+    });
+
+    await bundle.write({
+      file: './static/js/rivet-iife.js',
+      format: 'iife',
+      name: 'Rivet'
+    });
+  } catch (error) {
+    throw new Error('Error: this is probably a linting issue.');
+  }
 }
 
 async function compileESM() {
-  const bundle = await rollup.rollup({
-    input: './src/js/index.js',
-    plugins: [eslint(eslintOptionsESM)]
-  });
+  checkEnv();
 
-  await bundle.write({
-    file: './static/js/rivet-esm.js',
-    format: 'es',
-    name: 'Rivet'
-  });
+  try {
+    const bundle = await rollup.rollup({
+      input: './src/js/index.js',
+      plugins: [eslint(eslintOptionsESM)]
+    });
+
+    await bundle.write({
+      file: './static/js/rivet-esm.js',
+      format: 'es',
+      name: 'Rivet'
+    });
+  } catch (error) {
+    throw new Error('Error: this is probably a linting issue.');
+  }
 }
 
 function watchJS(callback) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -135,7 +135,7 @@ let eslintOptionsIIFE, eslintOptionsESM;
 switch (process.env.NODE_ENV) {
   case 'production':
     eslintOptionsIIFE = eslint({ throwOnError: true });
-    eslintOptionsESM = eslint({ throwOnError: false });
+    eslintOptionsESM = eslint({ throwOnError: true });
 
     break;
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -37,11 +37,7 @@ var bannerText = `/*!
 
 `;
 
-function setDevNodeEnv(callback) {
-  process.env.NODE_ENV = 'development';
-  callback();
-}
-
+// Set Node environment to 'production' for build and release exports
 function setProdNodeEnv(callback) {
   process.env.NODE_ENV = 'production';
   callback();
@@ -296,7 +292,7 @@ exports.release = series(
 );
 
 exports.build = series(
-  setDevNodeEnv,
+  setProdNodeEnv,
   lintSassBuild,
   compileSass,
   compileIIFE,
@@ -313,7 +309,6 @@ exports.build = series(
 exports.fractalBuild = fractalBuild;
 
 exports.headless = series(
-  setDevNodeEnv,
   compileSass,
   lintSassWatch,
   compileIIFE,
@@ -324,7 +319,6 @@ exports.headless = series(
 );
 
 exports.default = series(
-  setDevNodeEnv,
   compileSass,
   lintSassWatch,
   compileIIFE,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -127,29 +127,22 @@ function prefixReleaseCSS() {
  * JS tasks
  */
 
-let eslintOptionsIIFE, eslintOptionsESM;
+// Set default eslint options for compiling IIFE/ESM
+let eslintOptionsIIFE = { throwOnError: false },
+  eslintOptionsESM = { throwOnError: false };
 
 /**
- * Set eslint options for IIFE and ESM if environment is set to 'production'
+ * Set new eslint options for compiling IIFE/ESM if env is set to 'production'
  */
-switch (process.env.NODE_ENV) {
-  case 'production':
-    eslintOptionsIIFE = eslint({ throwOnError: true });
-    eslintOptionsESM = eslint({ throwOnError: true });
-
-    break;
-
-  default:
-    eslintOptionsIIFE = eslint({ throwOnError: false });
-    eslintOptionsESM = eslint({ throwOnError: false });
-
-    break;
+if (process.env.NODE_ENV === 'production') {
+  eslintOptionsIIFE = { throwOnError: true };
+  eslintOptionsESM = { throwOnError: true };
 }
 
 async function compileIIFE() {
   const bundle = await rollup.rollup({
     input: './src/js/index.js',
-    plugins: [eslintOptionsIIFE, babel({ runtimeHelpers: true })]
+    plugins: [eslint(eslintOptionsIIFE), babel({ runtimeHelpers: true })]
   });
 
   await bundle.write({
@@ -162,7 +155,7 @@ async function compileIIFE() {
 async function compileESM() {
   const bundle = await rollup.rollup({
     input: './src/js/index.js',
-    plugins: [eslintOptionsESM]
+    plugins: [eslint(eslintOptionsESM)]
   });
 
   await bundle.write({

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -16,7 +16,6 @@ export default class Accordion {
       ...defaultOptions,
       ...options
     };
-    
 
     // Instance properties
     this.openAllOnInit = settings.openAllOnInit;

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -16,6 +16,7 @@ export default class Accordion {
       ...defaultOptions,
       ...options
     };
+    
 
     // Instance properties
     this.openAllOnInit = settings.openAllOnInit;
@@ -50,7 +51,6 @@ export default class Accordion {
 
     // Set this.openOnInit if needed
     try {
-
       if (initializedPanels.length > 1) {
         throw new TypeError('Caught');
       }


### PR DESCRIPTION
In this PR:

- Added new task `setProdNodeEnv` to set `process.env.NODE_ENV` to `production`
- Added the `setProdNodeEnv` task to the `release` and `build` exports
- Added logic to set different options within `eslint()` if the `setProdNodeEnv` has been run (ex: `throwOnError: true`)