### PR TITLE
Header system local module nav toggle fix

### DIFF
--- a/src/sass/header-system/_header-local.scss
+++ b/src/sass/header-system/_header-local.scss
@@ -42,6 +42,7 @@
     svg {
       width: .75 * $spacing-sm;
       height: .75 * $spacing-sm;
+      flex-shrink: 0;
     }
   }
 


### PR DESCRIPTION
This issue has come up on a couple sites using the prototype version of the header system. I just got another report of the issue and realized that we hadn't fixed it here in the codebase. Wanted to get this in before we finish up the next alpha release.

Issue was being caused by the `flex-shrink` property defaulting to `shrink` which caused the svg icon inside the toggle button not to appear on iOS Safari. I tested in iOS locally. Can confirm this fixes the issue.