### PR TITLE
Set OS to Ubuntu 16.04 for GH Actions workflows

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -2,12 +2,12 @@ name: Publish alpha release
 
 on:
   push:
-    tags: 
-      - 'v**-alpha**'
+    tags:
+      - "v**-alpha**"
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -20,7 +20,7 @@ jobs:
 
   publish-npm:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -34,7 +34,7 @@ jobs:
 
   create-release:
     needs: publish-npm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -3,7 +3,7 @@ name: Publish alpha release
 on:
   push:
     tags:
-      - "v**-alpha**"
+      - 'v**-alpha**'
 
 jobs:
   build:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,11 +1,11 @@
 name: Test build
 
-on: 
+on:
   push:
     branches:
-    - 'feature/**'
-    - '2.0.0-dev'
-    - '!2.0.0-master'
+      - "feature/**"
+      - "2.0.0-dev"
+      - "!2.0.0-master"
 
 jobs:
   build:
@@ -14,15 +14,15 @@ jobs:
       matrix:
         node-version: [10.x, 12.x]
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: npm install, build, and test
-      run: |
-        npm ci
-        npm run build --if-present
-        npm test
-      env:
-        CI: true
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install, build, and test
+        run: |
+          npm ci
+          npm run build --if-present
+          npm test
+        env:
+          CI: true

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     strategy:
       matrix:
         node-version: [10.x, 12.x]

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -3,9 +3,9 @@ name: Test build
 on:
   push:
     branches:
-      - "feature/**"
-      - "2.0.0-dev"
-      - "!2.0.0-master"
+      - 'feature/**'
+      - '2.0.0-dev'
+      - '!2.0.0-master'
 
 jobs:
   build:


### PR DESCRIPTION
This PR updates the OS for the two workflows from `ubuntu-latest` to `ubuntu-16.04`. This is a fix for an issue within the `test-build` workflow where Cypress was failing to start.

The Cypress GH Action readme details this fix to the issue here: https://github.com/cypress-io/github-action#important

> We are getting reports that Cypress has suddenly started crashing when running on ubuntu-latest OS. Seems, GH Actions have switched from 16.04 to 18.04 overnight, and are having a xvfb issue. Please work around this problem by using runs-on: ubuntu-16.04 image.