### PR TITLE
Migrated documentation for link component

### DIFF
--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -7,12 +7,16 @@ Inline text links are used to navigate between documents (pages).
 - Navigating to a new page or view in your application
 - Navigating to different web page, e.g. external documentation
 
-## When to consider something else
+## When to use something else
 
 Use the button component for:
 - Opening or closing a modal or dialog
 - Triggering a dropdown menu
 - Submitting data to the server
+
+## Accessibility requirements
+
+Never use a link to say "click here." A nondescript link forces users to backtrack and read the surrounding text for more context. This is even more problematic for those who rely on screen readers, which can list links for quicker navigation. A list of "click here" isn’t helpful for anyone.
 
 ## Implementation notes
 

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -13,3 +13,15 @@ Use the button component for:
 - Opening or closing a modal or dialog
 - Triggering a dropdown menu
 - Submitting data to the server
+
+## Implementation notes
+
+Your link should always describe where it will take users. Users tend to scan text online, and elements that stand out (like links) grab attention. Clear links can help users navigate more quickly.
+
+For example, instead of:
+
+> [Learn more](#)
+
+Use:
+
+> [Learn how to reset your passphrase](#)

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -1,1 +1,4 @@
 # Link
+
+Inline text links are used to navigate between documents (pages).
+

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -16,10 +16,11 @@ Use the button component for:
 
 ## Adding the markup
 
-To mark up a link in Rivet, add the `a` HTML element.
+To mark up a link in Rivet, add the `a` HTML element. Optionally, the class `rvt-link` can be added to a link to apply link styles.
 
 ```
 <a href="#">This is a text link</a> on a light background.
+<a href="#" class="rvt-link">This is a text link</a> on a light background, with the class rvt-link.
 ```
 
 To bold the link text, add the class `rvt-link-bold`.

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -14,6 +14,19 @@ Use the button component for:
 - Triggering a dropdown menu
 - Submitting data to the server
 
+## Adding the markup
+
+To mark up a link in Rivet, add the `a` HTML element.
+
+```
+<a href="#">This is a text link</a> on a light background.
+```
+
+To bold the link text, add the class `rvt-link-bold`.
+
+<p>This is a <a href="#" class="rvt-link-bold">bolded link</a>.</p>
+```
+
 ## Accessibility requirements
 
 Never use a link to say "click here." A nondescript link forces users to backtrack and read the surrounding text for more context. This is even more problematic for those who rely on screen readers, which can list links for quicker navigation. A list of "click here" isn’t helpful for anyone.

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -29,7 +29,7 @@ To bold the link text, add the class `rvt-link-bold`.
 
 ## Accessibility requirements
 
-Never use a link to say "click here." A nondescript link forces users to backtrack and read the surrounding text for more context. This is even more problematic for those who rely on screen readers, which can list links for quicker navigation. A list of "click here" isn’t helpful for anyone.
+Never use a link to say "click here." A nondescript link forces users to backtrack and read the surrounding text for more context. This is even more problematic for those who rely on screen readers, which can list links for quicker navigation. A list of links reading "click here" isn’t helpful for anyone.
 
 ## Implementation notes
 

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -2,3 +2,14 @@
 
 Inline text links are used to navigate between documents (pages).
 
+## When to use
+
+- Navigating to a new page or view in your application
+- Navigating to different web page, e.g. external documentation
+
+## When to consider something else
+
+Use the button component for:
+- Opening or closing a modal or dialog
+- Triggering a dropdown menu
+- Submitting data to the server


### PR DESCRIPTION
This PR migrates the `link` docs, adds a markup section, and reworks the "Microcopy & accessibility notes" into "accessibility requirements" and "implementation notes".