### PR TITLE
Updated loading indicator margin to center XXS indicator in small button

### DIFF
--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -302,10 +302,14 @@
     top: 50%;
 
     /**
-         * This negative margin accounts for the width/height of the
-         * default loading indicator above.
-         */
+     * This negative margin accounts for the width/height of the
+     * default loading indicator above.
+     */
     margin-top: -.65rem;
     margin-left: -$xs;
+
+    &--xxs {
+      margin-top: -$xs;
+    }
   }
 }


### PR DESCRIPTION
Documentation needs to be updated to say that XXS indicator is the only size you can use in small buttons.

Fixes #391 