### PR TITLE
Removed normalize.css

### DIFF
--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -50,7 +50,6 @@ export default class Accordion {
 
     // Set this.openOnInit if needed
     try {
-
       if (initializedPanels.length > 1) {
         throw new TypeError('Caught');
       }

--- a/src/sass/components/_accordion.scss
+++ b/src/sass/components/_accordion.scss
@@ -7,17 +7,18 @@
   }
 
   &__title button {
-    margin: 0;
-    display: flex;
     align-items: center;
     background-color: transparent;
     border: none;
-    width: 100%;
+    cursor: pointer;
+    display: flex;
+    margin: 0;
     padding: 0;
+    width: 100%;
 
     &:focus {
-      outline: none;
       box-shadow: 0 0 0 $xxs/2 $color-white, 0 0 0 $xxs $color-blue-600;
+      outline: none;
     }
 
     &:hover {
@@ -59,13 +60,13 @@
   }
 
   &--panel &__title button[aria-expanded="true"] {
-    border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
   }
 
   &--panel &__content {
-    padding: $sm;
     border-top: 1px solid $color-black-200;
+    padding: $sm;
   }
 }
 

--- a/src/sass/components/_alerts.scss
+++ b/src/sass/components/_alerts.scss
@@ -38,6 +38,7 @@
     border-radius: 0;
     border-radius: $xxs;
     color: $color-black;
+    cursor: pointer;
     line-height: 1;
     padding: 0;
     position: absolute;

--- a/src/sass/components/_dropdown.scss
+++ b/src/sass/components/_dropdown.scss
@@ -18,6 +18,7 @@
     align-items: center;
     border: none;
     background-color: transparent;
+    cursor: pointer;
     padding: 0;
 
     &:focus {

--- a/src/sass/components/_inputs.scss
+++ b/src/sass/components/_inputs.scss
@@ -52,6 +52,7 @@ select {
 textarea {
   height: $spacing-unit * 15;
   line-height: 1.5;
+  overflow: auto; // Remove scrollbar in IE
 }
 
 input[type='search'] {

--- a/src/sass/components/_sidenav.scss
+++ b/src/sass/components/_sidenav.scss
@@ -44,6 +44,7 @@
     align-items: center;
     background: transparent;
     border: none;
+    cursor: pointer;
     display: none; // Hide by default if JS doesn't load
     justify-content: center;
     padding: $sm*.875;
@@ -110,23 +111,30 @@ $level-styles: (
   $indent-rem: $indent / 16;
 
   // Indent the link text
+
   #{$indent-selector} > .rvt-sidenav__item-wrapper > .rvt-sidenav__link,
   #{$indent-selector} > .rvt-sidenav__link {
     padding-left: $indent-rem + rem;
   }
 
   // Set border-top color per nested level
+
   #{$indent-selector} {
     @if $index == 1 {
       border-color: $color-black-100;
-    } @else if $index == 2 {
+    }
+
+    @else if $index == 2 {
       border-color: $color-black-200;
-    } @else if $index == 3 {
+    }
+
+    @else if $index == 3 {
       border-color: $color-black-300;
     }
   }
 
   // Set the background shade
+
   #{$shade-selector} {
     background-color: $shade;
   }

--- a/src/sass/components/_tables.scss
+++ b/src/sass/components/_tables.scss
@@ -6,6 +6,8 @@
  */
 
 table {
+  border-collapse: collapse;
+  border-spacing: 0;
   text-align: left;
   width: 100%;
 }

--- a/src/sass/components/_tabs.scss
+++ b/src/sass/components/_tabs.scss
@@ -10,6 +10,7 @@
     border-bottom: none;
     border-radius: 0;
     color: $color-black-700;
+    cursor: pointer;
     display: block;
     line-height: 1;
     margin-right: $xs;

--- a/src/sass/core/_base.scss
+++ b/src/sass/core/_base.scss
@@ -7,6 +7,7 @@ html {
 
 html * {
   box-sizing: border-box;
+  font: inherit;
 }
 
 body {

--- a/src/sass/core/_base.scss
+++ b/src/sass/core/_base.scss
@@ -61,8 +61,15 @@ abbr[title] {
   text-decoration: none;
 }
 
-// Set button margins to zero to override Safari user agent stylesheet
+/**
+ * Set button margins to zero to override Safari user agent stylesheet
+ * Remove inner focus from buttons in Firefox
+ */
 
 button {
   margin: 0;
+
+  &::-moz-focus-inner {
+    border: 0;
+  }
 }

--- a/src/sass/core/_base.scss
+++ b/src/sass/core/_base.scss
@@ -60,3 +60,9 @@ abbr[title] {
   border: none;
   text-decoration: none;
 }
+
+// Set button margins to zero to override Safari user agent stylesheet
+
+button {
+  margin: 0;
+}

--- a/src/sass/rivet.scss
+++ b/src/sass/rivet.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@import "libs/normalize";
+// @import "libs/normalize";
 @import "core/variables";
 @import "core/tools";
 @import "core/fonts";


### PR DESCRIPTION
In this PR:

`libs/normalize` in `rivet.scss` has been commented out to disable all `normalize.css` styles. To test out the differences with or without normalize.css, this line can be uncommented and commented to enable and disable. Once everything looks good, this line and the `libs/_normalize.scss` file can be removed entirely.

- Set `font` on all elements to `inherit` (`_base.scss`)
- Set `button` margins to 0 to override Safari user agent stylesheet defaults (`_base.scss`)
- Added `-moz-focus-inner` to remove border on focused buttons within Firefox (`_base.scss`)
- Removed scrollbar from `textarea` in IE (`_inputs.scss`)
- Set `border-collapse` and `border-spacing` to match normalize (`_tables.scss`)