### PR TITLE
Fixed .eslintignore syntax

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,6 @@
-_build/
-cypress/
-js/
-node_modules/
-src/js/vendor.js
-static/
+/_build/
+/cypress/
+/js/
+/node_modules/
+/src/js/vendor.js
+/static/


### PR DESCRIPTION
Reference to `js/` in `.eslintignore` was targeting `src/js/`