### PR TITLE
Created script for uploading release asset

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: 12
       - run: npm ci
       - name: Create artifact
-        run: npm build
+        run: npm run asset:upload
       - name: Create release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -60,6 +60,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./rivet.zip
+          asset_path: ./rivet-gh-release.zip
           asset_name: rivet.zip
           asset_content_type: application/zip

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -239,16 +239,16 @@ function distJS() {
 }
 
 // Strip out comments from JS files
-function stripJS(callback) {
-  src('./js/rivet-iife.js')
+function stripIIFE() {
+  return src('./js/rivet-iife.js')
     .pipe(strip())
     .pipe(dest('./js'));
+}
 
-  src('./js/rivet-esm.js')
+function stripESM() {
+  return src('./js/rivet-esm.js')
     .pipe(strip())
     .pipe(dest('./js'));
-
-  callback();
 }
 
 function minifyJS() {
@@ -336,7 +336,8 @@ exports.release = series(
   compileIIFE,
   compileESM,
   distJS,
-  stripJS,
+  stripIIFE,
+  stripESM,
   minifyJS,
   headerJS,
   releaseCopySass,
@@ -352,7 +353,8 @@ exports.build = series(
   compileIIFE,
   compileESM,
   distJS,
-  stripJS,
+  stripIIFE,
+  stripESM,
   minifyJS,
   headerJS,
   vendorJS,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "start": "gulp",
     "build": "npm run clean && gulp release && zip -r rivet.zip css js sass tokens index.html",
+    "asset:upload": "npm run clean && gulp release && zip -r rivet-gh-release.zip css js sass tokens index.html",
     "fix": "stylelint 'src/sass/**/*.scss' --fix",
     "test": "start-server-and-test cypress:serve http://localhost:3000 cypress:test",
     "cypress:browser": "cypress open",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "module": "js/rivet-esm.js",
   "scripts": {
     "start": "gulp",
-    "build": "npm run clean && gulp release && zip -r rivet.zip css js sass tokens index.html",
+    "build": "npm run clean && gulp release",
     "asset:upload": "npm run clean && gulp release && zip -r rivet-gh-release.zip css js sass tokens index.html",
     "fix": "stylelint 'src/sass/**/*.scss' --fix",
     "test": "start-server-and-test cypress:serve http://localhost:3000 cypress:test",


### PR DESCRIPTION
This fixes an issue caused by `rivet.zip` file being present in our `.gitignore`, which resulted in it being unreachable by the `upload-release-asset` action. To fix this, we created a new script in `package.json` to create a renamed asset for upload to GitHub for release.