### PR TITLE
Added optional data-rvt-close-click-outside attribute to disclosure

### DIFF
--- a/src/components/disclosure/disclosure.njk
+++ b/src/components/disclosure/disclosure.njk
@@ -1,4 +1,4 @@
-<div class="rvt-disclosure" data-rvt-disclosure="disclosure-1">
+<div class="rvt-disclosure" data-rvt-disclosure="disclosure-1" data-rvt-close-click-outside>
   <button class="rvt-disclosure__toggle" data-rvt-disclosure-toggle aria-expanded="false">Disclose more information</button>
   <div class="rvt-disclosure__content" data-rvt-disclosure-target hidden>
     <div class="rvt-prose rvt-flow">

--- a/src/js/components/disclosure.js
+++ b/src/js/components/disclosure.js
@@ -118,7 +118,21 @@ export default class Disclosure extends Component {
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
 
-        this._addDocumentEventHandlers()
+        if (this._shouldAddDocumentEventHandlers()) {
+          this._addDocumentEventHandlers()
+        }
+      },
+
+      /************************************************************************
+       * Returns true if document event handlers should be added for this
+       * disclosure instance.
+       *
+       * @private
+       * @returns {boolean} Should add external event handlers
+       ***********************************************************************/
+
+      _shouldAddDocumentEventHandlers () {
+        return this.element.hasAttribute('data-rvt-close-click-outside')
       },
 
       /************************************************************************

--- a/src/js/components/disclosure.js
+++ b/src/js/components/disclosure.js
@@ -152,6 +152,18 @@ export default class Disclosure extends Component {
 
       disconnected () {
         Component.dispatchComponentRemovedEvent(this.element)
+
+        this._removeDocumentEventHandlers()
+      },
+
+      /************************************************************************
+       * Removes document event handlers related to the disclosure.
+       *
+       * @private
+       ***********************************************************************/
+
+      _removeDocumentEventHandlers () {
+        document.removeEventListener('click', this._onDocumentClick, false)
       },
 
       /************************************************************************

--- a/src/js/components/disclosure.js
+++ b/src/js/components/disclosure.js
@@ -47,6 +47,7 @@ export default class Disclosure extends Component {
         this._initElements()
         this._initProperties()
         this._removeIconFromTabOrder()
+        this._bindExternalEventHandlers()
 
         Component.bindMethodToDOMElement(this, 'open', this.open)
         Component.bindMethodToDOMElement(this, 'close', this.close)
@@ -100,11 +101,35 @@ export default class Disclosure extends Component {
       },
 
       /************************************************************************
+       * Binds the disclosure instance to handler methods for relevant events
+       * that originate outside the component's root DOM element.
+       *
+       * @private
+       ***********************************************************************/
+
+      _bindExternalEventHandlers () {
+        this._onDocumentClick = this._onDocumentClick.bind(this)
+      },
+
+      /************************************************************************
        * Called when the disclosure is added to the DOM.
        ***********************************************************************/
 
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
+
+        this._addDocumentEventHandlers()
+      },
+
+      /************************************************************************
+       * Adds event handlers to the document that are related to the
+       * disclosure.
+       *
+       * @private
+       ***********************************************************************/
+
+      _addDocumentEventHandlers () {
+        document.addEventListener('click', this._onDocumentClick, false)
       },
 
       /************************************************************************
@@ -227,6 +252,32 @@ export default class Disclosure extends Component {
 
       _clickOriginatedInsideDisclosureTarget (event) {
         return this.targetElement.contains(event.target)
+      },
+
+      /************************************************************************
+       * Handles click events broadcast to the document that are related to
+       * the disclosure but did not originate inside the disclosure itself.
+       *
+       * @param {Event} event - Click event
+       ***********************************************************************/
+
+      _onDocumentClick (event) {
+        if (!this._clickOriginatedOutsideDisclosure(event)) { return }
+
+        if (!this._isOpen()) { return }
+
+        this.close()
+      },
+
+      /************************************************************************
+       * Returns true if the click event originated inside the disclosure.
+       *
+       * @param {Event} event - Click event
+       * @returns {boolean} Event originated outside disclosure
+       ***********************************************************************/
+
+      _clickOriginatedOutsideDisclosure (event) {
+        return ! this.element.contains(event.target)
       },
 
       /************************************************************************


### PR DESCRIPTION
This PR adds support for an optional `data-rvt-close-click-outside` attribute that can be added to a disclosure component's root element.

If present, the disclosure will close itself if the user clicks anywhere outside the disclosure element.

The dropdown and modal have similar functionality, but implemented slightly differently due to the unique nature of both components. I'll attempt to DRY this out a little in a separate PR.