### PR TITLE
Set card title link element to display block

### DIFF
--- a/src/sass/card/_base.scss
+++ b/src/sass/card/_base.scss
@@ -51,6 +51,7 @@
   }
 
   &__title a {
+    display: block;
     text-decoration: none;
     color: $color-black-500;
   }


### PR DESCRIPTION
Empty space between link text and arrow is now clickable.