### PR TITLE
Fixed issue where Sidenav current indicator was causing links to shift on nested lists of links

### DIFF
--- a/src/components/sidenav/sidenav.njk
+++ b/src/components/sidenav/sidenav.njk
@@ -21,7 +21,7 @@
       <ul class="rvt-sidenav__list" data-rvt-sidenav-list="toggle-1">
         <li class="rvt-sidenav__item">
           <div class="rvt-sidenav__item-wrapper">
-            <a href="#" class="rvt-sidenav__link">Level two</a>
+            <a href="#" class="rvt-sidenav__link" aria-current="page">Level two</a>
             <button class="rvt-sidenav__toggle" data-rvt-sidenav-toggle="toggle-2">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
                   <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -49,11 +49,6 @@
     flex-basis: 100%;
   }
 
-  &__item &__item &__link {
-    padding-top: $spacing-xxs * 1.2;
-    padding-bottom: $spacing-xxs * 1.2;
-  }
-
   &__link {
     font-size: $ts-14;
     color: $color-black-base;
@@ -62,11 +57,22 @@
     padding-right: $spacing-xs;
     padding-bottom: $spacing-xs;
     padding-left: $spacing-sm;
+    position: relative;
     text-decoration: none;
 
     &[aria-current] {
-      box-shadow: inset $spacing-xxs 0 0 $color-crimson-base;
       background-color: $color-black-000;
+    }
+
+    &[aria-current]::before {
+      content: '';
+      display: block;
+      width: .25rem;
+      height: 100%;
+      background-color: $color-crimson-base;
+      position: absolute;
+      top: 0;
+      left: 0;
     }
 
     &:focus,
@@ -74,6 +80,15 @@
       color: $color-blue-base;
       text-decoration: underline;
     }
+  }
+
+  &__item &__item &__link {
+    padding-top: $spacing-xxs * 1.2;
+    padding-bottom: $spacing-xxs * 1.2;
+  }
+
+  &__item > &__list &__link[aria-current]::before {
+    margin-left: -$spacing-xxs;
   }
 
   &__link[aria-current] + &__toggle {
@@ -84,14 +99,6 @@
   &__link[aria-current] + &__toggle:focus {
     color: $color-black-600;
     background-color: $color-black-100;
-  }
-
-  /**
-   * Pulls back alignment of current state for nested links
-   */
-
-  &__item > &__list &__link[aria-current] {
-    margin-left: -$spacing-xxs;
   }
 
   &__toggle {


### PR DESCRIPTION
Links that are in nested menus were shifting based on margin applied to links with the `aria-current` attribute. This pr reworks the way current states are displayed in the Sidenav to use the `::before` pseudo element instead of an inset box shadow. 