### PR TITLE
Fixed issue where non-breaking content cause main content area to overflow

### DIFF
--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -16,6 +16,8 @@
   }
 
   &__content {
+    // This stops some overflow issues if non-breaking content starts to overflow.
+    min-width: 0;
     padding-top: $spacing-lg;
     padding-bottom: $spacing-lg;
   }


### PR DESCRIPTION
This is a small fix that we've implemented as a patch once we noticed it using `2.0.0-alpha.5` on the v2 docs site. 