### PR TITLE
Restructured header disclosure markup

### DIFF
--- a/src/components/disclosure/disclosure.njk
+++ b/src/components/disclosure/disclosure.njk
@@ -4,5 +4,15 @@
     <div class="rvt-prose rvt-flow">
       <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Reiciendis quas quisquam ratione officia accusamus quaerat tenetur laudantium, necessitatibus sapiente maxime accusantium deserunt voluptate illum vero quae ea dicta quos? Fugiat.</p>
     </div>
+
+    <div class="rvt-disclosure" data-rvt-disclosure="disclosure-2">
+      <button class="rvt-disclosure__toggle" data-rvt-disclosure-toggle aria-expanded="false">Disclose more information</button>
+      <div class="rvt-disclosure__content" data-rvt-disclosure-target hidden>
+        <div class="rvt-prose rvt-flow">
+          <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Reiciendis quas quisquam ratione officia accusamus quaerat tenetur laudantium, necessitatibus sapiente maxime accusantium deserunt voluptate illum vero quae ea dicta quos? Fugiat.</p>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>

--- a/src/components/header-system/03-header-system-main-nav.njk
+++ b/src/components/header-system/03-header-system-main-nav.njk
@@ -28,30 +28,32 @@
           </a>
         </div>
 
-        <div class="rvt-header-global__controls" data-rvt-disclosure="menu">
+        <div class="rvt-header-global__controls">
 
-          <!-- Menu button that shows/hides navigation on smaller screens -->
+          <div data-rvt-disclosure="menu">
+            <!-- Menu button that shows/hides navigation on smaller screens -->
+            <button aria-expanded="false" class="rvt-global-toggle rvt-global-toggle--menu rvt-hide-lg-up"
+              data-rvt-disclosure-toggle="menu">
+              <span class="rvt-sr-only">Menu</span>
+              <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__open" viewBox="0 0 16 16">
+                <g fill="currentColor">
+                  <path d="M15,3H1A1,1,0,0,1,1,1H15a1,1,0,0,1,0,2Z"></path>
+                  <path d="M15,9H1A1,1,0,0,1,1,7H15a1,1,0,0,1,0,2Z"></path>
+                  <path d="M15,15H1a1,1,0,0,1,0-2H15a1,1,0,0,1,0,2Z"></path>
+                </g>
+              </svg>
+              <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__close" fill="currentColor"
+                viewBox="0 0 16 16">
+                <path
+                  d="M8.46954 7.00409L13.7595 1.71409C13.9234 1.52279 14.009 1.27671 13.9993 1.02504C13.9895 0.773362 13.8852 0.534623 13.7071 0.356528C13.529 0.178434 13.2903 0.0741014 13.0386 0.0643803C12.7869 0.0546591 12.5408 0.140265 12.3495 0.304092L7.05954 5.59409L1.76954 0.294092C1.58124 0.105788 1.32585 -3.72428e-09 1.05954 -1.74018e-09C0.793242 2.43924e-10 0.537847 0.105788 0.349544 0.294092C0.16124 0.482395 0.055452 0.73779 0.055452 1.00409C0.055452 1.27039 0.16124 1.52579 0.349544 1.71409L5.64954 7.00409L0.349544 12.2941C0.244862 12.3837 0.159841 12.4941 0.0998179 12.6181C0.0397946 12.7422 0.00606467 12.8773 0.000745174 13.015C-0.00457432 13.1528 0.0186315 13.2901 0.0689061 13.4184C0.119181 13.5467 0.195439 13.6633 0.292893 13.7607C0.390348 13.8582 0.506896 13.9345 0.635221 13.9847C0.763546 14.035 0.900878 14.0582 1.0386 14.0529C1.17632 14.0476 1.31145 14.0138 1.43551 13.9538C1.55958 13.8938 1.6699 13.8088 1.75954 13.7041L7.05954 8.41409L12.3495 13.7041C12.5408 13.8679 12.7869 13.9535 13.0386 13.9438C13.2903 13.9341 13.529 13.8297 13.7071 13.6517C13.8852 13.4736 13.9895 13.2348 13.9993 12.9831C14.009 12.7315 13.9234 12.4854 13.7595 12.2941L8.46954 7.00409Z"
+                  fill="currentColor"></path>
+              </svg>
+            </button>
+            <nav aria-label="Primary navigation" class="rvt-header-menu" data-rvt-disclosure-target="menu" hidden>
+              {% include "@header-system-navigation-partial" %}
+            </nav>
+          </div>
 
-          <button aria-expanded="false" class="rvt-global-toggle rvt-global-toggle--menu rvt-hide-lg-up"
-            data-rvt-disclosure-toggle="menu">
-            <span class="rvt-sr-only">Menu</span>
-            <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__open" viewBox="0 0 16 16">
-              <g fill="currentColor">
-                <path d="M15,3H1A1,1,0,0,1,1,1H15a1,1,0,0,1,0,2Z"></path>
-                <path d="M15,9H1A1,1,0,0,1,1,7H15a1,1,0,0,1,0,2Z"></path>
-                <path d="M15,15H1a1,1,0,0,1,0-2H15a1,1,0,0,1,0,2Z"></path>
-              </g>
-            </svg>
-            <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__close" fill="currentColor"
-              viewBox="0 0 16 16">
-              <path
-                d="M8.46954 7.00409L13.7595 1.71409C13.9234 1.52279 14.009 1.27671 13.9993 1.02504C13.9895 0.773362 13.8852 0.534623 13.7071 0.356528C13.529 0.178434 13.2903 0.0741014 13.0386 0.0643803C12.7869 0.0546591 12.5408 0.140265 12.3495 0.304092L7.05954 5.59409L1.76954 0.294092C1.58124 0.105788 1.32585 -3.72428e-09 1.05954 -1.74018e-09C0.793242 2.43924e-10 0.537847 0.105788 0.349544 0.294092C0.16124 0.482395 0.055452 0.73779 0.055452 1.00409C0.055452 1.27039 0.16124 1.52579 0.349544 1.71409L5.64954 7.00409L0.349544 12.2941C0.244862 12.3837 0.159841 12.4941 0.0998179 12.6181C0.0397946 12.7422 0.00606467 12.8773 0.000745174 13.015C-0.00457432 13.1528 0.0186315 13.2901 0.0689061 13.4184C0.119181 13.5467 0.195439 13.6633 0.292893 13.7607C0.390348 13.8582 0.506896 13.9345 0.635221 13.9847C0.763546 14.035 0.900878 14.0582 1.0386 14.0529C1.17632 14.0476 1.31145 14.0138 1.43551 13.9538C1.55958 13.8938 1.6699 13.8088 1.75954 13.7041L7.05954 8.41409L12.3495 13.7041C12.5408 13.8679 12.7869 13.9535 13.0386 13.9438C13.2903 13.9341 13.529 13.8297 13.7071 13.6517C13.8852 13.4736 13.9895 13.2348 13.9993 12.9831C14.009 12.7315 13.9234 12.4854 13.7595 12.2941L8.46954 7.00409Z"
-                fill="currentColor"></path>
-            </svg>
-          </button>
-          <nav aria-label="Primary navigation" class="rvt-header-menu" data-rvt-disclosure-target="menu" hidden>
-            {% include "@header-system-navigation-partial" %}
-          </nav>
         </div>
       </div>
     </div>

--- a/src/components/header-system/04-header-system-main-nav-search.njk
+++ b/src/components/header-system/04-header-system-main-nav-search.njk
@@ -13,7 +13,7 @@
             <!-- Trident logo -->
 
             <div class="rvt-lockup__tab">
-              <svg xmlns="http://www.w3.org/2000/svg" class="rvt-lockup__trident" viewBox="0 0 28 34">
+              <svg class="rvt-lockup__trident" viewBox="0 0 28 34">
                 <path
                   d="M-3.34344e-05 4.70897H8.83308V7.174H7.1897V21.1426H10.6134V2.72321H8.83308V0.121224H18.214V2.65476H16.2283V21.1426H19.7889V7.174H18.214V4.64047H27.0471V7.174H25.0614V23.6761L21.7746 26.8944H16.2967V30.455H18.214V33.8787H8.76463V30.592H10.6819V26.8259H5.20403L1.91726 23.6077V7.174H-3.34344e-05V4.70897Z"
                   fill="currentColor"></path>
@@ -30,35 +30,39 @@
           </a>
         </div>
 
-        <div class="rvt-header-global__controls" data-rvt-disclosure="menu">
+        <div class="rvt-header-global__controls">
 
-          <!-- Menu button that shows/hides navigation on smaller screens -->
+          <!-- menu disclosure -->
+          <div data-rvt-disclosure="menu">
+            <!-- Menu button that shows/hides navigation on smaller screens -->
+            <button
+              aria-expanded="false"
+              data-rvt-disclosure-toggle="menu"
+              class="rvt-global-toggle rvt-global-toggle--menu rvt-hide-lg-up"
+            >
+              <span class="rvt-sr-only">Menu</span>
+              <svg class="rvt-global-toggle__open" viewBox="0 0 16 16">
+                <g fill="currentColor">
+                  <path d="M15,3H1A1,1,0,0,1,1,1H15a1,1,0,0,1,0,2Z"></path>
+                  <path d="M15,9H1A1,1,0,0,1,1,7H15a1,1,0,0,1,0,2Z"></path>
+                  <path d="M15,15H1a1,1,0,0,1,0-2H15a1,1,0,0,1,0,2Z"></path>
+                </g>
+              </svg>
+              <svg class="rvt-global-toggle__close" fill="currentColor" viewBox="0 0 16 16">
+                <path d="M8.46954 7.00409L13.7595 1.71409C13.9234 1.52279 14.009 1.27671 13.9993 1.02504C13.9895 0.773362 13.8852 0.534623 13.7071 0.356528C13.529 0.178434 13.2903 0.0741014 13.0386 0.0643803C12.7869 0.0546591 12.5408 0.140265 12.3495 0.304092L7.05954 5.59409L1.76954 0.294092C1.58124 0.105788 1.32585 -3.72428e-09 1.05954 -1.74018e-09C0.793242 2.43924e-10 0.537847 0.105788 0.349544 0.294092C0.16124 0.482395 0.055452 0.73779 0.055452 1.00409C0.055452 1.27039 0.16124 1.52579 0.349544 1.71409L5.64954 7.00409L0.349544 12.2941C0.244862 12.3837 0.159841 12.4941 0.0998179 12.6181C0.0397946 12.7422 0.00606467 12.8773 0.000745174 13.015C-0.00457432 13.1528 0.0186315 13.2901 0.0689061 13.4184C0.119181 13.5467 0.195439 13.6633 0.292893 13.7607C0.390348 13.8582 0.506896 13.9345 0.635221 13.9847C0.763546 14.035 0.900878 14.0582 1.0386 14.0529C1.17632 14.0476 1.31145 14.0138 1.43551 13.9538C1.55958 13.8938 1.6699 13.8088 1.75954 13.7041L7.05954 8.41409L12.3495 13.7041C12.5408 13.8679 12.7869 13.9535 13.0386 13.9438C13.2903 13.9341 13.529 13.8297 13.7071 13.6517C13.8852 13.4736 13.9895 13.2348 13.9993 12.9831C14.009 12.7315 13.9234 12.4854 13.7595 12.2941L8.46954 7.00409Z" fill="currentColor"></path>
+              </svg>
+            </button>
+            <nav aria-label="Primary navigation" class="rvt-header-menu" data-rvt-disclosure-target="menu" hidden>
+              {% include "@header-system-navigation-partial" %}
+            </nav>
+          </div>
 
-          <button aria-expanded="false" class="rvt-global-toggle rvt-global-toggle--menu rvt-hide-lg-up"
-            data-rvt-disclosure-toggle="menu">
-            <span class="rvt-sr-only">Menu</span>
-            <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__open" viewBox="0 0 16 16">
-              <g fill="currentColor">
-                <path d="M15,3H1A1,1,0,0,1,1,1H15a1,1,0,0,1,0,2Z"></path>
-                <path d="M15,9H1A1,1,0,0,1,1,7H15a1,1,0,0,1,0,2Z"></path>
-                <path d="M15,15H1a1,1,0,0,1,0-2H15a1,1,0,0,1,0,2Z"></path>
-              </g>
-            </svg>
-            <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__close" fill="currentColor"
-              viewBox="0 0 16 16">
-              <path
-                d="M8.46954 7.00409L13.7595 1.71409C13.9234 1.52279 14.009 1.27671 13.9993 1.02504C13.9895 0.773362 13.8852 0.534623 13.7071 0.356528C13.529 0.178434 13.2903 0.0741014 13.0386 0.0643803C12.7869 0.0546591 12.5408 0.140265 12.3495 0.304092L7.05954 5.59409L1.76954 0.294092C1.58124 0.105788 1.32585 -3.72428e-09 1.05954 -1.74018e-09C0.793242 2.43924e-10 0.537847 0.105788 0.349544 0.294092C0.16124 0.482395 0.055452 0.73779 0.055452 1.00409C0.055452 1.27039 0.16124 1.52579 0.349544 1.71409L5.64954 7.00409L0.349544 12.2941C0.244862 12.3837 0.159841 12.4941 0.0998179 12.6181C0.0397946 12.7422 0.00606467 12.8773 0.000745174 13.015C-0.00457432 13.1528 0.0186315 13.2901 0.0689061 13.4184C0.119181 13.5467 0.195439 13.6633 0.292893 13.7607C0.390348 13.8582 0.506896 13.9345 0.635221 13.9847C0.763546 14.035 0.900878 14.0582 1.0386 14.0529C1.17632 14.0476 1.31145 14.0138 1.43551 13.9538C1.55958 13.8938 1.6699 13.8088 1.75954 13.7041L7.05954 8.41409L12.3495 13.7041C12.5408 13.8679 12.7869 13.9535 13.0386 13.9438C13.2903 13.9341 13.529 13.8297 13.7071 13.6517C13.8852 13.4736 13.9895 13.2348 13.9993 12.9831C14.009 12.7315 13.9234 12.4854 13.7595 12.2941L8.46954 7.00409Z"
-                fill="currentColor"></path>
-            </svg>
-          </button>
-          <nav aria-label="Primary navigation" class="rvt-header-menu" data-rvt-disclosure-target="menu" hidden>
-            {% include "@header-system-navigation-partial" %}
-          </nav>
-          <div data-rvt-disclosure="search"> 
+          <!-- Search disclosure -->
+          <div data-rvt-disclosure="search">
               <!-- Button that shows/hides the search field -->
               <button class="rvt-global-toggle" data-rvt-disclosure-toggle="search" aria-expanded="false">
                   <span class="rvt-sr-only">Search</span>
-                  <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__search" height="16" viewBox="0 0 16 16" width="16">
+                  <svg class="rvt-global-toggle__search" height="16" viewBox="0 0 16 16" width="16">
                       <path d="M15.71,14.29,10.89,9.47a6,6,0,1,0-1.42,1.42l4.82,4.82a1,1,0,0,0,1.42,0A1,1,0,0,0,15.71,14.29ZM6,10a4,4,0,1,1,4-4A4,4,0,0,1,6,10Z" fill="currentColor"></path>
                   </svg>
               </button>
@@ -75,8 +79,29 @@
                   </div>
               </form>
           </div>
-        </div>
+
+        </div><!-- /.controls -->
       </div>
     </div>
   </div>
 </header>
+
+<script>
+  const search = document.querySelector('[data-rvt-disclosure="search"]')
+  const menu = document.querySelector('[data-rvt-disclosure="menu"]')
+
+  function handleDisclosureOpen(event) {
+    if (event.target.dataset.rvtDisclosure == 'search') {
+      menu.close()
+      setTimeout(function() {
+        search.querySelector('input[type="text"]').focus()
+      })
+    } else if (event.target.dataset.rvtDisclosure == 'menu') {
+      search.close()
+    } else {
+      return
+    }
+  }
+
+  document.addEventListener('rvt:disclosureOpened', handleDisclosureOpen)
+</script>

--- a/src/components/header-system/04-header-system-main-nav-search.njk
+++ b/src/components/header-system/04-header-system-main-nav-search.njk
@@ -85,23 +85,3 @@
     </div>
   </div>
 </header>
-
-<script>
-  const search = document.querySelector('[data-rvt-disclosure="search"]')
-  const menu = document.querySelector('[data-rvt-disclosure="menu"]')
-
-  function handleDisclosureOpen(event) {
-    if (event.target.dataset.rvtDisclosure == 'search') {
-      menu.close()
-      setTimeout(function() {
-        search.querySelector('input[type="text"]').focus()
-      })
-    } else if (event.target.dataset.rvtDisclosure == 'menu') {
-      search.close()
-    } else {
-      return
-    }
-  }
-
-  document.addEventListener('rvt:disclosureOpened', handleDisclosureOpen)
-</script>

--- a/src/components/header-system/05-header-system-with-local-nav.njk
+++ b/src/components/header-system/05-header-system-with-local-nav.njk
@@ -30,31 +30,33 @@
           </a>
         </div>
 
-        <div class="rvt-header-global__controls" data-rvt-disclosure="menu">
+        <div class="rvt-header-global__controls">
 
-          <!-- Menu button that shows/hides navigation on smaller screens -->
+          <div data-rvt-disclosure="menu">
 
-          <button aria-expanded="false" class="rvt-global-toggle rvt-global-toggle--menu rvt-hide-lg-up"
-            data-rvt-disclosure-toggle="menu">
-            <span class="rvt-sr-only">Menu</span>
-            <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__open" viewBox="0 0 16 16">
-              <g fill="currentColor">
-                <path d="M15,3H1A1,1,0,0,1,1,1H15a1,1,0,0,1,0,2Z"></path>
-                <path d="M15,9H1A1,1,0,0,1,1,7H15a1,1,0,0,1,0,2Z"></path>
-                <path d="M15,15H1a1,1,0,0,1,0-2H15a1,1,0,0,1,0,2Z"></path>
-              </g>
-            </svg>
-            <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__close" fill="currentColor"
-              viewBox="0 0 16 16">
-              <path
-                d="M8.46954 7.00409L13.7595 1.71409C13.9234 1.52279 14.009 1.27671 13.9993 1.02504C13.9895 0.773362 13.8852 0.534623 13.7071 0.356528C13.529 0.178434 13.2903 0.0741014 13.0386 0.0643803C12.7869 0.0546591 12.5408 0.140265 12.3495 0.304092L7.05954 5.59409L1.76954 0.294092C1.58124 0.105788 1.32585 -3.72428e-09 1.05954 -1.74018e-09C0.793242 2.43924e-10 0.537847 0.105788 0.349544 0.294092C0.16124 0.482395 0.055452 0.73779 0.055452 1.00409C0.055452 1.27039 0.16124 1.52579 0.349544 1.71409L5.64954 7.00409L0.349544 12.2941C0.244862 12.3837 0.159841 12.4941 0.0998179 12.6181C0.0397946 12.7422 0.00606467 12.8773 0.000745174 13.015C-0.00457432 13.1528 0.0186315 13.2901 0.0689061 13.4184C0.119181 13.5467 0.195439 13.6633 0.292893 13.7607C0.390348 13.8582 0.506896 13.9345 0.635221 13.9847C0.763546 14.035 0.900878 14.0582 1.0386 14.0529C1.17632 14.0476 1.31145 14.0138 1.43551 13.9538C1.55958 13.8938 1.6699 13.8088 1.75954 13.7041L7.05954 8.41409L12.3495 13.7041C12.5408 13.8679 12.7869 13.9535 13.0386 13.9438C13.2903 13.9341 13.529 13.8297 13.7071 13.6517C13.8852 13.4736 13.9895 13.2348 13.9993 12.9831C14.009 12.7315 13.9234 12.4854 13.7595 12.2941L8.46954 7.00409Z"
-                fill="currentColor"></path>
-            </svg>
-          </button>
-          <nav aria-label="Primary navigation" class="rvt-header-menu" data-rvt-disclosure-target="menu" hidden>
-            {% include "@header-system-navigation-partial" %}
-          </nav>
-          <div data-rvt-disclosure="search"> 
+            <!-- Menu button that shows/hides navigation on smaller screens -->
+            <button aria-expanded="false" class="rvt-global-toggle rvt-global-toggle--menu rvt-hide-lg-up"
+              data-rvt-disclosure-toggle="menu">
+              <span class="rvt-sr-only">Menu</span>
+              <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__open" viewBox="0 0 16 16">
+                <g fill="currentColor">
+                  <path d="M15,3H1A1,1,0,0,1,1,1H15a1,1,0,0,1,0,2Z"></path>
+                  <path d="M15,9H1A1,1,0,0,1,1,7H15a1,1,0,0,1,0,2Z"></path>
+                  <path d="M15,15H1a1,1,0,0,1,0-2H15a1,1,0,0,1,0,2Z"></path>
+                </g>
+              </svg>
+              <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__close" fill="currentColor"
+                viewBox="0 0 16 16">
+                <path
+                  d="M8.46954 7.00409L13.7595 1.71409C13.9234 1.52279 14.009 1.27671 13.9993 1.02504C13.9895 0.773362 13.8852 0.534623 13.7071 0.356528C13.529 0.178434 13.2903 0.0741014 13.0386 0.0643803C12.7869 0.0546591 12.5408 0.140265 12.3495 0.304092L7.05954 5.59409L1.76954 0.294092C1.58124 0.105788 1.32585 -3.72428e-09 1.05954 -1.74018e-09C0.793242 2.43924e-10 0.537847 0.105788 0.349544 0.294092C0.16124 0.482395 0.055452 0.73779 0.055452 1.00409C0.055452 1.27039 0.16124 1.52579 0.349544 1.71409L5.64954 7.00409L0.349544 12.2941C0.244862 12.3837 0.159841 12.4941 0.0998179 12.6181C0.0397946 12.7422 0.00606467 12.8773 0.000745174 13.015C-0.00457432 13.1528 0.0186315 13.2901 0.0689061 13.4184C0.119181 13.5467 0.195439 13.6633 0.292893 13.7607C0.390348 13.8582 0.506896 13.9345 0.635221 13.9847C0.763546 14.035 0.900878 14.0582 1.0386 14.0529C1.17632 14.0476 1.31145 14.0138 1.43551 13.9538C1.55958 13.8938 1.6699 13.8088 1.75954 13.7041L7.05954 8.41409L12.3495 13.7041C12.5408 13.8679 12.7869 13.9535 13.0386 13.9438C13.2903 13.9341 13.529 13.8297 13.7071 13.6517C13.8852 13.4736 13.9895 13.2348 13.9993 12.9831C14.009 12.7315 13.9234 12.4854 13.7595 12.2941L8.46954 7.00409Z"
+                  fill="currentColor"></path>
+              </svg>
+            </button>
+            <nav aria-label="Primary navigation" class="rvt-header-menu" data-rvt-disclosure-target="menu" hidden>
+              {% include "@header-system-navigation-partial" %}
+            </nav>
+          </div>
+          <div data-rvt-disclosure="search">
               <!-- Button that shows/hides the search field -->
               <button class="rvt-global-toggle" data-rvt-disclosure-toggle="search" aria-expanded="false">
                   <span class="rvt-sr-only">Search</span>
@@ -79,79 +81,75 @@
       </div>
     </div>
   </div>
-  
+
   <!--
     TODO: Refactor this to use context data for nav items
   -->
   <div class="rvt-header-local">
     <div class="{{ siteContainer }}">
-      <div class="rvt-header-local__inner" data-rvt-disclosure="local-header-menu">
+      <div class="rvt-header-local__inner">
 
         <!-- Secondary navigation title -->
 
         <a href="#" class="rvt-header-local__title">Section title</a>
 
-        <!-- Menu button that shows/hides secondary navigation on smaller screens -->
+        <div data-rvt-disclosure="local-header-menu">
 
-        <button aria-expanded="false" class="rvt-global-toggle rvt-global-toggle--menu rvt-hide-lg-up"
-          data-rvt-disclosure-toggle="local-header-menu">
-          <span class="rvt-sr-only">Toggle local menu</span>
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-            <path fill="currentColor"
-              d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z" />
-          </svg>
-        </button>
-
-        <nav aria-label="Secondary navigation" class="rvt-header-menu" data-rvt-disclosure-target="local-header-menu" hidden>
-          <ul class="rvt-header-menu__list">
-            <!-- Secondary navigation link -->
-            <li class="rvt-header-menu__item">
-              <a class="rvt-header-menu__link" href="#">Section Item One</a>
-            </li>
-            <!-- Secondary navigation link with dropdown -->
-            <li class="rvt-header-menu__item">
-              <div class="rvt-header-menu__dropdown rvt-dropdown" data-rvt-dropdown="secondary-nav-2">
-                <div class="rvt-header-menu__group">
-                  <!-- Link that appears in secondary navigation -->
-                  <a class="rvt-header-menu__link" href="#">Section Item Two</a>
-                  <!-- Button that shows/hides dropdown links -->
-                  <button aria-expanded="false" class="rvt-dropdown__toggle rvt-header-menu__toggle"
-                    data-rvt-dropdown-toggle="secondary-nav-2">
-                    <span class="rvt-sr-only">Toggle Sub-navigation</span>
-                    <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__open" height="16"
-                      viewBox="0 0 16 16" width="16">
-                      <path
-                        d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"
-                        fill="currentColor"></path>
-                    </svg>
-                  </button>
+          <!-- Menu button that shows/hides secondary navigation on smaller screens -->
+          <button aria-expanded="false" class="rvt-global-toggle rvt-global-toggle--menu rvt-hide-lg-up"
+            data-rvt-disclosure-toggle="local-header-menu">
+            <span class="rvt-sr-only">Toggle local menu</span>
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+              <path fill="currentColor"
+                d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z" />
+            </svg>
+          </button>
+          <nav aria-label="Secondary navigation" class="rvt-header-menu" data-rvt-disclosure-target="local-header-menu" hidden>
+            <ul class="rvt-header-menu__list">
+              <!-- Secondary navigation link -->
+              <li class="rvt-header-menu__item">
+                <a class="rvt-header-menu__link" href="#">Section Item One</a>
+              </li>
+              <!-- Secondary navigation link with dropdown -->
+              <li class="rvt-header-menu__item">
+                <div class="rvt-header-menu__dropdown rvt-dropdown" data-rvt-dropdown="secondary-nav-2">
+                  <div class="rvt-header-menu__group">
+                    <!-- Link that appears in secondary navigation -->
+                    <a class="rvt-header-menu__link" href="#">Section Item Two</a>
+                    <!-- Button that shows/hides dropdown links -->
+                    <button aria-expanded="false" class="rvt-dropdown__toggle rvt-header-menu__toggle"
+                      data-rvt-dropdown-toggle="secondary-nav-2">
+                      <span class="rvt-sr-only">Toggle Sub-navigation</span>
+                      <svg xmlns="http://www.w3.org/2000/svg" class="rvt-global-toggle__open" height="16"
+                        viewBox="0 0 16 16" width="16">
+                        <path
+                          d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"
+                          fill="currentColor"></path>
+                      </svg>
+                    </button>
+                  </div>
+                  <div class="rvt-header-menu__submenu rvt-dropdown__menu rvt-dropdown__menu--right"
+                    data-rvt-dropdown-menu="secondary-nav-2" hidden>
+                    <ul class="rvt-header-menu__submenu-list">
+                      <!-- Dropdown links -->
+                      <li class="rvt-header-menu__submenu-item">
+                        <a class="rvt-header-menu__submenu-link" href="#">Sub Item One</a>
+                      </li>
+                      <li class="rvt-header-menu__submenu-item">
+                        <a class="rvt-header-menu__submenu-link" href="#">Sub Item Two</a>
+                      </li>
+                      <li class="rvt-header-menu__submenu-item">
+                        <a class="rvt-header-menu__submenu-link" href="#">Sub Item Three</a>
+                      </li>
+                    </ul>
+                  </div>
                 </div>
-                <div class="rvt-header-menu__submenu rvt-dropdown__menu rvt-dropdown__menu--right"
-                  data-rvt-dropdown-menu="secondary-nav-2" hidden>
-                  <ul class="rvt-header-menu__submenu-list">
-
-                    <!-- Dropdown links -->
-
-                    <li class="rvt-header-menu__submenu-item">
-                      <a class="rvt-header-menu__submenu-link" href="#">Sub Item One</a>
-                    </li>
-
-                    <li class="rvt-header-menu__submenu-item">
-                      <a class="rvt-header-menu__submenu-link" href="#">Sub Item Two</a>
-                    </li>
-
-                    <li class="rvt-header-menu__submenu-item">
-                      <a class="rvt-header-menu__submenu-link" href="#">Sub Item Three</a>
-                    </li>
-
-                  </ul>
-                </div>
-              </div>
-            </li>
-          </ul>
-        </nav>
+              </li>
+            </ul>
+          </nav>
+        </div>
       </div>
     </div>
   </div>
-  
+
 </header>

--- a/src/sass/header-system/_header-local.scss
+++ b/src/sass/header-system/_header-local.scss
@@ -10,6 +10,7 @@
     position: relative;
     display: flex;
     align-items: center;
+    justify-content: space-between;
     padding-top: $spacing-sm * .75;
     padding-bottom: $spacing-sm * .75;
   }
@@ -54,6 +55,10 @@
 
 @include mq($breakpoint-lg) {
   .rvt-header-local {
+    &__inner {
+      justify-content: flex-start;
+    }
+
     &__title {
       border-right: 1px solid $color-black-100;
       font-size: $ts-18;

--- a/src/sass/header-system/_header-menu.scss
+++ b/src/sass/header-system/_header-menu.scss
@@ -161,6 +161,7 @@
     left: unset;
     font-size: $ts-14;
     align-items: center;
+    width: auto;
 
     &__list {
       display: flex;


### PR DESCRIPTION
@scottanthonymurray This is maybe somewhat related to the other disclosure stuff you're working on, so I wanted to get this open.

It re-works the header navigation markup a bit so as to avoid the nested disclosure situation that currently exists. there are now two separate `data-rvt-disclosure` wrappers/root elements inside of the `rvt-header-global__controls` element in the the header and I've applied the CSS to position them correctly based on this new markup structure.