### PR TITLE
Added avatar variants to quote component

### DIFF
--- a/src/components/avatar/avatar.njk
+++ b/src/components/avatar/avatar.njk
@@ -1,4 +1,4 @@
-<div class="rvt-avatar{% if modifier %} rvt-avatar{{ modifier }}{% endif %}">
+<div class="rvt-avatar{% if modifier %} rvt-avatar{{ modifier }}{% endif %}{% if utility_class %} {{ utility_class }}{% endif %}">
   {% if image %}
     <img class="rvt-avatar__image" src="{{ image }}" alt="{% if alt %}{{ alt }}{% endif %}">
   {% elif text %}

--- a/src/components/quote/quote.config.yml
+++ b/src/components/quote/quote.config.yml
@@ -30,3 +30,33 @@ variants:
       attributes:
         text: 'XL'
         size: '--xl'
+  - name: 'avatar-image-extra-small'
+    context:
+      avatar: true
+      attributes:
+        image: 'http://www.fillmurray.com/300/300'
+        size: '--xs'
+  - name: 'avatar-image-small'
+    context:
+      avatar: true
+      attributes:
+        image: 'http://www.fillmurray.com/300/300'
+        size: '--sm'
+  - name: 'avatar-image-medium'
+    context:
+      avatar: true
+      attributes:
+        image: 'http://www.fillmurray.com/300/300'
+        size: '--md'
+  - name: 'avatar-image-large'
+    context:
+      avatar: true
+      attributes:
+        image: 'http://www.fillmurray.com/300/300'
+        size: '--lg'
+  - name: 'avatar-image-extra-large'
+    context:
+      avatar: true
+      attributes:
+        image: 'http://www.fillmurray.com/300/300'
+        size: '--xl'

--- a/src/components/quote/quote.config.yml
+++ b/src/components/quote/quote.config.yml
@@ -6,6 +6,12 @@ collated: true
 context:
   utility_class: 'rvt-m-right-sm'
 variants:
+  - name: 'avatar-extra-small'
+    context:
+      avatar: true
+      attributes:
+        text: 'XS'
+        size: '--xs'
   - name: 'avatar-small'
     context:
       avatar: true

--- a/src/components/quote/quote.config.yml
+++ b/src/components/quote/quote.config.yml
@@ -2,3 +2,31 @@ title: Quote
 label: Quote
 status: 'wip'
 preview: '@preview-no-padding'
+collated: true
+context:
+  utility_class: 'rvt-m-right-sm'
+variants:
+  - name: 'avatar-small'
+    context:
+      avatar: true
+      attributes:
+        text: 'SM'
+        size: '--sm'
+  - name: 'avatar-medium'
+    context:
+      avatar: true
+      attributes:
+        text: 'MD'
+        size: '--md'
+  - name: 'avatar-large'
+    context:
+      avatar: true
+      attributes:
+        text: 'LG'
+        size: '--lg'
+  - name: 'avatar-extra-large'
+    context:
+      avatar: true
+      attributes:
+        text: 'XL'
+        size: '--xl'

--- a/src/components/quote/quote.config.yml
+++ b/src/components/quote/quote.config.yml
@@ -3,8 +3,6 @@ label: Quote
 status: 'wip'
 preview: '@preview-no-padding'
 collated: true
-context:
-  utility_class: 'rvt-m-right-sm'
 variants:
   - name: 'avatar-extra-small'
     context:

--- a/src/components/quote/quote.njk
+++ b/src/components/quote/quote.njk
@@ -1,4 +1,7 @@
 <div class="rvt-quote">
+  {% if avatar %}
+    {% render '@avatar', { modifier: attributes.size, text: attributes.text, image: attributes.image, utility_class: utility_class }, true %}
+  {% endif %}
   <blockquote class="rvt-quote__text">
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
     <cite>Author Name</cite>

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -30,6 +30,10 @@
       font-size: $ts-32 * 4;
     }
   }
+
+  .#{$prefix}-avatar {
+    margin-right: $spacing-md;
+  }
 }
 
 @include mq($breakpoint-md) {

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -32,7 +32,7 @@
   }
 
   .#{$prefix}-avatar {
-    margin-right: $spacing-md;
+    margin-right: $spacing-sm;
   }
 }
 

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -1,6 +1,8 @@
 @use 'core' as *;
 
 .#{$prefix}-quote {
+  display: flex;
+
   &__text {
     margin: 0;
     padding-left: $spacing-xxl;


### PR DESCRIPTION
In this PR:

- Text and image `avatar` variants in different sizes were added as options for the `quote` component
- A `utility_class` option was added to the `avatar` component so a utility like `rvt-m-right-md` could be added to the `avatar` within the quote component