### PR TITLE
Added missing integration tests for component API methods

### DIFF
--- a/cypress/integration/accordion_spec.js
+++ b/cypress/integration/accordion_spec.js
@@ -81,4 +81,30 @@ describe('Keyboard interactions', function () {
     cy.get('@trigger4').type('{home}');
     cy.get('@trigger1').should('to.have.focus');
   });
+
+  it('Should be able to open a panel with the .open() method', function() {
+    cy.window().then(win => {
+      var accordion = win.document.querySelector('[data-rvt-accordion="my-new-accordion"]');
+      accordion.open('my-new-accordion-1');
+    });
+
+    cy.get('[data-rvt-accordion-trigger="my-new-accordion-1"]').should('have.attr', 'aria-expanded', 'true');
+
+    cy.get('[data-rvt-accordion-panel="my-new-accordion-1"]')
+      .should('be.visible')
+      .and('not.have.attr', 'hidden');
+  });
+
+  it('Should be able to close a panel with the .close() method', function() {
+    cy.window().then(win => {
+      var accordion = win.document.querySelector('[data-rvt-accordion="my-new-accordion"]');
+      accordion.close('my-new-accordion-1');
+    });
+
+    cy.get('[data-rvt-accordion-trigger="my-new-accordion-1"]').should('have.attr', 'aria-expanded', 'false');
+
+    cy.get('[data-rvt-accordion-panel="my-new-accordion-1"]')
+      .should('not.be.visible')
+      .and('have.attr', 'hidden');
+  });
 });

--- a/cypress/integration/modal_spec.js
+++ b/cypress/integration/modal_spec.js
@@ -82,6 +82,29 @@ describe('Rivet basic modal interactions', function () {
     cy.get('@modal').should('not.be.visible');
   });
 
+  // .focusTrigger()
+
+  it('Should be able to focus on the modal trigger with the .focusTrigger() method', function() {
+    cy.window().then(win => {
+      var modal = win.document.querySelector('[data-rvt-modal="modalExample"]');
+      modal.focusTrigger();
+    });
+
+    cy.get('[data-rvt-modal-trigger="modalExample"]').should('be.focused');
+  });
+
+  // .focusModal()
+
+  it('Should be able to focus on the modal with the .focusModal() method', function() {
+    cy.window().then(win => {
+      var modal = win.document.querySelector('[data-rvt-modal="modalExample"]');
+      modal.open();
+      modal.focusModal();
+    });
+
+    cy.get('[data-rvt-modal="modalExample"]').should('be.focused');
+  });
+
 });
 
 describe('Rivet dialog modal interactions', function () {

--- a/cypress/integration/modal_spec.js
+++ b/cypress/integration/modal_spec.js
@@ -82,8 +82,6 @@ describe('Rivet basic modal interactions', function () {
     cy.get('@modal').should('not.be.visible');
   });
 
-  // .focusTrigger()
-
   it('Should be able to focus on the modal trigger with the .focusTrigger() method', function() {
     cy.window().then(win => {
       var modal = win.document.querySelector('[data-rvt-modal="modalExample"]');
@@ -92,8 +90,6 @@ describe('Rivet basic modal interactions', function () {
 
     cy.get('[data-rvt-modal-trigger="modalExample"]').should('be.focused');
   });
-
-  // .focusModal()
 
   it('Should be able to focus on the modal with the .focusModal() method', function() {
     cy.window().then(win => {

--- a/cypress/integration/tabs_spec.js
+++ b/cypress/integration/tabs_spec.js
@@ -50,4 +50,13 @@ describe('Rivet tab interactions', function () {
     cy.get('@panel2').should('not.be.visible');
     cy.get('@panel3').should('not.be.visible');
   });
+
+  it('Should be able to activate a tab with the .activateTab() method', function() {
+    cy.window().then(win => {
+      var tabs = win.document.querySelector('[data-rvt-tabs="tabset-1"]');
+      tabs.activateTab('tab-2');
+    });
+
+    cy.get('[data-rvt-tab-panel="tab-2"]').should('be.visible').should('not.have.attr', 'hidden');
+  });
 });


### PR DESCRIPTION
This PR adds integration tests for the following component API methods:

- `Accordion.open()`
- `Accordion.close()`
- `Modal.focusTrigger()`
- `Modal.focusModal()`
- `Tabs.activateTab()`