### PR TITLE
Updated link hub icon color to use correct color scale

### DIFF
--- a/src/sass/link-hub/_base.scss
+++ b/src/sass/link-hub/_base.scss
@@ -26,7 +26,7 @@
 
   &__link::after {
     content: '';
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="%2395adcb" d="M15.92,8.38a1,1,0,0,0-.22-1.09l-4-4a1,1,0,0,0-1.41,1.41L12.59,7H1A1,1,0,0,0,1,9H12.59l-2.29,2.29a1,1,0,1,0,1.41,1.41l4-4A1,1,0,0,0,15.92,8.38Z"/></svg>');
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path fill="%2394D2E7" d="M15.92,8.38a1,1,0,0,0-.22-1.09l-4-4a1,1,0,0,0-1.41,1.41L12.59,7H1A1,1,0,0,0,1,9H12.59l-2.29,2.29a1,1,0,1,0,1.41,1.41l4-4A1,1,0,0,0,15.92,8.38Z"/></svg>');
     background-repeat: no-repeat;
     background-position: center;
     display: inline-block;


### PR DESCRIPTION
I just caught that I used the old blue color scale for the arrow inline svg background image. This PR updates to the correct color value.