### PR TITLE
Created avatar component

### DIFF
--- a/src/components/avatar/avatar.config.yml
+++ b/src/components/avatar/avatar.config.yml
@@ -2,12 +2,17 @@ title: 'Avatar'
 status: 'ready'
 collated: 'true'
 context:
-  text: 'RG'
+  text: 'XS'
+  modifier: '--xs'
 variants:
   - name: 'small'
     context:
       text: 'SM'
       modifier: '--sm'
+  - name: 'regular'
+    context:
+      text: 'RG'
+      modifier: false
   - name: 'medium'
     context:
       text: 'MD'
@@ -20,14 +25,18 @@ variants:
     context:
       text: 'XL'
       modifier: '--xl'
-  - name: 'regular-image'
+  - name: 'extra-small-image'
     context:
       image: 'http://www.fillmurray.com/300/300'
-      modifier: false
+      modifier: '--xs'
   - name: 'small-image'
     context:
       image: 'http://www.fillmurray.com/300/300'
       modifier: '--sm'
+  - name: 'regular-image'
+    context:
+      image: 'http://www.fillmurray.com/300/300'
+      modifier: false
   - name: 'medium-image'
     context:
       image: 'http://www.fillmurray.com/300/300'

--- a/src/components/avatar/avatar.config.yml
+++ b/src/components/avatar/avatar.config.yml
@@ -1,15 +1,13 @@
 title: 'Avatar'
 status: 'ready'
 collated: 'true'
+context:
+  text: 'RG'
 variants:
   - name: 'small'
     context:
       text: 'SM'
       modifier: '--sm'
-  - name: 'regular'
-    context:
-      text: 'RG'
-      modifier: '--rg'
   - name: 'medium'
     context:
       text: 'MD'
@@ -22,13 +20,14 @@ variants:
     context:
       text: 'XL'
       modifier: '--xl'
+  - name: 'regular-image'
+    context:
+      image: 'http://www.fillmurray.com/300/300'
+      modifier: false
   - name: 'small-image'
     context:
       image: 'http://www.fillmurray.com/300/300'
       modifier: '--sm'
-  - name: 'regular-image'
-    context:
-      image: 'http://www.fillmurray.com/300/300'
   - name: 'medium-image'
     context:
       image: 'http://www.fillmurray.com/300/300'

--- a/src/components/avatar/avatar.config.yml
+++ b/src/components/avatar/avatar.config.yml
@@ -1,0 +1,43 @@
+title: 'Avatar'
+status: 'ready'
+collated: 'true'
+variants:
+  - name: 'small'
+    context:
+      text: 'SM'
+      modifier: '--sm'
+  - name: 'regular'
+    context:
+      text: 'RG'
+      modifier: '--rg'
+  - name: 'medium'
+    context:
+      text: 'MD'
+      modifier: '--md'
+  - name: 'large'
+    context:
+      text: 'LG'
+      modifier: '--lg'
+  - name: 'extra-large'
+    context:
+      text: 'XL'
+      modifier: '--xl'
+  - name: 'small-image'
+    context:
+      image: 'http://www.fillmurray.com/300/300'
+      modifier: '--sm'
+  - name: 'regular-image'
+    context:
+      image: 'http://www.fillmurray.com/300/300'
+  - name: 'medium-image'
+    context:
+      image: 'http://www.fillmurray.com/300/300'
+      modifier: '--md'
+  - name: 'large-image'
+    context:
+      image: 'http://www.fillmurray.com/300/300'
+      modifier: '--lg'
+  - name: 'extra-large-image'
+    context:
+      image: 'http://www.fillmurray.com/300/300'
+      modifier: '--xl'

--- a/src/components/avatar/avatar.njk
+++ b/src/components/avatar/avatar.njk
@@ -1,0 +1,7 @@
+<div class="rvt-avatar{% if modifier %} rvt-avatar{{ modifier }}{% endif %}">
+  {% if image %}
+    <img src="{{ image }}" alt="{% if alt %}{{ alt }}{% endif %}">
+  {% elif text %}
+    <span class="rvt-avatar__text">{{ text }}</span>
+  {% endif %}
+</div>

--- a/src/components/example-layouts/example-layouts--avatar-responsive.njk
+++ b/src/components/example-layouts/example-layouts--avatar-responsive.njk
@@ -4,6 +4,7 @@
   {% render '@avatar', {'text': 'XS', 'modifier': '--xs-md-up'} %}
   {% render '@avatar', {'text': 'XS', 'modifier': '--xs-lg-up'} %}
   {% render '@avatar', {'text': 'XS', 'modifier': '--xs-xl-up'} %}
+  {% render '@avatar', {'text': 'XS', 'modifier': '--xs-xxl-up'} %}
 </div>
 
 <h2 class="rvt-text-bold rvt-ts-16 rvt-m-all-sm">Size set as 'sm' at different breakpoints</h2>
@@ -12,6 +13,7 @@
   {% render '@avatar', {'text': 'SM', 'modifier': '--sm-md-up'} %}
   {% render '@avatar', {'text': 'SM', 'modifier': '--sm-lg-up'} %}
   {% render '@avatar', {'text': 'SM', 'modifier': '--sm-xl-up'} %}
+  {% render '@avatar', {'text': 'SM', 'modifier': '--sm-xxl-up'} %}
 </div>
 
 <h2 class="rvt-text-bold rvt-ts-16 rvt-m-all-sm">Size set as 'md' at different breakpoints</h2>
@@ -20,6 +22,7 @@
   {% render '@avatar', {'text': 'MD', 'modifier': '--md-md-up'} %}
   {% render '@avatar', {'text': 'MD', 'modifier': '--md-lg-up'} %}
   {% render '@avatar', {'text': 'MD', 'modifier': '--md-xl-up'} %}
+  {% render '@avatar', {'text': 'MD', 'modifier': '--md-xxl-up'} %}
 </div>
 
 <h2 class="rvt-text-bold rvt-ts-16 rvt-m-all-sm">Size set as 'lg' at different breakpoints</h2>
@@ -28,6 +31,7 @@
   {% render '@avatar', {'text': 'LG', 'modifier': '--lg-md-up'} %}
   {% render '@avatar', {'text': 'LG', 'modifier': '--lg-lg-up'} %}
   {% render '@avatar', {'text': 'LG', 'modifier': '--lg-xl-up'} %}
+  {% render '@avatar', {'text': 'LG', 'modifier': '--lg-xxl-up'} %}
 </div>
 
 <h2 class="rvt-text-bold rvt-ts-16 rvt-m-all-sm">Size set as 'xl' at different breakpoints</h2>
@@ -36,4 +40,5 @@
   {% render '@avatar', {'text': 'XL', 'modifier': '--xl-md-up'} %}
   {% render '@avatar', {'text': 'XL', 'modifier': '--xl-lg-up'} %}
   {% render '@avatar', {'text': 'XL', 'modifier': '--xl-xl-up'} %}
+  {% render '@avatar', {'text': 'XL', 'modifier': '--xl-xxl-up'} %}
 </div>

--- a/src/components/example-layouts/example-layouts--avatar-responsive.njk
+++ b/src/components/example-layouts/example-layouts--avatar-responsive.njk
@@ -1,0 +1,39 @@
+<h2 class="rvt-text-bold rvt-ts-16 rvt-m-all-sm">Size set as 'xs' at different breakpoints</h2>
+<div class="rvt-flex">
+  {% render '@avatar', {'text': 'XS', 'modifier': '--xs-sm-up'} %}
+  {% render '@avatar', {'text': 'XS', 'modifier': '--xs-md-up'} %}
+  {% render '@avatar', {'text': 'XS', 'modifier': '--xs-lg-up'} %}
+  {% render '@avatar', {'text': 'XS', 'modifier': '--xs-xl-up'} %}
+</div>
+
+<h2 class="rvt-text-bold rvt-ts-16 rvt-m-all-sm">Size set as 'sm' at different breakpoints</h2>
+<div class="rvt-flex">
+  {% render '@avatar', {'text': 'SM', 'modifier': '--sm-sm-up'} %}
+  {% render '@avatar', {'text': 'SM', 'modifier': '--sm-md-up'} %}
+  {% render '@avatar', {'text': 'SM', 'modifier': '--sm-lg-up'} %}
+  {% render '@avatar', {'text': 'SM', 'modifier': '--sm-xl-up'} %}
+</div>
+
+<h2 class="rvt-text-bold rvt-ts-16 rvt-m-all-sm">Size set as 'md' at different breakpoints</h2>
+<div class="rvt-flex">
+  {% render '@avatar', {'text': 'MD', 'modifier': '--md-sm-up'} %}
+  {% render '@avatar', {'text': 'MD', 'modifier': '--md-md-up'} %}
+  {% render '@avatar', {'text': 'MD', 'modifier': '--md-lg-up'} %}
+  {% render '@avatar', {'text': 'MD', 'modifier': '--md-xl-up'} %}
+</div>
+
+<h2 class="rvt-text-bold rvt-ts-16 rvt-m-all-sm">Size set as 'lg' at different breakpoints</h2>
+<div class="rvt-flex">
+  {% render '@avatar', {'text': 'LG', 'modifier': '--lg-sm-up'} %}
+  {% render '@avatar', {'text': 'LG', 'modifier': '--lg-md-up'} %}
+  {% render '@avatar', {'text': 'LG', 'modifier': '--lg-lg-up'} %}
+  {% render '@avatar', {'text': 'LG', 'modifier': '--lg-xl-up'} %}
+</div>
+
+<h2 class="rvt-text-bold rvt-ts-16 rvt-m-all-sm">Size set as 'xl' at different breakpoints</h2>
+<div class="rvt-flex">
+  {% render '@avatar', {'text': 'XL', 'modifier': '--xl-sm-up'} %}
+  {% render '@avatar', {'text': 'XL', 'modifier': '--xl-md-up'} %}
+  {% render '@avatar', {'text': 'XL', 'modifier': '--xl-lg-up'} %}
+  {% render '@avatar', {'text': 'XL', 'modifier': '--xl-xl-up'} %}
+</div>

--- a/src/components/example-layouts/example-layouts--avatar.njk
+++ b/src/components/example-layouts/example-layouts--avatar.njk
@@ -1,0 +1,7 @@
+<div class="rvt-bg-black rvt-p-all-md">
+  {% render '@avatar' %}
+</div>
+
+<div class="rvt-bg-black rvt-p-all-md">
+  {% render '@avatar', {image: 'http://www.fillmurray.com/300/300'} %}
+</div>

--- a/src/sass/avatar/_base.scss
+++ b/src/sass/avatar/_base.scss
@@ -19,10 +19,15 @@
     width: 100%;
   }
 
-  &--sm {
+  &--xs {
     font-size: $ts-14;
     height: $spacing-lg;
     width: $spacing-lg;
+  }
+
+  &--sm {
+    height: $spacing-lg * 2;
+    width: $spacing-lg * 2;
   }
 
   &--md {

--- a/src/sass/avatar/_base.scss
+++ b/src/sass/avatar/_base.scss
@@ -68,7 +68,7 @@ $avatar-widths: (
 @each $variable, $size in $breakpoints {
   @include mq($size) {
     @each $pixels, $rems in $avatar-widths {
-      .#{$prefix}-avatar-#{$pixels}-#{$variable}-up {
+      .#{$prefix}-avatar--#{$pixels}-#{$variable}-up {
         font-size: map-get($avatar-fonts, $pixels);
         height: $rems !important;
         width: $rems !important;

--- a/src/sass/avatar/_base.scss
+++ b/src/sass/avatar/_base.scss
@@ -1,5 +1,21 @@
 @use 'core' as *;
 
+$avatar-fonts: (
+  'xs': $ts-14,
+  'sm': $ts-16,
+  'md': $ts-23,
+  'lg': $ts-32,
+  'xl': $ts-41
+);
+
+$avatar-widths: (
+  'xs': $spacing-lg,
+  'sm': $spacing-lg * 2,
+  'md': $spacing-lg * 3,
+  'lg': $spacing-lg * 4,
+  'xl': $spacing-lg * 5
+);
+
 .#{$prefix}-avatar {
   align-items: center;
   background-color: $color-crimson-base;
@@ -8,10 +24,10 @@
   display: flex;
   flex-shrink: 0;
   font-weight: 700;
-  height: $spacing-lg * 2;
+  height: map-get($avatar-widths, 'sm');
   justify-content: center;
   overflow: hidden;
-  width: $spacing-lg * 2;
+  width: map-get($avatar-widths, 'sm');
 
   img {
     display: block;
@@ -21,30 +37,42 @@
 
   &--xs {
     font-size: $ts-14;
-    height: $spacing-lg;
-    width: $spacing-lg;
+    height: map-get($avatar-widths, 'xs');
+    width: map-get($avatar-widths, 'xs');
   }
 
   &--sm {
-    height: $spacing-lg * 2;
-    width: $spacing-lg * 2;
+    height: map-get($avatar-widths, 'sm');
+    width: map-get($avatar-widths, 'sm');
   }
 
   &--md {
     font-size: $ts-23;
-    height: $spacing-lg * 3;
-    width: $spacing-lg * 3;
+    height: map-get($avatar-widths, 'md');
+    width: map-get($avatar-widths, 'md');
   }
 
   &--lg {
     font-size: $ts-32;
-    height: $spacing-lg * 4;
-    width: $spacing-lg * 4;
+    height: map-get($avatar-widths, 'lg');
+    width: map-get($avatar-widths, 'lg');
   }
 
   &--xl {
     font-size: $ts-41;
-    height: $spacing-lg * 5;
-    width: $spacing-lg * 5;
+    height: map-get($avatar-widths, 'xl');
+    width: map-get($avatar-widths, 'xl');
+  }
+}
+
+@each $variable, $size in $breakpoints {
+  @include mq($size) {
+    @each $pixels, $rems in $avatar-widths {
+      .#{$prefix}-avatar-#{$pixels}-#{$variable}-up {
+        font-size: map-get($avatar-fonts, $pixels);
+        height: $rems !important;
+        width: $rems !important;
+      }
+    }
   }
 }

--- a/src/sass/avatar/_base.scss
+++ b/src/sass/avatar/_base.scss
@@ -1,0 +1,45 @@
+@use 'core' as *;
+
+.#{$prefix}-avatar {
+  align-items: center;
+  background-color: $color-crimson-base;
+  border-radius: 999rem;
+  color: $color-white-base;
+  display: flex;
+  flex-shrink: 0;
+  font-weight: 700;
+  height: $spacing-lg * 2;
+  justify-content: center;
+  overflow: hidden;
+  width: $spacing-lg * 2;
+
+  img {
+    display: block;
+    height: auto;
+    width: 100%;
+  }
+
+  &--sm {
+    font-size: $ts-14;
+    height: $spacing-lg;
+    width: $spacing-lg;
+  }
+
+  &--md {
+    font-size: $ts-23;
+    height: $spacing-lg * 3;
+    width: $spacing-lg * 3;
+  }
+
+  &--lg {
+    font-size: $ts-32;
+    height: $spacing-lg * 4;
+    width: $spacing-lg * 4;
+  }
+
+  &--xl {
+    font-size: $ts-41;
+    height: $spacing-lg * 5;
+    width: $spacing-lg * 5;
+  }
+}

--- a/src/sass/avatar/_index.scss
+++ b/src/sass/avatar/_index.scss
@@ -1,0 +1,1 @@
+@forward 'base';

--- a/src/sass/rivet.scss
+++ b/src/sass/rivet.scss
@@ -7,6 +7,7 @@
 @use 'accordion';
 @use 'action';
 @use 'alerts';
+@use 'avatar';
 @use 'badges';
 @use 'box';
 @use 'breadcrumb';


### PR DESCRIPTION
In this PR:

- Created nunjucks template, config.yml for settings, and a blank README for docs
- Set up component variants based on this prototype: https://codepen.io/levimcg/pen/ZEGbMgw
- Added the `xs` variant and set the "regular" option to default to the `sm` variant so that if no modifier class is set, then the avatar will default to the `sm` variant
- Added responsive classes for different breakpoints. This required adding two Sass maps that could potentially be refactored as design tokens, if needed.
- Added an example layout of the text and image avatars displaying on a dark background