### PR TITLE
Update input background color to white

### DIFF
--- a/src/sass/inputs/_base.scss
+++ b/src/sass/inputs/_base.scss
@@ -12,7 +12,7 @@
     display: block;
     width: 100%;
     border-radius: $spacing-xxs;
-    background-color: inherit;
+    background-color: $color-white-base;
     border: 1px solid $color-black-400;
     padding: $spacing-xs;
     height: $spacing-xl;


### PR DESCRIPTION
Updating the input background color to white ensures that inputs retain good contrast against contextual color. Also, if an input is placed on a light gray background, it makes it so the inputs don't accidentally look disabled.