### PR TITLE
Added missing event.preventDefault() call to dropdown down key handler

### DIFF
--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -393,6 +393,8 @@ export default class Dropdown extends Component {
        ***********************************************************************/
 
       _handleDownKey (event) {
+        event.preventDefault()
+        
         if (!this._isOpen()) { this.open() }
 
         this._eventOriginatedInsideMenu(event)


### PR DESCRIPTION
The up key handler already calls `event.preventDefault()`.