### PR TITLE
Implemented data-rvt-disclosure-open-on-init attribute

### DIFF
--- a/src/components/disclosure/disclosure.njk
+++ b/src/components/disclosure/disclosure.njk
@@ -1,4 +1,4 @@
-<div class="rvt-disclosure" data-rvt-disclosure="disclosure-1" data-rvt-close-click-outside>
+<div class="rvt-disclosure" data-rvt-disclosure="disclosure-1" data-rvt-close-click-outside data-rvt-disclosure-open-on-init>
   <button class="rvt-disclosure__toggle" data-rvt-disclosure-toggle aria-expanded="false">Disclose more information</button>
   <div class="rvt-disclosure__content" data-rvt-disclosure-target hidden>
     <div class="rvt-prose rvt-flow">

--- a/src/js/components/disclosure.js
+++ b/src/js/components/disclosure.js
@@ -46,6 +46,7 @@ export default class Disclosure extends Component {
         this._initSelectors()
         this._initElements()
         this._initProperties()
+        this._setInitialDisclosureState()
         this._removeIconFromTabOrder()
         this._bindExternalEventHandlers()
 
@@ -86,6 +87,26 @@ export default class Disclosure extends Component {
 
       _initProperties () {
         this.isOpen = false
+      },
+
+      /************************************************************************
+       * Sets the initial state of the disclosure.
+       *
+       * @private
+       ***********************************************************************/
+
+      _setInitialDisclosureState () {
+        if (this._shouldBeOpenByDefault()) { this.open() }
+      },
+
+      /************************************************************************
+       * Returns true if the disclosure should be open by default.
+       *
+       * @private
+       ***********************************************************************/
+
+      _shouldBeOpenByDefault () {
+        return this.element.hasAttribute('data-rvt-disclosure-open-on-init')
       },
 
       /************************************************************************


### PR DESCRIPTION
This PR implements the missing `data-rvt-disclosure-open-on-init` attribute for the disclosure component.

This attribute was listed in the documentation but never implemented.