### PR TITLE
Created quote component

### DIFF
--- a/src/components/quote/quote.config.yml
+++ b/src/components/quote/quote.config.yml
@@ -1,0 +1,3 @@
+title: Quote
+label: Quote
+status: 'wip'

--- a/src/components/quote/quote.config.yml
+++ b/src/components/quote/quote.config.yml
@@ -1,3 +1,4 @@
 title: Quote
 label: Quote
 status: 'wip'
+preview: '@preview-no-padding'

--- a/src/components/quote/quote.njk
+++ b/src/components/quote/quote.njk
@@ -1,0 +1,6 @@
+<div class="rvt-quote">
+  <blockquote class="rvt-quote__text">
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+    <cite>Author Name</cite>
+  </blockquote>
+</div>

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -1,0 +1,41 @@
+@use 'core' as *;
+
+.#{$prefix}-quote {
+  &__text {
+    margin: 0;
+    padding-left: $spacing-xxl;
+    position: relative;
+
+    p {
+      font-size: $ts-23;
+      line-height: 1.4;
+      margin: 0;
+    }
+
+    cite {
+      color: $color-black-500;
+      display: block;
+      font-size: $ts-16;
+      margin-top: $spacing-md;
+    }
+
+    &::before {
+      content: '\201C';
+      position: absolute;
+      top: -$spacing-xs;
+      left: 0;
+      line-height: 1;
+      font-size: $ts-32 * 4;
+    }
+  }
+}
+
+@include mq($breakpoint-md) {
+  .#{$prefix}-quote {
+    &__text {
+      p {
+        font-size: $ts-32;
+      }
+    }
+  }
+}

--- a/src/sass/quote/_index.scss
+++ b/src/sass/quote/_index.scss
@@ -1,0 +1,1 @@
+@forward 'base';

--- a/src/sass/rivet.scss
+++ b/src/sass/rivet.scss
@@ -29,6 +29,7 @@
 @use 'menu';
 @use 'modals';
 @use 'pagination';
+@use 'quote';
 @use 'radios';
 @use 'sidenav';
 @use 'step-indicator';


### PR DESCRIPTION
In this PR:

This component was created using [this prototype](https://codepen.io/levimcg/pen/BaNoOGZ) as a base example. There are only three main parts: the decorative double-quote pseudoelement, the quote, and the author, so there currently aren't any other variants to test or review.

- The example has been checked to make sure all of the text is passing color contrast requirements for accessibility.
- The `preview` property was set to the `preview-no-padding` template to make it easier to review the component.