### PR TITLE
Set default image style to max-width: 100%

### DIFF
--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -54,7 +54,7 @@ hr {
 
 img {
   display: block;
-  width: 100%;
+  max-width: 100%;
   height: auto;
 }
 

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -29,6 +29,10 @@
   &__break-out {
     margin-right: -$spacing-md;
     margin-left: -$spacing-md;
+
+    img {
+      width: 100%;
+    }
   }
 
   &__sidebar {


### PR DESCRIPTION
This replaces the `width: 100%` style declaration for all Rivet images.

https://app.asana.com/0/1199946964816580/1201839449092957/f

Note that this change caused images in the Details layout breakout elements to not fill the width of their container. This PR adds a `width: 100%` style declaration to `img` elements within `rvt-layout__break-out` containers.