### PR TITLE
Enforce checkbox block styling in CSS, HTML, and examples

### DIFF
--- a/src/components/checkbox/README.md
+++ b/src/components/checkbox/README.md
@@ -1,79 +1,82 @@
 # Checkbox
+
 Checkboxes allow users to select one or more options from a list of choices.
 
 ## Example markup
+
 ```html
 <fieldset class="rvt-fieldset">
   <legend class="rvt-sr-only">Checkbox list</legend>
   <ul class="rvt-plain-list rvt-width-xl">
     <li>
-      <span class="rvt-checkbox">
+      <div class="rvt-checkbox">
         <input type="checkbox" name="checkbox-demo" id="checkbox-1">
         <!--
           Can work with hidden input elements that some framework template languages generate
         -->
         <input type="hidden">
         <label for="checkbox-1">Option one</label>
-      </span>
+      </div>
     </li>
     <li>
-      <span class="rvt-checkbox">
+      <div class="rvt-checkbox">
         <input type="checkbox" name="checkbox-demo" id="indeterminate">
         <label for="indeterminate">Option two</label>
-      </span>
+      </div>
     </li>
     <li>
-      <span class="rvt-checkbox">
+      <div class="rvt-checkbox">
         <input type="checkbox" name="checkbox-demo" id="checkbox-3" disabled>
         <label for="checkbox-3">Option three</label>
-      </span>
+      </div>
     </li>
     <li>
-      <span class="rvt-checkbox">
+      <div class="rvt-checkbox">
         <input type="checkbox" name="checkbox-demo" id="checkbox-4" disabled checked>
         <label for="checkbox-4">Option four</label>
-      </span>
+      </div>
     </li>
     <li>
-      <span class="rvt-checkbox">
+      <div class="rvt-checkbox">
         <input aria-describedby="checkbox-description" type="checkbox" name="checkbox-demo" id="checkbox-long">
         <label for="checkbox-long">Just a quick note</label>
         <div id="checkbox-description" class="rvt-checkbox__description">This checkbox has a really long label that can wrap on to two lines and still have nice left alignment.</div>
-      </span>
+      </div>
     </li>
     <li>
-      <span class="rvt-checkbox rvt-checkbox--sr-only-label">
+      <div class="rvt-checkbox rvt-checkbox--sr-only-label">
         <input type="checkbox" name="checkbox-demo" id="checkbox-hidden-label">
         <label for="checkbox-hidden-label">This label text is visually hidden</label>
-      </span>
+      </div>
     </li>
   </ul>
 </fieldset>
 ```
 
 ## Visually-hidden label modifier
+
 To visually hide the label of a checkbox, but still make it accessible to screen readers, use the `rvt-checkbox--sr-only-label` modifier on the `rvt-checkbox` wrapper element.
 
 The markup in this example will visually hide the label element, leaving only the checkbox element visible. This can be useful in situations such as when checkboxes are used to select entire rows of data from a table.
 
 ```html
-<span class="rvt-checkbox rvt-checkbox--sr-only-label">
+<div class="rvt-checkbox rvt-checkbox--sr-only-label">
   <input type="checkbox" name="checkbox-demo" id="checkbox-hidden-label">
   <label for="checkbox-hidden-label">This label text is visually hidden</label>
-</span>
+</div>
 ```
 
 ## Description element
+
 In some cases it can be helpful to provide additional more detailed information about the functionality of a checkbox in addition to the the text inside the `<label>` element. In these instances you can use the `.rvt-checkbox__description` element to provide more context to a user.
 
-1. Add a `<div class="rvt-checkbox__description" id="checkbox-description"></div>` element as a direct child of the `<span class="rvt-checkbox">` element, placed after the `<label>` element. Make the id unique for the document.
+1. Add a `<div class="rvt-checkbox__description" id="checkbox-description"></div>` element as a direct child of the `<div class="rvt-checkbox">` element, placed after the `<label>` element. Make the id unique for the document.
 2. Add an `aria-describedby` attribute to the checkbox `<input>`, referencing the `id` attribute of the description element.
 
-### Description element example
 ```html
-<span class="rvt-checkbox">
+<div class="rvt-checkbox">
   <input aria-describedby="checkbox-description" type="checkbox" name="checkbox-demo" id="checkbox-long">
   <label for="checkbox-long">Just a quick note</label>
   <div id="checkbox-description" class="rvt-checkbox__description">This checkbox has a really long label that can wrap on to two lines and still have nice left alignment.</div>
-</span>
+</div>
 ```

--- a/src/components/checkbox/checkbox.njk
+++ b/src/components/checkbox/checkbox.njk
@@ -2,61 +2,61 @@
   <legend class="rvt-sr-only">Checkbox list</legend>
   <ul class="rvt-plain-list rvt-width-xl">
     <li>
-      <span class="rvt-checkbox">
+      <div class="rvt-checkbox">
         <input type="checkbox" name="checkbox-demo" id="checkbox-1">
         <!--
           Can work with hidden input elements that some framework template languages generate
         -->
         <input type="hidden">
         <label for="checkbox-1">Option one</label>
-      </span>
+      </div>
     </li>
     <li>
-      <span class="rvt-checkbox">
+      <div class="rvt-checkbox">
         <input type="checkbox" name="checkbox-demo" id="indeterminate">
         <label for="indeterminate">Option two</label>
-      </span>
+      </div>
     </li>
     <li>
-      <span class="rvt-checkbox">
+      <div class="rvt-checkbox">
         <input type="checkbox" name="checkbox-demo" id="checkbox-3" disabled>
         <label for="checkbox-3">Option three</label>
-      </span>
+      </div>
     </li>
     <li>
-      <span class="rvt-checkbox">
+      <div class="rvt-checkbox">
         <input type="checkbox" name="checkbox-demo" id="checkbox-4" disabled checked>
         <label for="checkbox-4">Option four</label>
-      </span>
+      </div>
     </li>
     <li>
-      <span class="rvt-checkbox">
+      <div class="rvt-checkbox">
         <input aria-describedby="checkbox-description" type="checkbox" name="checkbox-demo" id="checkbox-long">
         <label for="checkbox-long">Just a quick note</label>
         <div id="checkbox-description" class="rvt-checkbox__description">This checkbox has a really long label that can wrap on to two lines and still have nice left alignment.</div>
-      </span>
+      </div>
     </li>
     <li>
-      <span class="rvt-checkbox rvt-checkbox--sr-only-label">
+      <div class="rvt-checkbox rvt-checkbox--sr-only-label">
         <input type="checkbox" name="checkbox-demo" id="checkbox-hidden-label">
         <label for="checkbox-hidden-label">This label text is visually hidden</label>
-      </span>
+      </div>
     </li>
   </ul>
 </fieldset>
 
-<ul class="rvt-plain-list rvt-flex rvt-m-top-lg">
-  <li class="rvt-m-right-sm">
-    <span class="rvt-checkbox">
+<ul class="rvt-inline-list rvt-m-top-lg">
+  <li>
+    <div class="rvt-checkbox">
       <input type="checkbox" name="checkbox-demo" id="inline-1">
       <label for="inline-1">Option two</label>
-    </span>
+    </div>
   </li>
-  <li class="rvt-m-right-sm">
-    <span class="rvt-checkbox">
+  <li>
+    <div class="rvt-checkbox">
       <input type="checkbox" name="checkbox-demo" id="inline-2">
       <label for="inline-2">Option two</label>
-    </span>
+    </div>
   </li>
 </ul>
 

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -3,7 +3,7 @@
 
 @use '../core' as *;
 
-.rvt-checkbox {
+.#{$prefix}-checkbox {
   display: inline-block;
   padding-left: $spacing-lg;
   position: relative;
@@ -37,6 +37,7 @@
   input[type=checkbox] ~ label {
     cursor: pointer;
     display: inline-block;
+    line-height: 1.5;
   }
 
   input[type=checkbox] ~ label::before {
@@ -87,6 +88,7 @@
 
   &__description {
     color: $color-black-600;
+    display: block;
     font-size: $ts-14;
   }
 }


### PR DESCRIPTION
Summary:

1. Replace `rvt-plain-list rvt-flex` example with `rvt-inline-list`.
2. Enforce line-height for checkbox labels, so the effective height is 24px.
3. Enforce the description element to be styled as a block, in case the markup is not a `<div>`.
4. Update all examples to use `<div>` over `<span>`.