### PR TITLE
Added line-height tokens and utility classes

### DIFF
--- a/src/components/examples/examples--feedback-form.njk
+++ b/src/components/examples/examples--feedback-form.njk
@@ -4,7 +4,7 @@
         <div class="rvt-container rvt-container--junior rvt-container--center">
             <div class="rvt-grid">
                 <div class="rvt-grid__item-4-md-up">
-                    <h1 class="rvt-ts-36 rvt-lh-title">Student <strong>feedback</strong></h1>
+                    <h1 class="rvt-ts-36 rvt-lh-tight">Student <strong>feedback</strong></h1>
                     <p class="rvt-m-top-remove rvt-m-bottom-lg">English 201 Fall 2018</p>
                     <p class="rvt-m-bottom-xl">We appreciate you taking the time to fill out the English 201 fall sememster feedback from. Your feedback is instrumental in helping us to improve the class.</p>
                 </div>

--- a/src/components/examples/examples--personal-details-form.njk
+++ b/src/components/examples/examples--personal-details-form.njk
@@ -1,6 +1,6 @@
 {% include "@header-system-main-nav" %}
 <main role="main" id="main-content" class="rvt-container rvt-container--center rvt-container--freshman rvt-m-top-xxl">
-    <h1 class="rvt-ts-36 rvt-text-bold rvt-lh-title">Contact form</h1>
+    <h1 class="rvt-ts-36 rvt-text-bold rvt-lh-tight">Contact form</h1>
     <p class="rvt-ts-20 ">Please fill out the form below and someone from our office will get contact You as soon as possible</p>
 
     <div class="rvt-error-container" role="status" aria-live="polite">

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -121,7 +121,7 @@
   padding: 0;
 
   &__item {
-    line-height: 1.5;
+    line-height: $line-height-base;
   }
 
   &__item:not(first-child) {

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -38,7 +38,7 @@
   input[type='checkbox'] ~ label {
     cursor: pointer;
     display: inline-block;
-    line-height: 1.5;
+    line-height: $line-height-base;
   }
 
   input[type='checkbox'] ~ label::before {

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -26,7 +26,7 @@ body {
   height: 100%;
   margin: 0;
   padding: 0;
-  line-height: 1.5;
+  line-height: $line-height-base;
 }
 
 /**

--- a/src/sass/file-input/_base.scss
+++ b/src/sass/file-input/_base.scss
@@ -50,7 +50,7 @@
 
     span {
       font-weight: $font-weight-bold;
-      line-height: 1.5;
+      line-height: $line-height-base;
       margin-right: $spacing-sm;
       display: inline-block;
     }

--- a/src/sass/hero-area/_base.scss
+++ b/src/sass/hero-area/_base.scss
@@ -20,7 +20,7 @@
 
   &__title {
     font-size: $ts-32;
-    line-height: $line-height-title;
+    line-height: $line-height-tight;
     margin-top: $spacing-xs;
   }
 

--- a/src/sass/hero-area/_base.scss
+++ b/src/sass/hero-area/_base.scss
@@ -20,7 +20,7 @@
 
   &__title {
     font-size: $ts-32;
-    line-height: 1.2;
+    line-height: $line-height-heading;
     margin-top: $spacing-xs;
   }
 

--- a/src/sass/hero-area/_base.scss
+++ b/src/sass/hero-area/_base.scss
@@ -20,7 +20,7 @@
 
   &__title {
     font-size: $ts-32;
-    line-height: $line-height-heading;
+    line-height: $line-height-title;
     margin-top: $spacing-xs;
   }
 

--- a/src/sass/inputs/_base.scss
+++ b/src/sass/inputs/_base.scss
@@ -32,7 +32,7 @@
 
   &-textarea {
     height: $spacing-base * 15;
-    line-height: 1.5;
+    line-height: $line-height-base;
     overflow: auto; // Remove scrollbar in IE
   }
 

--- a/src/sass/radios/_base.scss
+++ b/src/sass/radios/_base.scss
@@ -40,7 +40,7 @@ $padding: math.div(3rem, 16);
   input[type='radio'] ~ label {
     cursor: pointer;
     display: inline-block;
-    line-height: 1.5;
+    line-height: $line-height-base;
   }
 
   input[type='radio'] ~ label::before {

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -31,7 +31,7 @@
 
   &__number {
     font-size: $ts-41;
-    line-height: $line-height-title;
+    line-height: $line-height-tight;
   }
 
   &__description {

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -31,7 +31,7 @@
 
   &__number {
     font-size: $ts-41;
-    line-height: $line-height-heading;
+    line-height: $line-height-title;
   }
 
   &__description {

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -31,7 +31,7 @@
 
   &__number {
     font-size: $ts-41;
-    line-height: 1.2;
+    line-height: $line-height-heading;
   }
 
   &__description {

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -55,7 +55,7 @@ tr td {
 }
 
 .#{$prefix}-table-compact {
-  line-height: 1.2;
+  line-height: $line-height-heading;
 
   tr th,
   tr td {

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -55,7 +55,7 @@ tr td {
 }
 
 .#{$prefix}-table-compact {
-  line-height: $line-height-heading;
+  line-height: $line-height-title;
 
   tr th,
   tr td {

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -55,7 +55,7 @@ tr td {
 }
 
 .#{$prefix}-table-compact {
-  line-height: $line-height-title;
+  line-height: $line-height-tight;
 
   tr th,
   tr td {

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -33,7 +33,7 @@
     --flow-space: 3rem;
 
     font-weight: $font-weight-regular;
-    line-height: $line-height-heading;
+    line-height: $line-height-title;
     scroll-margin-top: $spacing-md;
   }
 

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -3,7 +3,7 @@
 .rvt-prose {
   // Benton sans feels really compact and can benefit from a little extra
   // line-height here.
-  line-height: 1.65;
+  line-height: $line-height-taller;
 
   h1 {
     font-size: $ts-32;
@@ -33,7 +33,7 @@
     --flow-space: 3rem;
 
     font-weight: $font-weight-regular;
-    line-height: 1.2;
+    line-height: $line-height-heading;
     scroll-margin-top: $spacing-md;
   }
 

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -3,7 +3,7 @@
 .rvt-prose {
   // Benton sans feels really compact and can benefit from a little extra
   // line-height here.
-  line-height: $line-height-taller;
+  line-height: $line-height-loose;
 
   h1 {
     font-size: $ts-32;
@@ -33,7 +33,7 @@
     --flow-space: 3rem;
 
     font-weight: $font-weight-regular;
-    line-height: $line-height-title;
+    line-height: $line-height-tight;
     scroll-margin-top: $spacing-md;
   }
 

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -42,11 +42,11 @@
 }
 
 .#{$prefix}-lh-title {
-  line-height: $line-height-title;
+  line-height: $line-height-tight;
 }
 
 .#{$prefix}-lh-taller {
-  line-height: $line-height-taller;
+  line-height: $line-height-loose;
 }
 
 .#{$prefix}-text-nobr {

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -41,11 +41,12 @@
   line-height: $line-height-base;
 }
 
-.#{$prefix}-lh-title {
+.#{$prefix}-lh-title,
+.#{$prefix}-lh-tight {
   line-height: $line-height-tight;
 }
 
-.#{$prefix}-lh-taller {
+.#{$prefix}-lh-loose {
   line-height: $line-height-loose;
 }
 

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -42,7 +42,7 @@
 }
 
 .#{$prefix}-lh-title {
-  line-height: $line-height-heading;
+  line-height: $line-height-title;
 }
 
 .#{$prefix}-lh-taller {

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -37,12 +37,16 @@
   text-align: center !important;
 }
 
-/**
- * Sets shorter line-height for headings and title.
- */
+.#{$prefix}-lh-base {
+  line-height: $line-height-base;
+}
 
 .#{$prefix}-lh-title {
-  line-height: 1.1;
+  line-height: $line-height-heading;
+}
+
+.#{$prefix}-lh-taller {
+  line-height: $line-height-taller;
 }
 
 .#{$prefix}-text-nobr {

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -41,7 +41,6 @@
   line-height: $line-height-base;
 }
 
-.#{$prefix}-lh-title,
 .#{$prefix}-lh-tight {
   line-height: $line-height-tight;
 }

--- a/src/tokens/line-heights.json
+++ b/src/tokens/line-heights.json
@@ -1,0 +1,13 @@
+{
+  "line-height": {
+    "base": {
+      "value": "1.5"
+    },
+    "heading": {
+      "value": "1.2"
+    },
+    "taller": {
+      "value": "1.65"
+    }
+  }
+}

--- a/src/tokens/line-heights.json
+++ b/src/tokens/line-heights.json
@@ -6,7 +6,10 @@
     "title": {
       "value": "1.2"
     },
-    "taller": {
+    "tight": {
+      "value": "1.2"
+    },
+    "loose": {
       "value": "1.65"
     }
   }

--- a/src/tokens/line-heights.json
+++ b/src/tokens/line-heights.json
@@ -3,7 +3,7 @@
     "base": {
       "value": "1.5"
     },
-    "heading": {
+    "title": {
       "value": "1.2"
     },
     "taller": {


### PR DESCRIPTION
This PR adds the following line-height tokens and utility classes:

- `$line-height-tight` / `.rvt-lh-tight`: `1.2`
- `$line-height-base` / `.rvt-lh-base`: `1.5`
- `$line-height-loose` / `.rvt-lh-loose`: `1.65`

The `.rvt-lh-title` class remains for backwards compatibility.