### PR TITLE
Updated src/index.js to named exports

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -16,4 +16,4 @@ import Modal from './components/modal';
 import Sidenav from './components/sidenav';
 import Tabs from './components/tabs';
 
-export default { Accordion, Alert, Dropdown, FileInput, Modal, Sidenav, Tabs };
+export { Accordion, Alert, Dropdown, FileInput, Modal, Sidenav, Tabs };


### PR DESCRIPTION
This PR changes the exports within `src/index.js` from `default` back to named exports. This had been previously fixed but was overridden by another commit or merge.

See this issue for more details: #299 