### PR TITLE
Use flex for inline lists

### DIFF
--- a/src/sass/lists/_base.scss
+++ b/src/sass/lists/_base.scss
@@ -30,33 +30,20 @@ dl dd {
   margin-left: 0;
 }
 
-@mixin plain-list {
+.#{$prefix}-plain-list {
   list-style: none;
   padding: 0;
 }
 
-@mixin inline-list {
-  /**
-   * This is a hack that remove extras space between elements that are
-   * set to display inline-block.
-   */
-  font-size: 0;
-
-  @include plain-list;
-
-  & li {
-    display: inline-block;
-    line-height: 1;
-    font-size: 1rem;
-    margin-right: $spacing-sm;
-    margin-bottom: $spacing-xs;
-  }
-}
-
-.#{$prefix}-plain-list {
-  @include plain-list;
-}
-
 .#{$prefix}-inline-list {
-  @include inline-list;
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-xs $spacing-sm;
+  list-style: none;
+  margin-top: $spacing-xs;
+  padding: 0;
+
+  & > li {
+    margin: 0;
+  }
 }


### PR DESCRIPTION
Notes:

1. The inline list implementation is replaced with flex.
2. List items no longer set a line height or font size.
3. Inline list item margins are reset only on direct children, in case there would be some odd case in which you have nested lists under an inline list.
4. Spacing is managed by the [gap property](https://developer.mozilla.org/en-US/docs/Web/CSS/gap), which has [good browser support](https://caniuse.com/flexbox-gap), outside of IE.
5. Top margin is included on inline lists to maintain current spacing expectations (top margins on list items). This could be adjusted, if such spacing is reviewed for all list styles.
6. Removed the Sass mixin, to keep the code simpler and remove unintended classes (`.plain-list`, `.inline-list`).