### PR TITLE
Updated sidenav API to accept toggle ID rather than element

### DIFF
--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -109,7 +109,7 @@ export default class Sidenav extends Component {
           return;
         }
 
-        const openEvent = Component.dispatchCustomEvent('sidenavListOpen', toggle, {
+        const openEvent = Component.dispatchCustomEvent('sidenavListOpened', toggle, {
           id: toggleId
         });
     
@@ -130,8 +130,8 @@ export default class Sidenav extends Component {
           console.warn(`No such toggle '${toggleId}' in Sidenav.close()`);
           return;
         }
-        // FIXME: Changed to sidenavListClosed to match tense of other events
-        const closeEvent = Component.dispatchCustomEvent('sidenavListClose', toggle, {
+
+        const closeEvent = Component.dispatchCustomEvent('sidenavListClosed', toggle, {
           id: toggleId
         });
     

--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -92,30 +92,52 @@ export default class Sidenav extends Component {
         }
     
         targetList.hasAttribute('hidden')
-          ? this.open(toggleButton, targetList)
-          : this.close(toggleButton, targetList);
+          ? this.open(toggleId)
+          : this.close(toggleId);
       },
 
-      open(toggleButton, targetList) {
-        const openEvent = Component.dispatchCustomEvent('sidenavListOpen', toggleButton, {
-          id: toggleButton.dataset.rvtSidenavToggle
+      open(toggleId) {
+        const toggle = this.element.querySelector(
+          `[${this.toggleAttribute}="${toggleId}"]`
+        );
+        const targetList = this.element.querySelector(
+          `[${this.listAttribute}="${toggleId}"]`
+        );
+
+        if (!toggle || !targetList) {
+          console.warn(`No such toggle '${toggleId}' in Sidenav.open()`);
+          return;
+        }
+
+        const openEvent = Component.dispatchCustomEvent('sidenavListOpen', toggle, {
+          id: toggleId
         });
     
         if (!openEvent) return;
     
-        toggleButton.setAttribute('aria-expanded', 'true');
+        toggle.setAttribute('aria-expanded', 'true');
         targetList.removeAttribute('hidden');
       },
     
-      close(toggleButton, targetList) {
+      close(toggleId) {
+        const toggle = this.element.querySelector(
+          `[${this.toggleAttribute}="${toggleId}"]`
+        );
+        const targetList = this.element.querySelector(
+          `[${this.listAttribute}="${toggleId}"]`
+        );
+        if (!toggle || !targetList) {
+          console.warn(`No such toggle '${toggleId}' in Sidenav.close()`);
+          return;
+        }
         // FIXME: Changed to sidenavListClosed to match tense of other events
-        const closeEvent = Component.dispatchCustomEvent('sidenavListClose', toggleButton, {
-          id: toggleButton.dataset.rvtSidenavToggle
+        const closeEvent = Component.dispatchCustomEvent('sidenavListClose', toggle, {
+          id: toggleId
         });
     
         if (!closeEvent) return;
     
-        toggleButton.setAttribute('aria-expanded', 'false');
+        toggle.setAttribute('aria-expanded', 'false');
         targetList.setAttribute('hidden', '');
       }
     }


### PR DESCRIPTION
You used to have to pass the entire toggle element to `open`/`close` fetched via `querySelector`. This PR changes the sidenav API where you now only have to pass the toggle element ID. This will make client code simpler.

- `open(toggleId)`
- `close(toggleId)`

There's some refactoring we'll need to do in the near future to reduce some duplication in the sidenav source file.