### PR TITLE
Updated accordion and tabs APIs to accept panel ID instead of element

### DIFF
--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -86,7 +86,7 @@ If you use the appropriate data attribute/id combination in your markup, modals 
 
 | Method                      | Description                                                                                                                      |
 | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| .activateTab(tab, callback) | - `tab` - The element to be activated. - `callback` - An optional callback function that is executed after the tab is activated. |
+| .activateTab(tabId) | `tabId` - The value of the `data-rvt-tab-panel` attribute of the tab to activate. |
 | .destroy()                  | Adds the built-in event listeners to the tab component.                                                                          |
 | .init()                     | Removes all built-in event listeners from the tab component.                                                                     |
 

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -57,7 +57,7 @@ export default class Accordion extends Component {
           });
     
           // If a specific panel was initialized set this.openOnInit equal to it, otherwise fallback to the first panel
-          this.openOnInit = initialPanel;
+          this.openOnInit = initialPanel.getAttribute(this.panelAttribute);
         } catch (e) {
           console.warn(
             'Only one accordion panel should have the data-rvt-accordion-panel-init attribute. If you wish to open all panels on initialization, please apply the appropriate attribute to the data-rvt-accordion element'
@@ -94,12 +94,12 @@ export default class Accordion extends Component {
         // If accordion is set to open all panels on init, open them
         if (this.openAllOnInit === true) {
           this.panels.forEach(panel => {
-            this.open(panel);
+            this.open(panel.getAttribute(this.panelAttribute));
           });
         } else {
           // Keep all other accordions closed by setting their initial states
           this.panels.forEach((panel, index) => {
-            if (panel !== this.openOnInit) {
+            if (panel.getAttribute(this.panelAttribute) !== this.openOnInit) {
               // Set non-initialized accordion panels to hidden
               this.panels[index].setAttribute('hidden', '');
               const trigger = this.element.querySelector(
@@ -125,15 +125,10 @@ export default class Accordion extends Component {
           this.triggerAttribute
         );
     
-        // Get the associated panel
-        const currentPanel = this.element.querySelector(
-          `[${this.panelAttribute}="${currentTriggerValue}"]`
-        );
-    
         // Open or close accordion
         currentTrigger.getAttribute('aria-expanded') === 'true'
-          ? this.close(currentPanel)
-          : this.open(currentPanel);
+          ? this.close(currentTriggerValue)
+          : this.open(currentTriggerValue);
       },
 
       _handleKeydown(event) {
@@ -190,8 +185,15 @@ export default class Accordion extends Component {
         }
       },
 
-      open(panel) {
-        // Trigger accordionOpened custom event. This event is used open accordion panels.
+      open(panelId) {
+        const panel = this.element.querySelector(
+          `[${this.panelAttribute}="${panelId}"]`
+        );
+
+        if (!panel) {
+          console.warn(`No such panel '${panelId}' in Accordion.open()`);
+          return;
+        }
     
         const activationEvent = Component.dispatchCustomEvent(
           'accordionOpened',
@@ -214,8 +216,15 @@ export default class Accordion extends Component {
         trigger.setAttribute('aria-expanded', 'true');
       },
 
-      close(panel) {
-        // Trigger accordionClosed custom event. This event is used to control the process of closing accordion panels.
+      close(panelId) {
+        const panel = this.element.querySelector(
+          `[${this.panelAttribute}="${panelId}"]`
+        );
+
+        if (!panel) {
+          console.warn(`No such panel '${panelId}' in Accordion.close()`);
+          return;
+        }
     
         const activationEvent = Component.dispatchCustomEvent(
           'accordionClosed',

--- a/src/js/components/tabs.js
+++ b/src/js/components/tabs.js
@@ -39,7 +39,9 @@ export default class Tabs extends Component {
         });
 
         // If a specific panel was initialized set this.openOnInit equal to it, otherwise fallback to the first panel
-        this.openOnInit = initialPanel || this.panels[0];
+        this.openOnInit = initialPanel.getAttribute(this.panelAttribute) || this.panels[0].getAttribute(this.panelAttribute);
+
+        console.log(this.openOnInit);
 
         // bind methods
         Component.bindMethodToDOMElement(this, 'activateTab', this.activateTab);
@@ -70,15 +72,10 @@ export default class Tabs extends Component {
         if (!currentTab) return;
     
         // Get the data-rvt-tab value
-        const currentTabValue = currentTab.getAttribute(this.tabAttribute);
-    
-        // Get the associated panel
-        const currentPanel = this.element.querySelector(
-          `[${this.panelAttribute}="${currentTabValue}"]`
-        );
+        const tabId = currentTab.getAttribute(this.tabAttribute);
     
         // Activate tab
-        this.activateTab(currentPanel);
+        this.activateTab(tabId);
       },
 
       _handleKeydown(event) {
@@ -131,9 +128,15 @@ export default class Tabs extends Component {
         }
       },
 
-      activateTab(tab) {
-        // Trigger tabActivated custom event. This event is used to control the process of switching between tabs.
-        console.log(this.element);
+      activateTab(tabId) {
+        const tab = this.element.querySelector(
+          `[${this.panelAttribute}="${tabId}"]`
+        );
+
+        if (!tab) {
+          console.warn(`No such tab '${tabId}' in Tabs.activateTab()`);
+          return;
+        }
 
         const activationEvent = Component.dispatchCustomEvent(
           'tabActivated',


### PR DESCRIPTION
This PR updates the accordion and tabs APIs to accept a panel ID string instead of the target panel element in `open()`, `close()`, and `activateTab()`. This brings these components in line with how the sidenav API is set up.

I haven't done any code cleanup or refactoring -- this PR just includes the bare minimum to get the new API to function. I'll come back and clean up the component source files in a later PR.