### PR TITLE
Fixed Sass paths to make npm package usable via build tools

### DIFF
--- a/src/sass/accordion/_base.scss
+++ b/src/sass/accordion/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-accordion {
   border-bottom: 1px solid $color-black-100;

--- a/src/sass/action/_base.scss
+++ b/src/sass/action/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .rvt-action {
   align-items: center;

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-alert {
   background-color: $color-black-100;

--- a/src/sass/avatar/_base.scss
+++ b/src/sass/avatar/_base.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 $avatar-fonts: (
   'xs': $ts-14,

--- a/src/sass/badges/_base.scss
+++ b/src/sass/badges/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-badge {
   background-color: $color-black-200;

--- a/src/sass/box/_base.scss
+++ b/src/sass/box/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-box {
   background-color: $color-white-base;

--- a/src/sass/breadcrumb/_base.scss
+++ b/src/sass/breadcrumb/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-breadcrumbs {
   list-style: none;

--- a/src/sass/buttons-segmented/_base.scss
+++ b/src/sass/buttons-segmented/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-button-segmented {
   display: inline-flex;

--- a/src/sass/buttons/_base.scss
+++ b/src/sass/buttons/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 %button-focus {
   outline: none;

--- a/src/sass/buttons/_button-links.scss
+++ b/src/sass/buttons/_button-links.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 .rvt-button--link {
   background-color: $color-crimson-base;

--- a/src/sass/calendar-tile/_base.scss
+++ b/src/sass/calendar-tile/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-cal {
   font-size: $ts-32;

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-checkbox {
   position: absolute;

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 html {
   font-size: 100%;

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-dropdown {
   position: relative;

--- a/src/sass/essay/_base.scss
+++ b/src/sass/essay/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2020 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .rvt-essay {
   display: flex;

--- a/src/sass/feature/_base.scss
+++ b/src/sass/feature/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-feature {
   display: flex;

--- a/src/sass/file-input/_base.scss
+++ b/src/sass/file-input/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-file {
   display: flex;

--- a/src/sass/footer-system/_footer-base.scss
+++ b/src/sass/footer-system/_footer-base.scss
@@ -1,6 +1,6 @@
 // Brand section (copyright)
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-footer-base {
   background-color: $color-crimson-base;

--- a/src/sass/footer-system/_footer-common.scss
+++ b/src/sass/footer-system/_footer-common.scss
@@ -1,6 +1,6 @@
 // Applies to all parts of the footer
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-footer-social,
 .#{$prefix}-footer-resources,

--- a/src/sass/footer-system/_footer-resources.scss
+++ b/src/sass/footer-system/_footer-resources.scss
@@ -1,6 +1,6 @@
 // Related section
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-footer-resources {
   background-color: $color-crimson-base;

--- a/src/sass/footer-system/_footer-social.scss
+++ b/src/sass/footer-system/_footer-social.scss
@@ -1,6 +1,6 @@
 // Social section
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-footer-social {
   background-color: $color-crimson-base;

--- a/src/sass/footer/_base.scss
+++ b/src/sass/footer/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-footer {
   align-items: center;

--- a/src/sass/grid/_base.scss
+++ b/src/sass/grid/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 // These Sass maps are used for all the basic row set up.
 

--- a/src/sass/header-system/_header-global.scss
+++ b/src/sass/header-system/_header-global.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-header-global {
   padding-top: $spacing-sm;

--- a/src/sass/header-system/_header-local.scss
+++ b/src/sass/header-system/_header-local.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 .rvt-header-local {
   border-top: 1px solid $color-black-100;

--- a/src/sass/header-system/_header-lockup.scss
+++ b/src/sass/header-system/_header-lockup.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-lockup {
   display: inline-flex;

--- a/src/sass/header-system/_header-menu.scss
+++ b/src/sass/header-system/_header-menu.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 /**
  * FIXME: Speculative ID menu stuff. This is from an old prototype, but might be

--- a/src/sass/header-system/_header-toggle-button.scss
+++ b/src/sass/header-system/_header-toggle-button.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 /**
  * Global header toggle stuff

--- a/src/sass/header-system/_header-wrapper.scss
+++ b/src/sass/header-system/_header-wrapper.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-header-wrapper {
   box-shadow: 0 3px 6px rgba($color-black-base, .07);

--- a/src/sass/header/_base.scss
+++ b/src/sass/header/_base.scss
@@ -1,8 +1,8 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'buttons';
-@use 'core' as *;
+@use '../buttons';
+@use '../core' as *;
 
 .#{$prefix}-skip-link {
   position: fixed;

--- a/src/sass/hero-area/_base.scss
+++ b/src/sass/hero-area/_base.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 .rvt-hero {
   padding-top: $spacing-md;

--- a/src/sass/input-group/_base.scss
+++ b/src/sass/input-group/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-input-group {
   display: flex;

--- a/src/sass/inputs/_base.scss
+++ b/src/sass/inputs/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix} {
   &-input[type],

--- a/src/sass/links/_base.scss
+++ b/src/sass/links/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 a,
 .#{$prefix}-link {

--- a/src/sass/lists/_base.scss
+++ b/src/sass/lists/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 ul,
 ol {

--- a/src/sass/loading-indicator/_base.scss
+++ b/src/sass/loading-indicator/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-loader {
   animation: .8s linear infinite loader;

--- a/src/sass/media-object/_base.scss
+++ b/src/sass/media-object/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-mo {
   display: flex;

--- a/src/sass/menu/_base.scss
+++ b/src/sass/menu/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-menu {
   &__list {

--- a/src/sass/modals/_base.scss
+++ b/src/sass/modals/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 /**
  * This class gets applied to the body of the document when the modal

--- a/src/sass/pagination/_base.scss
+++ b/src/sass/pagination/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-pagination {
   list-style: none;

--- a/src/sass/radios/_base.scss
+++ b/src/sass/radios/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-radio {
   position: absolute;

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2019 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-sidenav {
   &__label {

--- a/src/sass/step-indicator/_base.scss
+++ b/src/sass/step-indicator/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-steps {
   display: flex;

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 /**
  * Tables

--- a/src/sass/tabs/_base.scss
+++ b/src/sass/tabs/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-tabs {
   &__tab {

--- a/src/sass/timeline/_base.scss
+++ b/src/sass/timeline/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-timeline {
   position: relative;

--- a/src/sass/utilities/_border.scss
+++ b/src/sass/utilities/_border.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-border-all {
   border: 1px solid $color-black-100 !important;

--- a/src/sass/utilities/_color.scss
+++ b/src/sass/utilities/_color.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 /* stylelint-disable */
 

--- a/src/sass/utilities/_display.scss
+++ b/src/sass/utilities/_display.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 /* Hide only visually, but have it available for
  * screenreaders: h5bp.com/v

--- a/src/sass/utilities/_elements.scss
+++ b/src/sass/utilities/_elements.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix} {
   &-abbr,

--- a/src/sass/utilities/_flex.scss
+++ b/src/sass/utilities/_flex.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 // Display flex
 

--- a/src/sass/utilities/_flow.scss
+++ b/src/sass/utilities/_flow.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2021 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .rvt-flow > * {
   // This acts as a reset of sorts to create an even starting point in

--- a/src/sass/utilities/_spacing.scss
+++ b/src/sass/utilities/_spacing.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 /* stylelint-disable */
 

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-text-uppercase {
   text-transform: uppercase;

--- a/src/sass/utilities/_type-scale.scss
+++ b/src/sass/utilities/_type-scale.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 /* stylelint-disable */
 

--- a/src/sass/utilities/_visibility.scss
+++ b/src/sass/utilities/_visibility.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 %start-hidden {
   display: none !important;

--- a/src/sass/utilities/_width.scss
+++ b/src/sass/utilities/_width.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 // Builds non-responsive width utility classes
 

--- a/src/sass/utilities/_wysiwyg.scss
+++ b/src/sass/utilities/_wysiwyg.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 .#{$prefix}-wysiwyg {
   * + * {

--- a/src/sass/utilities/_z-index.scss
+++ b/src/sass/utilities/_z-index.scss
@@ -1,4 +1,4 @@
-@use 'core' as *;
+@use '../core' as *;
 
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause

--- a/src/sass/validation/_base.scss
+++ b/src/sass/validation/_base.scss
@@ -1,7 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use 'core' as *;
+@use '../core' as *;
 
 @include all-inputs('.#{$prefix}-validation-info') {
   transition: box-shadow .2s ease;


### PR DESCRIPTION
I tried using the Sass files shipped in the npm package in the `2.0.0-alpha.4` release and realized that we were using incorrect relative urls when referencing Sass partials. The build tool we were using in rivet-source was able to resolve the paths to the `core` package in each partial, but that's not the case when you try to import the various packages/modules that we ship in the npm package.

Essentialy it was changing all of the `@use 'core' as *;` statements to `@use '../core' as *;` (relative URLs).

I've tested this updated package locally using `npm pack` and everything works great now. This will allow users of the npm package to pick and choose only Sass components they need/want which could help reduce CSS bundle size if you are using Sass to generate the CSS for your project.

For example if some is building a one-page microsite that doesn't have any forms, modals, tabs, or dropdowns on it. They could import everything except those components which would greatly reduce the compiled size of their CSS. This allows developers to create custom CSS bundles of Rivet. Nice ✅ 