### PR TITLE
Fixed code error preventing modal dialog functionality from working

### DIFF
--- a/src/js/components/modal.js
+++ b/src/js/components/modal.js
@@ -65,7 +65,7 @@ export default class Modal extends Component {
         this.innerModalAttribute = 'data-rvt-modal-inner'
         this.triggerAttribute = 'data-rvt-modal-trigger'
         this.closeButtonAttribute = 'data-rvt-modal-close'
-        this.dialogAttribute = this.dialogAttribute
+        this.dialogAttribute = 'data-rvt-modal-dialog'
 
         this.innerModalSelector = `[${this.innerModalAttribute}]`
         this.triggerSelector = `[${this.triggerAttribute}]`


### PR DESCRIPTION
This PR fixes an error in the modal component JS that prevented the `data-rvt-modal-dialog` attribute from working properly.