### PR TITLE
Added basic details two-column page layout

### DIFF
--- a/src/components/_preview-no-padding.njk
+++ b/src/components/_preview-no-padding.njk
@@ -8,7 +8,7 @@
     <script src="{{ '/js/rivet-iife.js' | path }}"></script>
     <script src="{{ '/js/rivet-init.js' | path }}"></script>
 </head>
-<body class="rvt-flex rvt-flex-column">
+<body class="rvt-layout">
     {{ yield | safe }}
 </body>
 </html>

--- a/src/components/breadcrumb/breadcrumb.config.yml
+++ b/src/components/breadcrumb/breadcrumb.config.yml
@@ -9,9 +9,9 @@ context:
   items:
     - text: Home
       link: "#"
-    - text: Files
+    - text: Tier two
       link: "#"
-    - text: my-file.txt
+    - text: Tier three
       attributes:
         - label: "aria-label"
           value: "Current page"

--- a/src/components/breadcrumb/breadcrumb.njk
+++ b/src/components/breadcrumb/breadcrumb.njk
@@ -1,4 +1,4 @@
-<nav role="navigation" {% for attribute in attributes %} {{attribute.label}}="{{attribute.value}}"{% endfor %}>
+<nav{% if classes %} class="{{ classes }}"{% endif %} role="navigation" {% for attribute in attributes %} {{attribute.label}}="{{attribute.value}}"{% endfor %}>
     <ol class="rvt-breadcrumbs{% if callout %} rvt-breadcrumbs--call-out{% endif %}">
         {% for item in items %}
         <li {% for attribute in item.attributes %} {{attribute.label}}="{{attribute.value}}"{% endfor %}>{% if item.link %}<a href="{{ item.link }}">{{ item.text }}</a>{% else %}{{ item.text }}{% endif %}</li>

--- a/src/components/layouts/01-index-summary-page.njk
+++ b/src/components/layouts/01-index-summary-page.njk
@@ -22,7 +22,8 @@
   
   <div class="{{ siteContainer }} rvt-p-tb-xl rvt-p-tb-3-xl-md-up">  
     {% render "@billboard", {
-      classes: 'rvt-billboard--reverse'
+      classes: 'rvt-billboard--reverse',
+      cta: { text: 'See another page', url: '/components/preview/generic-details-page'}
     }, true %}
   </div>
   

--- a/src/components/layouts/01-index-summary-page.njk
+++ b/src/components/layouts/01-index-summary-page.njk
@@ -1,5 +1,5 @@
 {% include "@header-system-main-nav" %}
-<main class="rvt-grow-1">
+<main class="rvt-layout__wrapper">
   {%- set heroActions -%}
   <a class="rvt-button rvt-button--link" href="#">Read more about this</a>
   <a class="rvt-button rvt-button--plain" href="#">Also this action</a>

--- a/src/components/layouts/02-details-page.njk
+++ b/src/components/layouts/02-details-page.njk
@@ -1,0 +1,18 @@
+{% include "@header-system-main-nav" %}
+<!-- This can be any container you want or no container? -->
+<main class="rvt-layout__wrapper {{ siteContainer }}">
+  <div class="rvt-layout__sidebar" id="section-nav">
+    {% render "@sidenav" %}
+  </div>
+  <div class="rvt-layout__content">
+    <a class="rvt-hide-md-up" href="#section-nav">Section navigation</a>
+    
+    <div class="rvt-prose rvt-flow">
+      <h1>Hello, World</h1>
+      
+      {% include "@prose-placeholder-partial" %}
+    </div>
+      
+  </div>
+</main>
+{% include "@footer-system" %}

--- a/src/components/layouts/02-details-page.njk
+++ b/src/components/layouts/02-details-page.njk
@@ -1,15 +1,33 @@
 {% include "@header-system-main-nav" %}
 <!-- This can be any container you want or no container? -->
-<main class="rvt-layout__wrapper {{ siteContainer }}">
+<main class="rvt-layout__wrapper rvt-layout__wrapper--cols-2 {{ siteContainer }}">
   <div class="rvt-layout__sidebar" id="section-nav">
     {% render "@sidenav" %}
   </div>
   <div class="rvt-layout__content">
-    <a class="rvt-hide-md-up" href="#section-nav">Section navigation</a>
+    <a class="rvt-hide-md-up rvt-ts-14 rvt-inline-flex rvt-p-all-xxs rvt-link-bold rvt-border-radius rvt-bg-blue-000 rvt-shrink-0" href="#section-nav">Section navigation</a>
     
-    <div class="rvt-prose rvt-flow">
-      <h1>Hello, World</h1>
-      
+    <nav role="navigation" aria-label="Breadcrumb">
+      <ol class="rvt-breadcrumbs">
+        <li>
+          <a href="#">
+            <span class="rvt-sr-only">Home</span>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" id="rvt-icon-home">
+              <path fill="currentColor" d="M15.6 6.4l-7-5.19a.76.76 0 0 0-.19-.12A1 1 0 0 0 8 1a1 1 0 0 0-.42.09.76.76 0 0 0-.19.12L.4 6.4a1 1 0 0 0-.4.8 1 1 0 0 0 .2.6 1 1 0 0 0 1.4.2l.4-.3V14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V7.7l.4.3a1 1 0 0 0 .6.2 1 1 0 0 0 .6-1.8zM12 13H9V9H7v4H4V6.22l4-3 4 3z"></path>
+            </svg>
+          </a>
+        </li>
+        <li><a href="#">Tier two title</a></li>
+        <li><a href="#">Tier three title</a></li>
+      </ol>
+    </nav>
+
+    <div class="rvt-m-top-sm rvt-flow rvt-prose">
+      <h1>Lorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod tempor</h1>
+      <p class="rvt-ts-20 rvt-color-black-500">Lorem ipsum dolor sit, amet consectetur adipisicing elit. Esse exercitationem nulla inventore, velit earum explicabo voluptatibus eum. Repudiandae magni dolor facere debitis molestiae.</p>
+    </div>
+
+    <div class="rvt-prose rvt-flow rvt-border-top rvt-p-top-lg rvt-m-top-xl">
       {% include "@prose-placeholder-partial" %}
     </div>
       

--- a/src/components/layouts/02-generic-details-page.njk
+++ b/src/components/layouts/02-generic-details-page.njk
@@ -1,6 +1,6 @@
 {% include "@header-system-main-nav" %}
 <!-- This can be any container you want or no container? -->
-<main class="rvt-layout__wrapper rvt-layout__wrapper--cols-2 {{ siteContainer }}">
+<main class="rvt-layout__wrapper rvt-layout__wrapper--details {{ siteContainer }}">
   <div class="rvt-layout__sidebar" id="section-nav">
     {% render "@sidenav" %}
   </div>

--- a/src/components/layouts/02-generic-details-page.njk
+++ b/src/components/layouts/02-generic-details-page.njk
@@ -22,7 +22,7 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" id="rvt-icon-arrow-down">
           <path fill="currentColor" d="M12.71 10.29a1 1 0 0 0-1.41 0L9 12.59V1a1 1 0 0 0-2 0v11.59l-2.29-2.3A1 1 0 0 0 3.3 11.7l4 4a1 1 0 0 0 1.42 0l4-4a1 1 0 0 0-.01-1.41z"></path>
         </svg>
-        <span class="rvt-m-left-xs">In this section</span>
+        <span class="rvt-m-left-xs">Section navigation</span>
       </a>
     </nav>
 

--- a/src/components/layouts/02-generic-details-page.njk
+++ b/src/components/layouts/02-generic-details-page.njk
@@ -26,7 +26,7 @@
       </a>
     </nav>
 
-    <div class="rvt-m-top-xxl rvt-m-top-sm-md-up rvt-flow rvt-prose">
+    <div class="rvt-m-top-xxl rvt-m-top-md-md-up rvt-flow rvt-prose">
       <h1>Lorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod tempor</h1>
       <p class="rvt-ts-20 rvt-color-black-500">Lorem ipsum dolor sit, amet consectetur adipisicing elit. Esse exercitationem nulla inventore, velit earum explicabo voluptatibus eum. Repudiandae magni dolor facere debitis molestiae.</p>
     </div>

--- a/src/components/layouts/02-generic-details-page.njk
+++ b/src/components/layouts/02-generic-details-page.njk
@@ -26,10 +26,7 @@
       </a>
     </nav>
 
-    <div class="rvt-m-top-xxl rvt-m-top-md-md-up rvt-flow rvt-prose">
-      <h1>Lorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod tempor</h1>
-      <p class="rvt-ts-20 rvt-color-black-500">Lorem ipsum dolor sit, amet consectetur adipisicing elit. Esse exercitationem nulla inventore, velit earum explicabo voluptatibus eum. Repudiandae magni dolor facere debitis molestiae.</p>
-    </div>
+    {% include "@page-intro-partial" %}
 
     <div class="rvt-prose rvt-flow rvt-border-top rvt-p-top-lg rvt-m-top-xl">
       {% include "@prose-placeholder-partial" %}

--- a/src/components/layouts/02-generic-details-page.njk
+++ b/src/components/layouts/02-generic-details-page.njk
@@ -5,10 +5,8 @@
     {% render "@sidenav" %}
   </div>
   <div class="rvt-layout__content">
-    <a class="rvt-hide-md-up rvt-ts-14 rvt-inline-flex rvt-p-all-xxs rvt-link-bold rvt-border-radius rvt-bg-blue-000 rvt-shrink-0" href="#section-nav">Section navigation</a>
-    
-    <nav role="navigation" aria-label="Breadcrumb">
-      <ol class="rvt-breadcrumbs">
+    <nav class="rvt-flex rvt-items-center" role="navigation" aria-label="Breadcrumb">
+      <ol class="rvt-breadcrumbs rvt-grow-1">
         <li>
           <a href="#">
             <span class="rvt-sr-only">Home</span>
@@ -20,9 +18,15 @@
         <li><a href="#">Tier two title</a></li>
         <li><a href="#">Tier three title</a></li>
       </ol>
+      <a class="rvt-hide-md-up rvt-text-regular rvt-ts-14 rvt-inline-flex rvt-items-center rvt-p-tb-xxs rvt-p-lr-xs rvt-link-bold rvt-border-radius rvt-bg-blue-000 rvt-shrink-0" href="#section-nav">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" id="rvt-icon-arrow-down">
+          <path fill="currentColor" d="M12.71 10.29a1 1 0 0 0-1.41 0L9 12.59V1a1 1 0 0 0-2 0v11.59l-2.29-2.3A1 1 0 0 0 3.3 11.7l4 4a1 1 0 0 0 1.42 0l4-4a1 1 0 0 0-.01-1.41z"></path>
+        </svg>
+        <span class="rvt-m-left-xs">In this section</span>
+      </a>
     </nav>
 
-    <div class="rvt-m-top-sm rvt-flow rvt-prose">
+    <div class="rvt-m-top-xxl rvt-m-top-sm-md-up rvt-flow rvt-prose">
       <h1>Lorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod tempor</h1>
       <p class="rvt-ts-20 rvt-color-black-500">Lorem ipsum dolor sit, amet consectetur adipisicing elit. Esse exercitationem nulla inventore, velit earum explicabo voluptatibus eum. Repudiandae magni dolor facere debitis molestiae.</p>
     </div>

--- a/src/components/layouts/03-gener-details-single-column.njk
+++ b/src/components/layouts/03-gener-details-single-column.njk
@@ -23,10 +23,7 @@
       </a>
     </nav>
 
-    <div class="rvt-m-top-xxl rvt-m-top-md-md-up rvt-flow rvt-prose">
-      <h1>Lorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod tempor</h1>
-      <p class="rvt-ts-20 rvt-color-black-500">Lorem ipsum dolor sit, amet consectetur adipisicing elit. Esse exercitationem nulla inventore, velit earum explicabo voluptatibus eum. Repudiandae magni dolor facere debitis molestiae.</p>
-    </div>
+    {% include "@page-intro-partial" %}
 
     <div class="rvt-prose rvt-flow rvt-border-top rvt-p-top-lg rvt-m-top-xl">
       {% include "@prose-placeholder-partial" %}

--- a/src/components/layouts/03-gener-details-single-column.njk
+++ b/src/components/layouts/03-gener-details-single-column.njk
@@ -1,0 +1,37 @@
+{% include "@header-system-main-nav" %}
+<!-- This can be any container you want or no container? -->
+<main class="rvt-layout__wrapper rvt-layout__wrapper--single rvt-container-sm">
+  <div class="rvt-layout__content">
+    <nav class="rvt-flex rvt-items-center" role="navigation" aria-label="Breadcrumb">
+      <ol class="rvt-breadcrumbs rvt-grow-1">
+        <li>
+          <a href="#">
+            <span class="rvt-sr-only">Home</span>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" id="rvt-icon-home">
+              <path fill="currentColor" d="M15.6 6.4l-7-5.19a.76.76 0 0 0-.19-.12A1 1 0 0 0 8 1a1 1 0 0 0-.42.09.76.76 0 0 0-.19.12L.4 6.4a1 1 0 0 0-.4.8 1 1 0 0 0 .2.6 1 1 0 0 0 1.4.2l.4-.3V14a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V7.7l.4.3a1 1 0 0 0 .6.2 1 1 0 0 0 .6-1.8zM12 13H9V9H7v4H4V6.22l4-3 4 3z"></path>
+            </svg>
+          </a>
+        </li>
+        <li><a href="#">Tier two title</a></li>
+        <li><a href="#">Tier three title</a></li>
+      </ol>
+      <a class="rvt-hide-md-up rvt-text-regular rvt-ts-14 rvt-inline-flex rvt-items-center rvt-p-tb-xxs rvt-p-lr-xs rvt-link-bold rvt-border-radius rvt-bg-blue-000 rvt-shrink-0" href="#section-nav">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" id="rvt-icon-arrow-down">
+          <path fill="currentColor" d="M12.71 10.29a1 1 0 0 0-1.41 0L9 12.59V1a1 1 0 0 0-2 0v11.59l-2.29-2.3A1 1 0 0 0 3.3 11.7l4 4a1 1 0 0 0 1.42 0l4-4a1 1 0 0 0-.01-1.41z"></path>
+        </svg>
+        <span class="rvt-m-left-xs">In this section</span>
+      </a>
+    </nav>
+
+    <div class="rvt-m-top-xxl rvt-m-top-md-md-up rvt-flow rvt-prose">
+      <h1>Lorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod tempor</h1>
+      <p class="rvt-ts-20 rvt-color-black-500">Lorem ipsum dolor sit, amet consectetur adipisicing elit. Esse exercitationem nulla inventore, velit earum explicabo voluptatibus eum. Repudiandae magni dolor facere debitis molestiae.</p>
+    </div>
+
+    <div class="rvt-prose rvt-flow rvt-border-top rvt-p-top-lg rvt-m-top-xl">
+      {% include "@prose-placeholder-partial" %}
+    </div>
+      
+  </div>
+</main>
+{% include "@footer-system" %}

--- a/src/components/layouts/README.md
+++ b/src/components/layouts/README.md
@@ -1,4 +1,4 @@
-#Layouts
+# Layouts
 Pre-built layouts to give developers a head start when building websites and apps.
 
 ## Overview
@@ -12,7 +12,7 @@ With the `rvt-layout__wrapper` CSS class applied to the `main` element it will a
   <header class="rvt-header-wrapper">
     <!-- Rivet header markup -->
   </header>
-  <main class="rvt-layout__wrapper">
+  <main class="rvt-layout__wrapper rvt-container-lg">
     <!-- Site or App specific Layout content -->
   </main>
   <footer class="rvt-footer-base">
@@ -20,6 +20,26 @@ With the `rvt-layout__wrapper` CSS class applied to the `main` element it will a
   </footer>
 </body>
 ```
+
+### Details Layouts
+There are two versions of the Details layout. A single column version and a two-column (on larger screens) version with the [Sidenav component](/docs/components/sidenav/) included for section navigation.
+
+#### Single column markup
+```html
+<body class="rvt-layout">
+  <header class="rvt-header-wrapper">
+    <!-- Rivet header markup -->
+  </header>
+  <main class="rvt-layout__wrapper rvt-layout__wrapper--single rvt-container-sm">
+    <!-- Site or App specific Layout content -->
+  </main>
+  <footer class="rvt-footer-base">
+    <!-- Rivet footer markup -->
+  </footer>
+</body>
+```
+
+Note the use of the `rvt-container-sm` layout utility here. Using a small [Rivet container](/docs/utilities/container/) in this case will help constrain the running text to a readable width, which is important for usability reasons.
 
 ### Additional layout elements
 In addition to the base Rivet Layout elements `rvt-layout` and `rvt-layout__wrapper`, developers can create a common two-column layout on larger screens with two additional elements using the CSS classes `rvt-layout__sidebar` and `rvt-layout__content`.
@@ -29,7 +49,7 @@ In addition to the base Rivet Layout elements `rvt-layout` and `rvt-layout__wrap
   <header class="rvt-header-wrapper">
     <!-- Rivet header markup -->
   </header>
-  <main class="rvt-layout__wrapper">
+  <main class="rvt-layout__wrapper rvt-layout__wrapper--details">
     <div class="rvt-layout__sidebar">
       <!-- Rivet Sidenav component -->
     </div>
@@ -42,6 +62,8 @@ In addition to the base Rivet Layout elements `rvt-layout` and `rvt-layout__wrap
   </footer>
 </body>
 ```
+
+Note that the two-column details layout requires the addition of a `rvt-layout__wrapper--details` modifier CSS class on the `main` element.
 
 ### The "Break out" element
 You can apply the `rvt-layout__break-out` CSS class to an element within the `rvt-layout__content` column to make that content break out of the main column. The breakout element is useful for elements like images and stats that you want to call out within a column of running text.
@@ -63,10 +85,12 @@ You can apply the `rvt-layout__break-out` CSS class to an element within the `rv
 ```
 
 #### Do
-Use the break out element to call attention to an important piece or section of content.
+- Use the break out element to call attention to an important piece or section of content.
+- Only use the break out element inside the main content area (with the CSS class of `rvt-layout__content`)
 
 #### Don't
-Use more than one or two break out elements per page layout.
+- Use more than one or two break out elements per page layout.
+- Use the break out element outside of the main content layout element
 
 ### The "Feature slot" element
 The Feature slot provides a way to create an additional call out at the top of the main content column in the generic details Layout. Applying then `rvt-layout__feature-slot` CSS class to the first child of the `rvt-layout__content` element will create a space that causes running text to wrap around it and pulls the area out of the main content column.
@@ -81,3 +105,4 @@ The Feature slot provides a way to create an additional call out at the top of t
 
 #### Don't
 - Use more than one Feature slot per page
+- Use the Feature Slot outside of the main content area (`rvt-layout__content`)

--- a/src/components/layouts/README.md
+++ b/src/components/layouts/README.md
@@ -21,6 +21,10 @@ With the `rvt-layout__wrapper` CSS class applied to the `main` element it will a
 </body>
 ```
 
+### Using Rivet container utilities with Layouts
+Note the use of the additional [Rivet container](#) `rvt-container-lg` CSS utility class on the layout wrapper. The is used to constrain the maximum width of the layout. It is possible to use any of the Rivet container size utilities, but the "large" or `rvt-container-lg` variant is a good default. This container size should match the size used in the [header](#) and [footer](#) of you site or app.
+
+
 ### Details Layouts
 There are two versions of the Details layout. A single column version and a two-column (on larger screens) version with the [Sidenav component](/docs/components/sidenav/) included for section navigation.
 
@@ -41,7 +45,7 @@ There are two versions of the Details layout. A single column version and a two-
 
 Note the use of the `rvt-container-sm` layout utility here. Using a small [Rivet container](/docs/utilities/container/) in this case will help constrain the running text to a readable width, which is important for usability reasons.
 
-### Additional layout elements
+### Two-column markup
 In addition to the base Rivet Layout elements `rvt-layout` and `rvt-layout__wrapper`, developers can create a common two-column layout on larger screens with two additional elements using the CSS classes `rvt-layout__sidebar` and `rvt-layout__content`.
 
 ```html

--- a/src/components/layouts/README.md
+++ b/src/components/layouts/README.md
@@ -1,2 +1,44 @@
 #Layouts
-Layouts are a new concept in Rivet.
+Pre-built layouts to give developers a head start when building websites and apps.
+
+## Overview
+Every Rivet layout starts with a small amount of HTML with specific CSS classes applied. This is the most basic Rivet Layout that includes the base `rvt-layout` CSS class, a version of the [Rivet header](/docs/components/header/), and a version of the [Rivet footer](/docs/components/footer/).
+
+## Usage
+With the `rvt-layout__wrapper` CSS class applied to the `main` element it will automatically push the footer to the bottom of the viewport if there is not enough content to fill up the screen.
+
+```html
+<body class="rvt-layout">
+  <header class="rvt-header-wrapper">
+    <!-- Rivet header markup -->
+  </header>
+  <main class="rvt-layout__wrapper">
+    <!-- Site or App specific Layout content -->
+  </main>
+  <footer class="rvt-footer-base">
+    <!-- Rivet footer markup -->
+  </footer>
+</body>
+```
+
+### Additional layout elements
+In addition to the base Rivet Layout elements `rvt-layout` and `rvt-layout__wrapper`, developers can create a common two-column layout on larger screens with two additional elements using the CSS classes `rvt-layout__sidebar` and `rvt-layout__content`.
+
+```html
+<body class="rvt-layout">
+  <header class="rvt-header-wrapper">
+    <!-- Rivet header markup -->
+  </header>
+  <main class="rvt-layout__wrapper">
+    <div class="rvt-layout__sidebar">
+      <!-- Rivet Sidenav component -->
+    </div>
+    <div class="rvt-layout__content">
+      <!-- Site or App specific Layout content -->
+    </div>
+  </main>
+  <footer class="rvt-footer-base">
+    <!-- Rivet footer markup -->
+  </footer>
+</body>
+```

--- a/src/components/layouts/README.md
+++ b/src/components/layouts/README.md
@@ -61,3 +61,9 @@ You can apply the `rvt-layout__break-out` CSS class to an element within the `rv
   </div>
 </main>
 ```
+
+### Do
+Use the break out element to call attention to an important piece or section of content.
+
+### Don't
+Use more than one or two break out elements per page layout.

--- a/src/components/layouts/README.md
+++ b/src/components/layouts/README.md
@@ -62,8 +62,15 @@ You can apply the `rvt-layout__break-out` CSS class to an element within the `rv
 </main>
 ```
 
-### Do
+### The "Feature slot" element
+The Feature slot provides a way to create an additional call out at the top of the main content column in the generic details Layout. Applying then `rvt-layout__feature-slot` CSS class to the first child of the `rvt-layout__content` element will create a space that causes running text to wrap around it and pulls the area out of the main content column.
+
+- Possible uses include a small feature illustration or image
+- Contact information for a person profile
+- An important time-sensitive call-to-action
+
+### Dos
 Use the break out element to call attention to an important piece or section of content.
 
-### Don't
+### Don'ts
 Use more than one or two break out elements per page layout.

--- a/src/components/layouts/README.md
+++ b/src/components/layouts/README.md
@@ -42,3 +42,22 @@ In addition to the base Rivet Layout elements `rvt-layout` and `rvt-layout__wrap
   </footer>
 </body>
 ```
+
+### The "Break out" element
+You can apply the `rvt-layout__break-out` CSS class to an element within the `rvt-layout__content` column to make that content break out of the main column. The breakout element is useful for elements like images and stats that you want to call out within a column of running text.
+
+```html
+<main class="rvt-layout__wrapper">
+  <div class="rvt-layout__sidebar">
+    <!-- Rivet Sidenav component -->
+  </div>
+  <div class="rvt-layout__content">
+    <!-- Site or App specific Layout content -->
+    <div class="rvt-layout__break-out">
+      <!--
+        This image will be slightly wider than the rest of the main content column
+      -->
+      <img src="...">
+  </div>
+</main>
+```

--- a/src/components/layouts/README.md
+++ b/src/components/layouts/README.md
@@ -62,10 +62,10 @@ You can apply the `rvt-layout__break-out` CSS class to an element within the `rv
 </main>
 ```
 
-### Do
+#### Do
 Use the break out element to call attention to an important piece or section of content.
 
-### Don't
+#### Don't
 Use more than one or two break out elements per page layout.
 
 ### The "Feature slot" element
@@ -74,3 +74,10 @@ The Feature slot provides a way to create an additional call out at the top of t
 - Possible uses include a small feature illustration or image
 - Contact information for a person profile
 - An important time-sensitive call-to-action
+
+#### Do
+- Use to call out important information
+- Use to add visual interest to the intro of a page with an image or illustration
+
+#### Don't
+- Use more than one Feature slot per page

--- a/src/components/layouts/README.md
+++ b/src/components/layouts/README.md
@@ -62,15 +62,15 @@ You can apply the `rvt-layout__break-out` CSS class to an element within the `rv
 </main>
 ```
 
+### Do
+Use the break out element to call attention to an important piece or section of content.
+
+### Don't
+Use more than one or two break out elements per page layout.
+
 ### The "Feature slot" element
 The Feature slot provides a way to create an additional call out at the top of the main content column in the generic details Layout. Applying then `rvt-layout__feature-slot` CSS class to the first child of the `rvt-layout__content` element will create a space that causes running text to wrap around it and pulls the area out of the main content column.
 
 - Possible uses include a small feature illustration or image
 - Contact information for a person profile
 - An important time-sensitive call-to-action
-
-### Dos
-Use the break out element to call attention to an important piece or section of content.
-
-### Don'ts
-Use more than one or two break out elements per page layout.

--- a/src/components/layouts/_page-intro-partial.njk
+++ b/src/components/layouts/_page-intro-partial.njk
@@ -1,0 +1,4 @@
+<div class="rvt-m-top-xxl rvt-m-top-md-md-up rvt-flow rvt-prose">
+  <h1>Lorem ipsum dolor sit amet consectetur adipiscing elit, sed do eiusmod tempor</h1>
+  <p class="rvt-ts-20 rvt-color-black-500">Lorem ipsum dolor sit, amet consectetur adipisicing elit. Esse exercitationem nulla inventore, velit earum explicabo voluptatibus eum. Repudiandae magni dolor facere debitis molestiae.</p>
+</div>

--- a/src/components/layouts/_prose-placeholder-partial.njk
+++ b/src/components/layouts/_prose-placeholder-partial.njk
@@ -13,6 +13,7 @@
     This is new and important!
   </div>
 </div> #}
+<h2>Intro heading</h2>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum? Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam labore ullam quia architecto nulla! Magni qui eius consequuntur fuga ipsum commodi tenetur quas, hic sed reprehenderit sapiente tempora vitae amet?</p>
 <h2>Heading 2</h2>

--- a/src/components/layouts/_prose-placeholder-partial.njk
+++ b/src/components/layouts/_prose-placeholder-partial.njk
@@ -1,17 +1,26 @@
 {# <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p> #}
-<h2>Heading 2</h2>
+<div class="rvt-layout__feature-slot">
+  <div class="rvt-card rvt-card--raised">
+    <div class="rvt-card__body">
+      <span class="rvt-ts-18 rvt-text-bold">Something about someone</span>
+      <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Dolorum qui temporibus vero quibusdam aperiam exercitationem iste odit similique labore neque, officiis pariatur beatae et ea vel tenetur ducimus fugit molestiae.</p>
+    </div>
+  </div>
+</div>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
 <ul>
   <li>List item one</li>
   <li>List item two</li>
   <li>List item three</li>
 </ul>
-<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
+<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum? Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam labore ullam quia architecto nulla! Magni qui eius consequuntur fuga ipsum commodi tenetur quas, hic sed reprehenderit sapiente tempora vitae amet?</p>
+<h2>Heading 2</h2>
+<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni aliquam quam similique cum perferendis aut sint dolore nam quibusdam recusandae quaerat ad eligendi libero ea nisi porro harum, sequi sed.</p>
 <figure class="rvt-layout__break-out">
   <img src="https://www.fillmurray.com/600/400" alt="">
   <figcaption>A caption for this image</figcaption>
 </figure>
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam labore ullam quia architecto nulla! Magni qui eius consequuntur fuga ipsum commodi tenetur quas, hic sed reprehenderit sapiente tempora vitae amet?</p>
 <h2>Heading two again</h2>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eaque, neque dolor! Repellat cupiditate architecto itaque laborum debitis, nostrum neque blanditiis officia eveniet sint numquam velit repellendus rem, aut non accusantium.</p>
 <h1>Heading one</h1>

--- a/src/components/layouts/_prose-placeholder-partial.njk
+++ b/src/components/layouts/_prose-placeholder-partial.njk
@@ -8,6 +8,11 @@
   </div>
 </div>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
+{# <div class="rvt-layout__break-out rvt-bg-crimson rvt-color-white rvt-text-center rvt-p-all-xxl">
+  <div class="rvt-ts-52 rvt-text-bold">
+    This is new and important!
+  </div>
+</div> #}
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum? Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam labore ullam quia architecto nulla! Magni qui eius consequuntur fuga ipsum commodi tenetur quas, hic sed reprehenderit sapiente tempora vitae amet?</p>
 <h2>Heading 2</h2>

--- a/src/components/layouts/_prose-placeholder-partial.njk
+++ b/src/components/layouts/_prose-placeholder-partial.njk
@@ -14,4 +14,15 @@
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam labore ullam quia architecto nulla! Magni qui eius consequuntur fuga ipsum commodi tenetur quas, hic sed reprehenderit sapiente tempora vitae amet?</p>
 <h2>Heading two again</h2>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eaque, neque dolor! Repellat cupiditate architecto itaque laborum debitis, nostrum neque blanditiis officia eveniet sint numquam velit repellendus rem, aut non accusantium.</p>
+<h1>Heading one</h1>
+<h2>Heading two</h2>
+<h3>Heading three</h3>
+<h4>Heading four</h4>
+<h5>Heading five</h5>
+<h6>Heading six</h6>
+<ol>
+  <li>Item one</li>
+  <li>Item two</li>
+  <li>Item three</li>
+</ol>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex id excepturi maiores quasi molestiae eum voluptatum ipsam quibusdam nostrum odio voluptatem reiciendis sapiente dolores, quos optio rem. Molestias, veritatis totam.</p>

--- a/src/components/layouts/_prose-placeholder-partial.njk
+++ b/src/components/layouts/_prose-placeholder-partial.njk
@@ -4,10 +4,11 @@
     <div class="rvt-card__body">
       <span class="rvt-ts-18 rvt-text-bold">Something about someone</span>
       <p>Lorem ipsum, dolor sit amet consectetur adipisicing elit. Dolorum qui temporibus vero quibusdam aperiam exercitationem iste odit similique labore neque, officiis pariatur beatae et ea vel tenetur ducimus fugit molestiae.</p>
+      <a href="#" class="rvt-cta">Important CTA</a>
     </div>
   </div>
 </div>
-<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
+<p>Lorem ipsum dolor sit amet <em>consectetur adipisicing</em> elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
 {# <div class="rvt-layout__break-out rvt-bg-crimson rvt-color-white rvt-text-center rvt-p-all-xxl">
   <div class="rvt-ts-52 rvt-text-bold">
     This is new and important!
@@ -16,6 +17,8 @@
 <h2>Intro heading</h2>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum? Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam labore ullam quia architecto nulla! Magni qui eius consequuntur fuga ipsum commodi tenetur quas, hic sed reprehenderit sapiente tempora vitae amet?</p>
+<a href="#" class="rvt-cta">Go see this CTA example</a>
+<hr>
 <h2>Heading 2</h2>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni aliquam quam similique cum perferendis aut sint dolore nam quibusdam recusandae quaerat ad eligendi libero ea nisi porro harum, sequi sed.</p>
 <figure class="rvt-layout__break-out">
@@ -26,12 +29,16 @@
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eaque, neque dolor! Repellat cupiditate architecto itaque laborum debitis, nostrum neque blanditiis officia eveniet sint numquam velit repellendus rem, aut non accusantium.</p>
 <p>Images can also be displayed in with the main text content...</p>
 <img src="https://www.fillmurray.com/600/400" alt="">
+
+<hr>
+<h2>Kitchen sink</h2>
 <h1>Heading one</h1>
 <h2>Heading two</h2>
 <h3>Heading three</h3>
 <h4>Heading four</h4>
 <h5>Heading five</h5>
 <h6>Heading six</h6>
+<p>A paragraph Lorem ipsum dolor sit amet consectetur, adipisicing elit. Deleniti sapiente ab pariatur quia ducimus commodi sunt nam praesentium magnam error porro, minima accusantium magni exercitationem repellendus accusamus itaque cumque enim.</p>
 <ul>
   <li>List item one</li>
   <li>List item two</li>
@@ -42,4 +49,12 @@
   <li>Item two</li>
   <li>Item three</li>
 </ol>
-<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex id excepturi maiores quasi molestiae eum voluptatum ipsam quibusdam nostrum odio voluptatem reiciendis sapiente dolores, quos optio rem. Molestias, veritatis totam.</p>
+<dl>
+  <dt>Definition list item one</dt>
+  <dd>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</dd>
+  <dd>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</dd>
+  <dt>Definition list item two</dt>
+  <dd>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</dd>
+  <dt>Definition list item three</dt>
+  <dd>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</dd>
+</dl>

--- a/src/components/layouts/_prose-placeholder-partial.njk
+++ b/src/components/layouts/_prose-placeholder-partial.njk
@@ -8,27 +8,29 @@
   </div>
 </div>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
-<ul>
-  <li>List item one</li>
-  <li>List item two</li>
-  <li>List item three</li>
-</ul>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum? Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam labore ullam quia architecto nulla! Magni qui eius consequuntur fuga ipsum commodi tenetur quas, hic sed reprehenderit sapiente tempora vitae amet?</p>
 <h2>Heading 2</h2>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Magni aliquam quam similique cum perferendis aut sint dolore nam quibusdam recusandae quaerat ad eligendi libero ea nisi porro harum, sequi sed.</p>
 <figure class="rvt-layout__break-out">
   <img src="https://www.fillmurray.com/600/400" alt="">
-  <figcaption>A caption for this image</figcaption>
+  <figcaption>This is a break out content area with an image</figcaption>
 </figure>
 <h2>Heading two again</h2>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eaque, neque dolor! Repellat cupiditate architecto itaque laborum debitis, nostrum neque blanditiis officia eveniet sint numquam velit repellendus rem, aut non accusantium.</p>
+<p>Images can also be displayed in with the main text content...</p>
+<img src="https://www.fillmurray.com/600/400" alt="">
 <h1>Heading one</h1>
 <h2>Heading two</h2>
 <h3>Heading three</h3>
 <h4>Heading four</h4>
 <h5>Heading five</h5>
 <h6>Heading six</h6>
+<ul>
+  <li>List item one</li>
+  <li>List item two</li>
+  <li>List item three</li>
+</ul>
 <ol>
   <li>Item one</li>
   <li>Item two</li>

--- a/src/components/layouts/_prose-placeholder-partial.njk
+++ b/src/components/layouts/_prose-placeholder-partial.njk
@@ -1,0 +1,6 @@
+<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
+<h2>Heading 2</h2>
+<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
+<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
+<h2>Heading two again</h2>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eaque, neque dolor! Repellat cupiditate architecto itaque laborum debitis, nostrum neque blanditiis officia eveniet sint numquam velit repellendus rem, aut non accusantium.</p>

--- a/src/components/layouts/_prose-placeholder-partial.njk
+++ b/src/components/layouts/_prose-placeholder-partial.njk
@@ -1,6 +1,17 @@
-<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
+{# <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p> #}
 <h2>Heading 2</h2>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
+<ul>
+  <li>List item one</li>
+  <li>List item two</li>
+  <li>List item three</li>
+</ul>
 <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Incidunt earum, ipsa tempora quas nostrum id enim doloremque inventore doloribus vitae quasi? Sed, dolores. Magnam nesciunt quidem cum. Rem, ullam illum?</p>
+<figure class="rvt-layout__break-out">
+  <img src="https://www.fillmurray.com/600/400" alt="">
+  <figcaption>A caption for this image</figcaption>
+</figure>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam labore ullam quia architecto nulla! Magni qui eius consequuntur fuga ipsum commodi tenetur quas, hic sed reprehenderit sapiente tempora vitae amet?</p>
 <h2>Heading two again</h2>
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Eaque, neque dolor! Repellat cupiditate architecto itaque laborum debitis, nostrum neque blanditiis officia eveniet sint numquam velit repellendus rem, aut non accusantium.</p>
+<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex id excepturi maiores quasi molestiae eum voluptatum ipsam quibusdam nostrum odio voluptatem reiciendis sapiente dolores, quos optio rem. Molestias, veritatis totam.</p>

--- a/src/components/layouts/layouts.config.yml
+++ b/src/components/layouts/layouts.config.yml
@@ -1,4 +1,5 @@
 title: "Layouts"
+status: "wip"
 preview: '@preview-no-padding'
 context:
   cards:

--- a/src/components/sidenav/sidenav.njk
+++ b/src/components/sidenav/sidenav.njk
@@ -11,7 +11,7 @@
     </li>
     <li class="rvt-sidenav__item">
       <div class="rvt-sidenav__item-wrapper">
-        <a href="#" class="rvt-sidenav__link" aria-current="page">Section nav two (with some extra text for wrapping)</a>
+        <a href="#" class="rvt-sidenav__link" aria-current="page">Section nav two</a>
         <button href="#" class="rvt-sidenav__toggle" data-rvt-sidenav-toggle="toggle-1">
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
               <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>

--- a/src/sass/breadcrumb/_base.scss
+++ b/src/sass/breadcrumb/_base.scss
@@ -14,12 +14,11 @@
     margin-top: 0;
     margin-right: $spacing-xs;
     font-size: $ts-14;
-    line-height: 1;
 
     &::before {
       content: '/';
       padding-right: $spacing-xs;
-      color: #bbbbbb;
+      color: $color-black-200;
     }
 
     a {
@@ -51,11 +50,5 @@
     li:last-child {
       color: $color-black-700;
     }
-  }
-}
-
-@include mq($breakpoint-md) {
-  .#{$prefix}-breadcrumbs li {
-    font-size: $ts-base;
   }
 }

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -6,6 +6,13 @@
 html {
   font-size: 100%;
   height: 100%;
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion) {
+  html {
+    scroll-behavior: auto;
+  }
 }
 
 html * {

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -51,3 +51,19 @@ hr {
   border: none;
   background-color: $color-black-100;
 }
+
+img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+figure {
+  margin: 0;
+}
+
+figcaption {
+  padding-top: $spacing-sm;
+  padding-left: $spacing-sm;
+  font-size: $ts-14;
+}

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -67,3 +67,11 @@ figcaption {
   padding-left: $spacing-sm;
   font-size: $ts-14;
 }
+
+em {
+  font-style: italic;
+}
+
+strong {
+  font-weight: $font-weight-bold;
+}

--- a/src/sass/grid/_base.scss
+++ b/src/sass/grid/_base.scss
@@ -52,7 +52,8 @@ $gutter: $spacing-md / 2;
 @mixin row {
   display: flex;
   flex-wrap: wrap;
-  margin: 0 ($gutter/-1);
+  margin-right: ($gutter/-1);
+  margin-left: ($gutter/-1);
 }
 
 /**

--- a/src/sass/grid/_base.scss
+++ b/src/sass/grid/_base.scss
@@ -28,10 +28,10 @@ $row-columns: (
 // like, .row--yournewsize.
 
 $row-widths: (
-  'sm': 640px,
-  'md': 1024px,
-  'lg': 1140px,
-  'xl': 1380px
+  'sm': (840/16) * 1rem,
+  'md': (1024/16) * 1rem,
+  'lg': (1140/16) * 1rem,
+  'xl': (1380/16) * 1rem
 );
 
 // Global grid gutter. Set this to half of what you want the final gutter to be.

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -85,11 +85,3 @@
     }
   }
 }
-
-@include mq($breakpoint-xxl) {
-  .rvt-layout {
-    &__feature-slot {
-      margin-right: -$spacing-3-xl;
-    }
-  }
-}

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -1,0 +1,39 @@
+@use '../core' as *;
+
+.rvt-layout {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  &__wrapper {
+    flex-grow: 1;
+    width: 100%;
+    display: flex;
+    flex-direction: column-reverse;
+  }
+}
+
+@include mq($breakpoint-md) {
+  .rvt-layout {
+    &__wrapper {
+      flex-direction: row;
+    }
+
+    &__sidebar {
+      flex-basis: $width-md;
+      max-width: $width-md;
+      flex-grow: 1;
+      flex-shrink: 0;
+      padding-top: $spacing-xxl;
+    }
+
+    &__content {
+      flex-grow: 1;
+      border-left: 1px solid $color-black-100;
+      padding-top: $spacing-xxl;
+      padding-left: $spacing-xxl;
+      // padding-right: $spacing-xxl;
+      padding-bottom: $spacing-xxl;
+    }
+  }
+}

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -65,3 +65,31 @@
     }
   }
 }
+
+@include mq($breakpoint-xl) {
+  .rvt-layout {
+    &__break-out {
+      margin-right: -$spacing-xxl;
+    }
+
+    &__feature-slot {
+      margin-right: -$spacing-xxl;
+      float: right;
+      width: $width-xl;
+      margin-bottom: $spacing-lg;
+      margin-left: $spacing-lg;
+    }
+
+    &__feature-slot + * {
+      margin-top: 0;
+    }
+  }
+}
+
+@include mq($breakpoint-xxl) {
+  .rvt-layout {
+    &__feature-slot {
+      margin-right: -$spacing-3-xl;
+    }
+  }
+}

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -8,8 +8,27 @@
   &__wrapper {
     flex-grow: 1;
     width: 100%;
+  }
+
+  &__wrapper--cols-2 {
     display: flex;
     flex-direction: column-reverse;
+  }
+
+  &__content {
+    padding-top: $spacing-lg;
+    padding-bottom: $spacing-lg;
+  }
+
+  &__break-out {
+    margin-right: -$spacing-md;
+    margin-left: -$spacing-md;
+  }
+
+  &__sidebar {
+    padding-top: $spacing-lg;
+    padding-bottom: $spacing-lg;
+    border-top: 1px solid $color-black-100;
   }
 }
 
@@ -24,16 +43,20 @@
       max-width: $width-md;
       flex-grow: 1;
       flex-shrink: 0;
-      padding-top: $spacing-xxl;
+      padding-top: $spacing-xxl * 1.5;
+      border-top: none;
+      border-right: 1px solid $color-black-100;
     }
 
     &__content {
       flex-grow: 1;
-      border-left: 1px solid $color-black-100;
-      padding-top: $spacing-xxl;
+      padding-top: $spacing-xxl * 1.5;
       padding-left: $spacing-xxl;
-      // padding-right: $spacing-xxl;
       padding-bottom: $spacing-xxl;
+    }
+
+    &__break-out {
+      margin-left: -$spacing-xxl;
     }
   }
 }

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -58,5 +58,10 @@
     &__break-out {
       margin-left: -$spacing-xxl;
     }
+
+    &__break-out,
+    &__break-out + * {
+      --flow-space: 3rem;
+    }
   }
 }

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -20,6 +20,10 @@
     padding-bottom: $spacing-lg;
   }
 
+  &__wrapper--single &__content {
+    padding-left: 0;
+  }
+
   &__break-out {
     margin-right: -$spacing-md;
     margin-left: -$spacing-md;
@@ -63,6 +67,10 @@
     &__break-out + * {
       --flow-space: 3rem;
     }
+
+    &__wrapper--single &__break-out {
+      margin-left: -$spacing-md;
+    }
   }
 }
 
@@ -70,6 +78,10 @@
   .rvt-layout {
     &__break-out {
       margin-right: -$spacing-xxl;
+    }
+
+    &__wrapper--single &__break-out {
+      margin-left: -$spacing-xxl;
     }
 
     &__feature-slot {

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -10,7 +10,7 @@
     width: 100%;
   }
 
-  &__wrapper--cols-2 {
+  &__wrapper--details {
     display: flex;
     flex-direction: column-reverse;
   }

--- a/src/sass/layout/_index.scss
+++ b/src/sass/layout/_index.scss
@@ -1,0 +1,1 @@
+@forward 'base';

--- a/src/sass/rivet.scss
+++ b/src/sass/rivet.scss
@@ -30,6 +30,7 @@
 @use 'header-system';
 @use 'input-group';
 @use 'inputs';
+@use 'layout';
 @use 'links';
 @use 'lists';
 @use 'loading-indicator';

--- a/src/sass/utilities/_flow.scss
+++ b/src/sass/utilities/_flow.scss
@@ -14,6 +14,7 @@
 // consistent vertical space.
 
 .rvt-flow > * + * {
+  margin-top: 1rem; // Fallback for browsers that don't support var()
   margin-top: var(--flow-space, 1rem);
   margin-bottom: 0;
 }

--- a/src/sass/utilities/_index.scss
+++ b/src/sass/utilities/_index.scss
@@ -4,6 +4,7 @@
 @forward 'elements';
 @forward 'flex';
 @forward 'flow';
+@forward 'prose';
 @forward 'spacing';
 @forward 'text';
 @forward 'type-scale';

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -36,4 +36,11 @@
     font-weight: $font-weight-bold;
     line-height: 1.2;
   }
+
+  > img,
+  > img + *,
+  > figure,
+  > figure + * {
+    --flow-space: 3rem;
+  }
 }

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -37,7 +37,12 @@
   > img,
   > img + *,
   > figure,
-  > figure + * {
+  > figure + *,
+  > hr {
     --flow-space: 3rem;
+  }
+
+  > *:empty:not(hr) {
+    display: none;
   }
 }

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -5,15 +5,15 @@
     font-size: $ts-32;
   }
 
-  /**
-   * We RARELY ever get down into the h4-6 area, so I say
-   * just let the browser take care of those sizes and we'll
-   * set the font-weight. See below.
-   */
-
   h2,
   h3 {
     font-size: $ts-23;
+  }
+
+  h4,
+  h5,
+  h6 {
+    font-size: $ts-20;
   }
 
   h1,

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -1,13 +1,7 @@
 @use '../core' as *;
 
 .rvt-prose {
-  // Fall back for browsers that do not support the "ch" (character) unit.
-  max-width: 760px;
 
-  /**
-   * Constrain prose/longer-form copy to a readable, user-friendly line length.
-   */
-  max-width: 75ch;
 
   h1 {
     font-size: $ts-32;

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -1,8 +1,6 @@
 @use '../core' as *;
 
 .rvt-prose {
-
-
   h1 {
     font-size: $ts-32;
   }

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -27,6 +27,7 @@
 
     font-weight: $font-weight-bold;
     line-height: 1.2;
+    scroll-margin-top: $spacing-md;
   }
 
   > img,

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -1,6 +1,10 @@
 @use '../core' as *;
 
 .rvt-prose {
+  // Benton sans feels really compact and can benefit from a little extra
+  // line-height here.
+  line-height: 1.65;
+
   h1 {
     font-size: $ts-32;
   }

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -1,0 +1,39 @@
+@use '../core' as *;
+
+.rvt-prose {
+  // Fall back for browsers that do not support the "ch" (character) unit.
+  max-width: 760px;
+
+  /**
+   * Constrain prose/longer-form copy to a readable, user-friendly line length.
+   */
+  max-width: 75ch;
+
+  h1 {
+    font-size: $ts-32;
+  }
+
+  /**
+   * We RARELY ever get down into the h4-6 area, so I say
+   * just let the browser take care of those sizes and we'll
+   * set the font-weight. See below.
+   */
+
+  h2,
+  h3 {
+    font-size: $ts-23;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    // Reset the flow space here to put more space before headings.
+    --flow-space: 3rem;
+
+    font-weight: $font-weight-bold;
+    line-height: 1.2;
+  }
+}


### PR DESCRIPTION
This PR adds the basic shell for the the "details" layout. This will be the basis for a handful of other more specific layouts like a people profiles and articles. I wanted to break this up into a bit smaller PRs, so this only implements the basics. We can tackle more specific layouts like the person profile, and new/blog post in additional PRs.

- Implemented a base layout element creates a basic `rvt-layout` shell. This will be the basis from which we build additional layouts.
- The `rvt-layout` class is applied to the `body` and the child `rvt-layout__wrapper` class is applied to the `main` element. In this most simple form it creates a layout that pushes the footer to the bottom of the viewport if there is not enough page content to do so.
- Additional layout elements/CSS classes include `rvt-layout__sidebar` and `rvt-layout__content`. These two elements live as children of the `main.rvt-layout__wrapper` element to create the two-column "generic details" layout.
- Lastly there is a `rvt-layout__break-out` utility that can be used to pull feature content out of the main content column in the generic details layout (see /components/detail/generic-details-page) for a demo.