### PR TITLE
Fix checkbox rendering in Firefox

### DIFF
--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -35,11 +35,8 @@
   }
 
   input[type=checkbox] ~ label {
+    cursor: pointer;
     display: inline-block;
-
-    &:hover {
-      cursor: pointer;
-    }
   }
 
   input[type=checkbox] ~ label::before {

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -13,10 +13,10 @@
     height: $spacing-md;
     left: 0;
     margin: 0;
-    top: 0;
-    width: $spacing-lg;
     opacity: 0;
     position: absolute;
+    top: 0;
+    width: $spacing-lg;
   }
 
   &--sr-only-label {

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -44,30 +44,34 @@
 
   input[type=checkbox] ~ label::before {
     background-color: $color-white-base;
+    border: ($spacing-xxs / 2) solid $color-black-500;
     border-radius: $spacing-xxs / 2;
-    box-shadow: 0 0 0 ($spacing-xxs / 2) $color-black-500;
     content: '';
     display: inline-block;
     height: $spacing-sm;
-    left: $spacing-xxs;
+    left: $spacing-xxs / 2;
     position: absolute;
-    top: $spacing-xxs;
+    top: $spacing-xxs / 2;
     width: $spacing-sm;
   }
 
-  input[type=checkbox]:checked ~ label::before {
+  input[type=checkbox]:checked ~ label::before,
+  input[type=checkbox]:indeterminate ~ label::before {
     background-color: $color-blue-600;
     background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij4KICAgIDxwYXRoIGZpbGw9IiNmZmZmZmYiIGQ9Ik02LjcyLDEzbC0uNDgtLjM2LTMtM0ExLDEsMCwwLDEsNC43MSw4LjI5bDIuMTEsMi4xMiw0LjMzLTYuOTRhMSwxLDAsMCwxLDEuNywxLjA2TDcuNjQsMTIuODdaIi8+Cjwvc3ZnPgo=');
     background-position: 50% 50%;
     background-repeat: no-repeat;
-    box-shadow: 0 0 0 ($spacing-xxs / 2) $color-blue-600;
+    border-color: $color-blue-600;
+  }
+
+  input[type=checkbox]:indeterminate ~ label::before {
+    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij4KICA8cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJNMTMsOUgzQTEsMSwwLDAsMSwzLDdIMTNhMSwxLDAsMCwxLDAsMloiLz4KPC9zdmc+Cg==');
   }
 
   input[type=checkbox]:focus ~ label::before {
     box-shadow:
-      0 0 0 ($spacing-xxs / 2) $color-black-500,
-      0 0 0 $spacing-xxs $color-white-base,
-      0 0 0 ($spacing-xxs * 1.5) $color-blue-600;
+      0 0 0 ($spacing-xxs / 2) $color-white-base,
+      0 0 0 $spacing-xxs $color-blue-600;
   }
 
   input[type=checkbox]:disabled {
@@ -81,26 +85,7 @@
 
   input[type=checkbox]:disabled ~ label::before {
     background-color: $color-black-200;
-    box-shadow: 0 0 0 ($spacing-xxs / 2) $color-black-300;
-  }
-
-  input[type=checkbox]:indeterminate ~ label::before {
-    background-color: $color-blue-600;
-    background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiIgdmlld0JveD0iMCAwIDE2IDE2Ij4KICA8cGF0aCBmaWxsPSIjZmZmZmZmIiBkPSJNMTMsOUgzQTEsMSwwLDAsMSwzLDdIMTNhMSwxLDAsMCwxLDAsMloiLz4KPC9zdmc+Cg==');
-    box-shadow: 0 0 0 ($spacing-xxs / 2) $color-blue-600;
-  }
-
-  input[type=checkbox]:indeterminate:disabled ~ label::before {
-    background-color: $color-black-200;
-    box-shadow: 0 0 0 ($spacing-xxs / 2) $color-black-300;
-  }
-
-  input[type=checkbox]:checked:focus ~ label::before,
-  input[type=checkbox]:indeterminate:focus ~ label::before {
-    box-shadow:
-      0 0 0 ($spacing-xxs / 2) $color-blue-600,
-      0 0 0 $spacing-xxs $color-white-base,
-      0 0 0 ($spacing-xxs * 1.5) $color-blue-600;
+    border-color: $color-black-300;
   }
 
   &__description {


### PR DESCRIPTION
Rounded corners in Firefox causes background colors to bleed through at the corners, when using box-shadow. Replacing the box-shadow border with a literal border fixes this. Works in Chrome, Safari, and Firefox. Also, did some other cleanup.