### PR TITLE
Fixed broken dropdowns and icon text in header examples

### DIFF
--- a/src/components/_preview-no-padding.njk
+++ b/src/components/_preview-no-padding.njk
@@ -5,11 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link media="all" rel="stylesheet" href="{{ '/css/rivet.css' | path }}">
     <title>Preview Layout</title>
+    <script src="{{ '/js/rivet-iife.js' | path }}"></script>
 </head>
 <body>
     <div class="display-wrapper">
         {{ yield | safe }}
     </div>
-    <script src="{{ '/js/rivet-iife.js' | path }}"></script>
 </body>
 </html>

--- a/src/components/button/button/button.njk
+++ b/src/components/button/button/button.njk
@@ -9,7 +9,7 @@
     {% endif %}
   {% elif icon %}
     {% set img = "@includes--" + icon %}
-    {% if srContent %}<span class="sr-only">{{ srContent }}</span>{% endif %}
+    {% if srContent %}<span class="rvt-sr-only">{{ srContent }}</span>{% endif %}
     {% include img %}
     {% if not srContent %}
       <span class="rvt-m-left-xs">{{ content }}</span>

--- a/src/components/checkbox/checkbox.njk
+++ b/src/components/checkbox/checkbox.njk
@@ -1,4 +1,4 @@
-<legend class="sr-only">{{ legend }}</legend>
+<legend class="rvt-sr-only">{{ legend }}</legend>
 <ul{% if list %} class="rvt-plain-list"{% else %} class="rvt-inline-list"{% endif %}>
   {% for box in boxes %}
     <li{% if box.hidden %} class="rvt-checkbox-wrapper"{% endif %}>

--- a/src/components/dropdown/dropdown.config.yml
+++ b/src/components/dropdown/dropdown.config.yml
@@ -1,98 +1,98 @@
 title: Dropdown
 label: Dropdown
-status: "ready"
+status: 'ready'
 collated: true
 context:
-    title: "Navigation menu"
-    id: "dropdownNavigation"
-    items:
-      - text: "Item one"
-      - text: "Item two"
-      - text: "Item three"
-        attributes:
-          - label: "aria-current"
-            value: "page"
-      - relatedLinks:
-        - text: "Related item one"
-        - text: "Related item two"
+  title: 'Navigation menu'
+  id: 'dropdownNavigation'
+  items:
+    - text: 'Item one'
+    - text: 'Item two'
+    - text: 'Item three'
+      attributes:
+        - label: 'aria-current'
+          value: 'page'
+    - relatedLinks:
+        - text: 'Related item one'
+        - text: 'Related item two'
 variants:
-  - name: "secondary"
+  - name: 'secondary'
     context:
-        title: "Secondary menu"
-        id: "dropdownSecondary"
-        modifier: "-secondary"
-  - name: "right-align"
+      title: 'Secondary menu'
+      id: 'dropdownSecondary'
+      modifier: '-secondary'
+  - name: 'right-align'
     context:
-        title: "Right-aligned menu"
-        id: "dropdownRight"
-        class: "rvt-dropdown__menu--right"
-  - name: "buttons"
+      title: 'Right-aligned menu'
+      id: 'dropdownRight'
+      class: 'rvt-dropdown__menu--right'
+  - name: 'buttons'
     context:
-        title: "Dropdown with buttons"
-        id: "dropdownButtons"
-        buttons: true
-        items:
-          - text: "Notify all"
-            attributes:
-              - label: "role"
-                value: "menuitemradio"
-          - text: "Notify admins"
-            attributes:
-              - label: "aria-checked"
-                value: "true"
-              - label: "role"
-                value: "menuitemradio"
-          - text: "Notify contributors"
-            attributes:
-              - label: "role"
-                value: "menuitemradio"
-          - relatedLinks:
-            - text: "Profile settings"
-            - text: "Logout"
-  - name: "heading"
+      title: 'Dropdown with buttons'
+      id: 'dropdownButtons'
+      buttons: true
+      items:
+        - text: 'Notify all'
+          attributes:
+            - label: 'role'
+              value: 'menuitemradio'
+        - text: 'Notify admins'
+          attributes:
+            - label: 'aria-checked'
+              value: 'true'
+            - label: 'role'
+              value: 'menuitemradio'
+        - text: 'Notify contributors'
+          attributes:
+            - label: 'role'
+              value: 'menuitemradio'
+        - relatedLinks:
+            - text: 'Profile settings'
+            - text: 'Logout'
+  - name: 'heading'
     context:
-        title: "Dropdown with heading"
-        id: "dropdownHeading"
-        items:
-          - text: "Notify all"
-            attributes:
-              - label: "role"
-                value: "menuitemradio"
-          - text: "Notify admins"
-            attributes:
-              - label: "aria-checked"
-                value: "true"
-              - label: "role"
-                value: "menuitemradio"
-          - text: "Notify contributors"
-            attributes:
-              - label: "role"
-                value: "menuitemradio"
-          - text: "Personal settings"
-            relatedLinks:
-              - text: "Profile settings"
-              - text: "Logout"
-  - name: "heading"
+      title: 'Dropdown with heading'
+      id: 'dropdownHeading'
+      items:
+        - text: 'Notify all'
+          attributes:
+            - label: 'role'
+              value: 'menuitemradio'
+        - text: 'Notify admins'
+          attributes:
+            - label: 'aria-checked'
+              value: 'true'
+            - label: 'role'
+              value: 'menuitemradio'
+        - text: 'Notify contributors'
+          attributes:
+            - label: 'role'
+              value: 'menuitemradio'
+        - text: 'Personal settings'
+          relatedLinks:
+            - text: 'Profile settings'
+            - text: 'Logout'
+  - name: 'heading'
     context:
-        title: "Heading and buttons"
-        id: "dropdownHeadingButtons"
-        buttons: true
-        items:
-          - text: "Notify all"
-            attributes:
-              - label: "role"
-                value: "menuitemradio"
-          - text: "Notify admins"
-            attributes:
-              - label: "aria-checked"
-                value: "true"
-              - label: "role"
-                value: "menuitemradio"
-          - text: "Notify contributors"
-            attributes:
-              - label: "role"
-                value: "menuitemradio"
-          - text: "Personal settings"
-            relatedLinks:
-              - text: "Profile settings"
-              - text: "Logout"
+      title: 'Heading and buttons'
+      id: 'dropdownHeadingButtons'
+      buttons: true
+      items:
+        - text: 'Notify all'
+          attributes:
+            - label: 'role'
+              value: 'menuitemradio'
+        - text: 'Notify admins'
+          attributes:
+            - label: 'aria-checked'
+              value: 'true'
+            - label: 'role'
+              value: 'menuitemradio'
+        - text: 'Notify contributors'
+          attributes:
+            - label: 'role'
+              value: 'menuitemradio'
+        - text: 'Personal settings'
+          relatedLinks:
+            - text: 'Profile settings'
+            - text: 'Logout'

--- a/src/components/dropdown/dropdown.njk
+++ b/src/components/dropdown/dropdown.njk
@@ -47,7 +47,7 @@
 </div>
 
 <script>
-  setTimeout(function() {
+  window.addEventListener('load', function() {
     const dropdownWrapper{{ id }} = document.querySelector('[data-dropdown="{{ id }}"]');
     window.new{{ id }} = new Rivet.Dropdown(dropdownWrapper{{ id }});
 
@@ -60,5 +60,5 @@
       // event.preventDefault();
       // console.log('Closed:', event.detail.id);
     });
-  }, 500);
+  });
 </script>

--- a/src/components/dropdown/dropdown.njk
+++ b/src/components/dropdown/dropdown.njk
@@ -47,16 +47,18 @@
 </div>
 
 <script>
-  const dropdownWrapper{{ id }} = document.querySelector('[data-dropdown="{{ id }}"]');
-  window.new{{ id }} = new Rivet.Dropdown(dropdownWrapper{{ id }});
+  setTimeout(function() {
+    const dropdownWrapper{{ id }} = document.querySelector('[data-dropdown="{{ id }}"]');
+    window.new{{ id }} = new Rivet.Dropdown(dropdownWrapper{{ id }});
 
-  dropdownWrapper{{ id }}.querySelector('button').addEventListener('rvt:dropdownOpen', function(event) {
-    // event.preventDefault();
-    // console.log('Opened:', event.detail.id);
-  });
+    dropdownWrapper{{ id }}.querySelector('button').addEventListener('rvt:dropdownOpen', function(event) {
+      // event.preventDefault();
+      // console.log('Opened:', event.detail.id);
+    });
 
-  dropdownWrapper{{ id }}.querySelector('button').addEventListener('rvt:dropdownClose', function(event) {
-    // event.preventDefault();
-    // console.log('Closed:', event.detail.id);
-  });
+    dropdownWrapper{{ id }}.querySelector('button').addEventListener('rvt:dropdownClose', function(event) {
+      // event.preventDefault();
+      // console.log('Closed:', event.detail.id);
+    });
+  }, 500);
 </script>

--- a/src/components/dropdown/dropdown.njk
+++ b/src/components/dropdown/dropdown.njk
@@ -47,18 +47,16 @@
 </div>
 
 <script>
-  window.addEventListener('load', function() {
-    const dropdownWrapper{{ id }} = document.querySelector('[data-dropdown="{{ id }}"]');
-    window.new{{ id }} = new Rivet.Dropdown(dropdownWrapper{{ id }});
+  const dropdownWrapper{{ id }} = document.querySelector('[data-dropdown="{{ id }}"]');
+  window.new{{ id }} = new Rivet.Dropdown(dropdownWrapper{{ id }});
 
-    dropdownWrapper{{ id }}.querySelector('button').addEventListener('rvt:dropdownOpen', function(event) {
-      // event.preventDefault();
-      // console.log('Opened:', event.detail.id);
-    });
+  dropdownWrapper{{ id }}.querySelector('button').addEventListener('rvt:dropdownOpen', function(event) {
+    // event.preventDefault();
+    // console.log('Opened:', event.detail.id);
+  });
 
-    dropdownWrapper{{ id }}.querySelector('button').addEventListener('rvt:dropdownClose', function(event) {
-      // event.preventDefault();
-      // console.log('Closed:', event.detail.id);
-    });
+  dropdownWrapper{{ id }}.querySelector('button').addEventListener('rvt:dropdownClose', function(event) {
+    // event.preventDefault();
+    // console.log('Closed:', event.detail.id);
   });
 </script>

--- a/src/components/header/header.config.yml
+++ b/src/components/header/header.config.yml
@@ -1,187 +1,187 @@
-title: "Header"
-status: "ready"
-preview: "@preview-no-padding"
+title: 'Header'
+status: 'ready'
+preview: '@preview-no-padding'
 context:
-    home: "#0"
-    applicationTitle: "Application Title"
+  home: '#0'
+  applicationTitle: 'Application Title'
 variants:
-    - name: "id module"
-      context:
-          navigation: "true"
-          identityModule: "true"
-          user:
-            initials: "rs"
-            username: "rswanson"
-          id: "id-module-simple"
-    - name: "id module advanced"
-      context:
-          navigation: "true"
-          identityModule: "true"
-          user:
-            initials: "rs"
-            username: "rswanson"
-          dropdown: "true"
-          userFunctions:
-            - link: "#"
-              text: "Account settings"
-            - link: "#"
-              text: "Admin task one"
-            - link: "#"
-              text: "Admin task two"
-          id: "identity-module"
-    - name: "navigation"
-      context:
-          navigation: "true"
-          main: "true"
-          dropdown: "true"
-          navItems:
-            - link: "#"
-              text: "Nav one"
-            - text: "Nav two"
-              id: "1"
-              relatedLinks:
-                - link: "#"
-                  text: "Item one"
-                - link: "#"
-                  text: "Item two"
-                - link: "#"
-                  text: "Item three"
-            - link: "#"
-              text: "Nav three"
-            - text: "Nav four"
-              id: "2"
-              relatedLinks:
-                - link: "#"
-                  text: "Item one"
-                - link: "#"
-                  text: "Item two"
-                - link: "#"
-                  text: "Item three"
-                - link: "#"
-                  text: "Item four"
-          id: "navigation"
-    - name: "navigation identity"
-      context:
-          navigation: "true"
-          main: "true"
-          identityModule: "true"
-          user:
-            initials: "rs"
-            username: "rswanson"
-          dropdown: "true"
-          userFunctions:
-            - link: "#"
-              text: "Account settings"
-            - link: "#"
-              text: "Admin task one"
-            - link: "#"
-              text: "Admin task two"
-          navItems:
-            - link: "#"
-              text: "Nav one"
-            - text: "Nav two"
-              id: "1"
-              relatedLinks:
-                - link: "#"
-                  text: "Item one"
-                - link: "#"
-                  text: "Item two"
-                - link: "#"
-                  text: "Item three"
-                - link: "#"
-                  text: "Item four"
-            - link: "#"
-              text: "Nav three"
-            - text: "Nav four"
-              id: "2"
-              relatedLinks:
-                - link: "#"
-                  text: "Item one"
-                - link: "#"
-                  text: "Item two"
-                - link: "#"
-                  text: "Item three"
-                - link: "#"
-                  text: "Item four"
-          id: "navigation-identity"
-    - name: "navigation simple identity"
-      context:
-          navigation: "true"
-          main: "true"
-          identityModule: "true"
-          user:
-            initials: "rs"
-            username: "rswanson"
-          navItems:
-            - link: "#"
-              text: "Nav one"
-            - text: "Nav two"
-              id: "1"
-              relatedLinks:
-                - link: "#"
-                  text: "Item one"
-                - link: "#"
-                  text: "Item two"
-                - link: "#"
-                  text: "Item three"
-                - link: "#"
-                  text: "Item four"
-            - link: "#"
-              text: "Nav three"
-            - text: "Nav four"
-              id: "2"
-              relatedLinks:
-                - link: "#"
-                  text: "Item one"
-                - link: "#"
-                  text: "Item two"
-                - link: "#"
-                  text: "Item three"
-                - link: "#"
-                  text: "Item four"
-          id: "navigation-identity"
-    - name: "persistent"
-      context:
-          persistent: "true"
-          navigation: "true"
-          main: "true"
-          identityModule: "true"
-          user:
-            initials: "rs"
-            username: "rswanson"
-          dropdown: "true"
-          userFunctions:
-            - link: "#"
-              text: "Account settings"
-            - link: "#"
-              text: "Admin task one"
-            - link: "#"
-              text: "Admin task two"
-          navItems:
-            - link: "#"
-              text: "Nav one"
-            - text: "Nav two"
-              id: "1"
-              relatedLinks:
-                - link: "#"
-                  text: "Item one"
-                - link: "#"
-                  text: "Item two"
-                - link: "#"
-                  text: "Item three"
-                - link: "#"
-                  text: "Item four"
-            - link: "#"
-              text: "Nav three"
-            - text: "Nav four"
-              id: "2"
-              relatedLinks:
-                - link: "#"
-                  text: "Item one"
-                - link: "#"
-                  text: "Item two"
-                - link: "#"
-                  text: "Item three"
-                - link: "#"
-                  text: "Item four"
-          id: "mobile-drawer"
+  - name: 'id module'
+    context:
+      navigation: 'true'
+      identityModule: 'true'
+      user:
+        initials: 'rs'
+        username: 'rswanson'
+      id: 'idModuleSimple'
+  - name: 'id module advanced'
+    context:
+      navigation: 'true'
+      identityModule: 'true'
+      user:
+        initials: 'rs'
+        username: 'rswanson'
+      dropdown: 'true'
+      userFunctions:
+        - link: '#'
+          text: 'Account settings'
+        - link: '#'
+          text: 'Admin task one'
+        - link: '#'
+          text: 'Admin task two'
+      id: 'identityModule'
+  - name: 'navigation'
+    context:
+      navigation: 'true'
+      main: 'true'
+      dropdown: 'true'
+      navItems:
+        - link: '#'
+          text: 'Nav one'
+        - text: 'Nav two'
+          id: '1'
+          relatedLinks:
+            - link: '#'
+              text: 'Item one'
+            - link: '#'
+              text: 'Item two'
+            - link: '#'
+              text: 'Item three'
+        - link: '#'
+          text: 'Nav three'
+        - text: 'Nav four'
+          id: '2'
+          relatedLinks:
+            - link: '#'
+              text: 'Item one'
+            - link: '#'
+              text: 'Item two'
+            - link: '#'
+              text: 'Item three'
+            - link: '#'
+              text: 'Item four'
+      id: 'navigation'
+  - name: 'navigation identity'
+    context:
+      navigation: 'true'
+      main: 'true'
+      identityModule: 'true'
+      user:
+        initials: 'rs'
+        username: 'rswanson'
+      dropdown: 'true'
+      userFunctions:
+        - link: '#'
+          text: 'Account settings'
+        - link: '#'
+          text: 'Admin task one'
+        - link: '#'
+          text: 'Admin task two'
+      navItems:
+        - link: '#'
+          text: 'Nav one'
+        - text: 'Nav two'
+          id: '1'
+          relatedLinks:
+            - link: '#'
+              text: 'Item one'
+            - link: '#'
+              text: 'Item two'
+            - link: '#'
+              text: 'Item three'
+            - link: '#'
+              text: 'Item four'
+        - link: '#'
+          text: 'Nav three'
+        - text: 'Nav four'
+          id: '2'
+          relatedLinks:
+            - link: '#'
+              text: 'Item one'
+            - link: '#'
+              text: 'Item two'
+            - link: '#'
+              text: 'Item three'
+            - link: '#'
+              text: 'Item four'
+      id: 'navigationIdentity'
+  - name: 'navigation simple identity'
+    context:
+      navigation: 'true'
+      main: 'true'
+      identityModule: 'true'
+      user:
+        initials: 'rs'
+        username: 'rswanson'
+      navItems:
+        - link: '#'
+          text: 'Nav one'
+        - text: 'Nav two'
+          id: '1'
+          relatedLinks:
+            - link: '#'
+              text: 'Item one'
+            - link: '#'
+              text: 'Item two'
+            - link: '#'
+              text: 'Item three'
+            - link: '#'
+              text: 'Item four'
+        - link: '#'
+          text: 'Nav three'
+        - text: 'Nav four'
+          id: '2'
+          relatedLinks:
+            - link: '#'
+              text: 'Item one'
+            - link: '#'
+              text: 'Item two'
+            - link: '#'
+              text: 'Item three'
+            - link: '#'
+              text: 'Item four'
+      id: 'navigationIdentity'
+  - name: 'persistent'
+    context:
+      persistent: 'true'
+      navigation: 'true'
+      main: 'true'
+      identityModule: 'true'
+      user:
+        initials: 'rs'
+        username: 'rswanson'
+      dropdown: 'true'
+      userFunctions:
+        - link: '#'
+          text: 'Account settings'
+        - link: '#'
+          text: 'Admin task one'
+        - link: '#'
+          text: 'Admin task two'
+      navItems:
+        - link: '#'
+          text: 'Nav one'
+        - text: 'Nav two'
+          id: '1'
+          relatedLinks:
+            - link: '#'
+              text: 'Item one'
+            - link: '#'
+              text: 'Item two'
+            - link: '#'
+              text: 'Item three'
+            - link: '#'
+              text: 'Item four'
+        - link: '#'
+          text: 'Nav three'
+        - text: 'Nav four'
+          id: '2'
+          relatedLinks:
+            - link: '#'
+              text: 'Item one'
+            - link: '#'
+              text: 'Item two'
+            - link: '#'
+              text: 'Item three'
+            - link: '#'
+              text: 'Item four'
+      id: 'mobileDrawer'

--- a/src/components/header/header.njk
+++ b/src/components/header/header.njk
@@ -16,7 +16,7 @@
                 {% if not navItem.relatedLinks %}
                   {% render '@link', { link: navItem.link, text: navItem.text }, true %}
                 {% else %}
-                {% set navItemId = "subnavDropdown-"+ loop.index %}
+                {% set navItemId = "subnavDropdown"+ loop.index %}
                   {% render '@dropdown', { special: true, id: navItemId, title: navItem.text, items: navItem.relatedLinks }, true %}
                 {% endif %}
               </li>
@@ -27,7 +27,7 @@
       {% if identityModule %}
         <div class="rvt-header-id">
           {% if dropdown %}
-            {% set dropdownId = "dropdown-"+ id %}
+            {% set dropdownId = "dropdown"+ id %}
             {% render '@dropdown', { special: "true", identityModule: "true", initials: user.initials, username: user.username, items: userFunctions, id: dropdownId, class: "rvt-header-id__menu" }, true %}
           {% else %}
             <div href="#0" class="rvt-header-id__profile">

--- a/src/components/includes/includes--header-controls.njk
+++ b/src/components/includes/includes--header-controls.njk
@@ -49,7 +49,7 @@
     {% include "@includes--header-id-menu" %}
     <!-- Drawer close button - shows on small screens -->
     <button class="rvt-drawer-button" aria-haspopup="true" aria-expanded="false" data-drawer-toggle="mobile-drawer">
-        <span class="sr-only">Toggle menu</span>
+        <span class="rvt-sr-only">Toggle menu</span>
         {% include "@includes--drawer-button" %}
     </button>
 </div>

--- a/src/components/modal/modal.njk
+++ b/src/components/modal/modal.njk
@@ -32,7 +32,7 @@
     </div>
     {% if not dialog %}
     <button class="rvt-button rvt-button--plain rvt-modal__close" data-modal-close="{{ id }}" role="button">
-      <span class="v-hide">Close</span>
+      <span class="rvt-sr-only">Close</span>
       {% include "@includes--close" %}
     </button>
     {% endif %}


### PR DESCRIPTION
In this PR:

- Previously, the dropdowns weren't working in the header examples. If the inline `script` in the `dropdown.njk` file is wrapped with `window.addEventlistener('load')`, this makes sure it runs after the Rivet IIFE has been loaded. Otherwise, it runs too soon, `Rivet is not defined` is logged to the console, and the component fails to have its event listener added.
- Changed instances of `sr-only` and `v-hide` classes to `rvt-sr-only` to hide screenreader only text (examples: close icon and drawer icon buttons)
- Indented YAML contents for `dropdown.config.yml` and `header.config.yml`