### PR TITLE
Updated component custom events API

### DIFF
--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -196,10 +196,8 @@ export default class Accordion extends Component {
     
         const activationEvent = Component.dispatchCustomEvent(
           'accordionOpened',
-          panel,
-          {
-            id: panel.dataset.rvtAccordionPanel
-          }
+          this.element,
+          { panel }
         );
     
         if (!activationEvent) return;
@@ -227,10 +225,8 @@ export default class Accordion extends Component {
     
         const activationEvent = Component.dispatchCustomEvent(
           'accordionClosed',
-          panel,
-          {
-            id: panel.dataset.rvtAccordionPanel
-          }
+          this.element,
+          { panel }
         );
     
         if (!activationEvent) return;

--- a/src/js/components/alert.js
+++ b/src/js/components/alert.js
@@ -43,10 +43,7 @@ export default class Alert extends Component {
       dismiss() {
         const dismissEvent = Component.dispatchCustomEvent(
           'alertDismissed',
-          this.element,
-          {
-            id: this.element.dataset.rvtAlert
-          }
+          this.element
         );
     
         if (!dismissEvent) return;

--- a/src/js/components/alert.js
+++ b/src/js/components/alert.js
@@ -42,7 +42,7 @@ export default class Alert extends Component {
     
       dismiss() {
         const dismissEvent = Component.dispatchCustomEvent(
-          'alertDismiss',
+          'alertDismissed',
           this.element,
           {
             id: this.element.dataset.rvtAlert

--- a/src/js/components/component.js
+++ b/src/js/components/component.js
@@ -27,7 +27,7 @@ export default class Component {
     });
   }
 
-  static dispatchCustomEvent(eventName, element, detail) {
+  static dispatchCustomEvent(eventName, element, detail = {}) {
     const prefix = globalSettings.prefix;
     const event = new CustomEvent(`${prefix}:${eventName}`, {
       bubbles: true,

--- a/src/js/components/disclosure.js
+++ b/src/js/components/disclosure.js
@@ -56,7 +56,7 @@ export default class Disclosure extends Component {
           'disclosureOpened',
           this.toggleElement,
           {
-            id: this.toggleElement.dataset['rvtDisclosureToggle']
+            id: this.toggleElement.dataset.rvtDisclosureToggle
           }
         );
 
@@ -90,7 +90,7 @@ export default class Disclosure extends Component {
           'disclosureClosed',
           this.toggleElement,
           {
-            id: this.toggleElement.dataset['rvtDisclosureToggle']
+            id: this.toggleElement.dataset.rvtDisclosureToggle
           }
         );
 

--- a/src/js/components/disclosure.js
+++ b/src/js/components/disclosure.js
@@ -50,14 +50,11 @@ export default class Disclosure extends Component {
           return;
         }
 
-        // Fire a disclosureOpen event
+        // Fire a disclosureOpened event
 
         const openEvent = Component.dispatchCustomEvent(
           'disclosureOpened',
-          this.toggleElement,
-          {
-            id: this.toggleElement.dataset.rvtDisclosureToggle
-          }
+          this.element
         );
 
         // Bail if the event was suppressed

--- a/src/js/components/disclosure.js
+++ b/src/js/components/disclosure.js
@@ -56,7 +56,7 @@ export default class Disclosure extends Component {
           'disclosureOpen',
           this.toggleElement,
           {
-            id: this.toggleElement.dataset['toggle']
+            id: this.toggleElement.dataset['rvtDisclosureToggle']
           }
         );
 
@@ -90,7 +90,7 @@ export default class Disclosure extends Component {
           'disclosureClose',
           this.toggleElement,
           {
-            id: this.toggleElement.dataset['toggle']
+            id: this.toggleElement.dataset['rvtDisclosureToggle']
           }
         );
 

--- a/src/js/components/disclosure.js
+++ b/src/js/components/disclosure.js
@@ -53,7 +53,7 @@ export default class Disclosure extends Component {
         // Fire a disclosureOpen event
 
         const openEvent = Component.dispatchCustomEvent(
-          'disclosureOpen',
+          'disclosureOpened',
           this.toggleElement,
           {
             id: this.toggleElement.dataset['rvtDisclosureToggle']
@@ -87,7 +87,7 @@ export default class Disclosure extends Component {
         if (!this.activeToggle) return;
 
         const closeEvent = Component.dispatchCustomEvent(
-          'disclosureClose',
+          'disclosureClosed',
           this.toggleElement,
           {
             id: this.toggleElement.dataset['rvtDisclosureToggle']

--- a/src/js/components/disclosure.js
+++ b/src/js/components/disclosure.js
@@ -88,10 +88,7 @@ export default class Disclosure extends Component {
 
         const closeEvent = Component.dispatchCustomEvent(
           'disclosureClosed',
-          this.toggleElement,
-          {
-            id: this.toggleElement.dataset.rvtDisclosureToggle
-          }
+          this.element
         );
 
         if (!closeEvent) return;

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -74,10 +74,7 @@ export default class Dropdown extends Component {
 
         const openEvent = Component.dispatchCustomEvent(
           'dropdownOpened',
-          this.toggleElement,
-          {
-            id: this.toggleElement.dataset['toggle']
-          }
+          this.element
         );
 
         // Bail if the event was suppressed
@@ -108,10 +105,7 @@ export default class Dropdown extends Component {
 
         const closeEvent = Component.dispatchCustomEvent(
           'dropdownClosed',
-          this.toggleElement,
-          {
-            id: this.toggleElement.dataset['toggle']
-          }
+          this.element
         );
 
         if (!closeEvent) return;

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -70,10 +70,10 @@ export default class Dropdown extends Component {
           return;
         }
 
-        // Fire a disclosureOpen event
+        // Fire a dropdownOpened event
 
         const openEvent = Component.dispatchCustomEvent(
-          'disclosureOpen',
+          'dropdownOpened',
           this.toggleElement,
           {
             id: this.toggleElement.dataset['toggle']
@@ -107,7 +107,7 @@ export default class Dropdown extends Component {
         if (!this.activeToggle) return;
 
         const closeEvent = Component.dispatchCustomEvent(
-          'dropdownClose',
+          'dropdownClosed',
           this.toggleElement,
           {
             id: this.toggleElement.dataset['toggle']

--- a/src/js/components/fileInput.js
+++ b/src/js/components/fileInput.js
@@ -81,7 +81,6 @@ export default class FileInput extends Component {
             'fileAttached',
             this.element,
             {
-              id: this.element.dataset.rvtFileInput,
               files: Array.from(uploadInput.files).map(f => f.name)
             }
           );

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -210,9 +210,10 @@ export default class Modal extends Component {
 
       open() {
         // Trigger modalOpen custom event. This event is used to control the process of closing other open modals.
-        const openEvent = Component.dispatchCustomEvent('modalOpen', this.element, {
-          id: this.element.dataset.rvtModal
-        });
+        const openEvent = Component.dispatchCustomEvent(
+          'modalOpen',
+          this.element
+        );
     
         if (!openEvent) return;
     
@@ -222,9 +223,10 @@ export default class Modal extends Component {
 
       close() {
         // Trigger modalClose custom event.
-        const closeEvent = Component.dispatchCustomEvent('modalClose', this.element, {
-          id: this.element.dataset.rvtModal
-        });
+        const closeEvent = Component.dispatchCustomEvent(
+          'modalClose',
+          this.element
+        );
     
         if (!closeEvent) return;
     

--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -209,9 +209,9 @@ export default class Modal extends Component {
       },
 
       open() {
-        // Trigger modalOpen custom event. This event is used to control the process of closing other open modals.
+        // Trigger modalOpened custom event. This event is used to control the process of closing other open modals.
         const openEvent = Component.dispatchCustomEvent(
-          'modalOpen',
+          'modalOpened',
           this.element
         );
     
@@ -222,9 +222,9 @@ export default class Modal extends Component {
       },
 
       close() {
-        // Trigger modalClose custom event.
+        // Trigger modalClosed custom event.
         const closeEvent = Component.dispatchCustomEvent(
-          'modalClose',
+          'modalClosed',
           this.element
         );
     

--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -109,9 +109,13 @@ export default class Sidenav extends Component {
           return;
         }
 
-        const openEvent = Component.dispatchCustomEvent('sidenavListOpened', toggle, {
-          id: toggleId
-        });
+        const openEvent = Component.dispatchCustomEvent(
+          'sidenavListOpened', 
+          this.element,
+          {
+            list: targetList
+          }
+        );
     
         if (!openEvent) return;
     
@@ -131,9 +135,13 @@ export default class Sidenav extends Component {
           return;
         }
 
-        const closeEvent = Component.dispatchCustomEvent('sidenavListClosed', toggle, {
-          id: toggleId
-        });
+        const closeEvent = Component.dispatchCustomEvent(
+          'sidenavListClosed', 
+          this.element, 
+          {
+            list: targetList
+          }
+        );
     
         if (!closeEvent) return;
     

--- a/src/js/components/tabs.js
+++ b/src/js/components/tabs.js
@@ -140,10 +140,8 @@ export default class Tabs extends Component {
 
         const activationEvent = Component.dispatchCustomEvent(
           'tabActivated',
-          tab, 
-          {
-            id: tab.dataset.rvtTabPanel
-          }
+          this.element, 
+          { tab }
         );
     
         if (!activationEvent) return;


### PR DESCRIPTION
This PR updates the API for component custom events in the following ways:

- Event names are all past tense, i.e. `dropdownOpened`, `modalClosed`
- The value of the `event.target` property is always the emitting component's root DOM element
- The value of the `event.detail` property object only contains additional context about the event when needed, such as which tab was activated. References to relevant DOM elements are passed rather than ID strings.