### PR TITLE
Removed colon from CustomEvent names

### DIFF
--- a/cypress/integration/accordion_spec.js
+++ b/cypress/integration/accordion_spec.js
@@ -40,7 +40,7 @@ describe('Rivet accordion interactions', function () {
     cy.get('@panel1').should('not.be.visible');
   });
 });
-  
+
 describe('Keyboard interactions', function () {
   it('Should be able to cycle through toggles using the Down key', function () {
     // Test cycling through each panel toggle using the Down key
@@ -56,7 +56,7 @@ describe('Keyboard interactions', function () {
     cy.get('@trigger4').type('{downarrow}');
     cy.get('@trigger1').should('to.have.focus');
   });
-  
+
   it('Should be able to cycle through toggles using the Up key', function () {
     // Test cycling through each panel toggle using the Up key
     cy.get('@trigger4').type('{uparrow}');
@@ -71,12 +71,12 @@ describe('Keyboard interactions', function () {
     cy.get('@trigger1').type('{uparrow}');
     cy.get('@trigger4').should('to.have.focus');
   });
-  
+
   it('Should be able to jump to the last toggle using the End key', function() {
     cy.get('@trigger1').type('{end}');
     cy.get('@trigger4').should('to.have.focus');
   });
-  
+
   it('Should be able to jump to the first toggle using the Home key', function() {
     cy.get('@trigger4').type('{home}');
     cy.get('@trigger1').should('to.have.focus');
@@ -112,42 +112,42 @@ describe('API methods', function () {
 });
 
 describe('Custom events', function () {
-  it('Should fire a rvt:accordionOpened custom event with correct element references', function() {
+  it('Should fire a rvtAccordionOpened custom event with correct element references', function() {
     cy.window().then(win => {
       var accordion = win.document.querySelector('[data-rvt-accordion="my-new-accordion"]');
       var eventFired = false;
       var eventAccordionReference;
       var eventPanelReference;
-      
-      win.addEventListener('rvt:accordionOpened', event => {
+
+      win.addEventListener('rvtAccordionOpened', event => {
         eventFired = true;
         eventAccordionReference = event.target == accordion;
         eventPanelReference = event.detail.panel.dataset.rvtAccordionPanel == 'my-new-accordion-1';
       });
-      
+
       accordion.open('my-new-accordion-1');
-      
-      if (!eventFired) throw new Error('Did not fire accordionOpened event');
+
+      if (!eventFired) throw new Error('Did not fire AccordionOpened event');
       if (!eventAccordionReference) throw new Error('Did not pass correct reference to emitting accordion component element');
       if (!eventPanelReference) throw new Error('Did not pass correct reference to opened panel element');
     });
   });
 
-  it('Should fire a rvt:accordionClosed custom event with correct element references', function() {
+  it('Should fire a rvtAccordionClosed custom event with correct element references', function() {
     cy.window().then(win => {
       var accordion = win.document.querySelector('[data-rvt-accordion="my-new-accordion"]');
       var eventFired = false;
       var eventAccordionReference;
       var eventPanelReference;
-      
-      win.addEventListener('rvt:accordionClosed', event => {
+
+      win.addEventListener('rvtAccordionClosed', event => {
         eventFired = true;
         eventAccordionReference = event.target == accordion;
         eventPanelReference = event.detail.panel.dataset.rvtAccordionPanel == 'my-new-accordion-1';
       });
-      
+
       accordion.close('my-new-accordion-1');
-      
+
       if (!eventFired) throw new Error('Did not fire accordionClosed event');
       if (!eventAccordionReference) throw new Error('Did not pass correct reference to emitting accordion component element');
       if (!eventPanelReference) throw new Error('Did not pass correct reference to closed panel element');

--- a/cypress/integration/alert_spec.js
+++ b/cypress/integration/alert_spec.js
@@ -37,20 +37,20 @@ describe('Rivet alert interactions', function () {
     cy.get('@warningAlert').should('not.exist');
   });
 
-  it('Should fire a rvt:alertDismissed custom event with correct element references', function() {
+  it('Should fire a rvtAlertDismissed custom event with correct element references', function() {
     cy.window().then(win => {
       var alert = win.document.querySelector('[data-rvt-alert="warning"]');
       var eventFired = false;
       var eventAlertReference;
-      
-      win.addEventListener('rvt:alertDismissed', event => {
+
+      win.addEventListener('rvtAlertDismissed', event => {
         eventFired = true;
         eventAlertReference = event.target == alert;
       });
-      
+
       alert.dismiss();
-      
-      if (!eventFired) throw new Error('Did not fire alertDismissed event');
+
+      if (!eventFired) throw new Error('Did not fire AlertDismissed event');
       if (!eventAlertReference) throw new Error('Did not pass correct reference to emitting alert component element');
     });
   });

--- a/cypress/integration/dialog_spec.js
+++ b/cypress/integration/dialog_spec.js
@@ -101,38 +101,38 @@ describe('Rivet basic dialog interactions', function () {
     cy.get('[data-rvt-dialog="dialogExample"]').should('be.focused');
   });
 
-  it('Should fire a rvt:dialogOpened custom event with correct element references', function() {
+  it('Should fire a rvtDialogOpened custom event with correct element references', function() {
     cy.window().then(win => {
       var dialog = win.document.querySelector('[data-rvt-dialog="dialogExample"]');
       var eventFired = false;
       var eventDialogReference;
-      
-      win.addEventListener('rvt:dialogOpened', event => {
+
+      win.addEventListener('rvtDialogOpened', event => {
         eventFired = true;
         eventDialogReference = event.target == dialog;
       });
-      
+
       dialog.open();
-      
+
       if (!eventFired) throw new Error('Did not fire dialogOpened event');
       if (!eventDialogReference) throw new Error('Did not pass correct reference to emitting dialog component element');
     });
   });
 
-  it('Should fire a rvt:dialogClosed custom event with correct element references', function() {
+  it('Should fire a rvtDialogClosed custom event with correct element references', function() {
     cy.window().then(win => {
       var dialog = win.document.querySelector('[data-rvt-dialog="dialogExample"]');
       var eventFired = false;
       var eventDialogReference;
-      
-      win.addEventListener('rvt:dialogClosed', event => {
+
+      win.addEventListener('rvtDialogClosed', event => {
         eventFired = true;
         eventDialogReference = event.target == dialog;
       });
-      
+
       dialog.open();
       dialog.close();
-      
+
       if (!eventFired) throw new Error('Did not fire dialogClosed event');
       if (!eventDialogReference) throw new Error('Did not pass correct reference to emitting dialog component element');
     });

--- a/cypress/integration/disclosure_spec.js
+++ b/cypress/integration/disclosure_spec.js
@@ -11,40 +11,40 @@ describe('Disclosure Interaction', function() {
   });
 
   it('Should see the disclosure toggle', function() {
-    cy.get(DISCLOSURE_TOGGLE).should('have.attr', 'aria-expanded', 'false');
+    cy.get(DISCLOSURE_TOGGLE).first().should('have.attr', 'aria-expanded', 'false');
 
-    cy.get(DISCLOSURE_TARGET)
+    cy.get(DISCLOSURE_TARGET).first()
       .should('not.be.visible')
       .and('have.attr', 'hidden');
-      
+
   });
 
   it('Should be able to open the disclosure', function() {
-    cy.get(DISCLOSURE_TOGGLE)
+    cy.get(DISCLOSURE_TOGGLE).first()
       .click()
       .should('have.attr', 'aria-expanded', 'true');
 
-    cy.get(DISCLOSURE_TARGET)
+    cy.get(DISCLOSURE_TARGET).first()
       .should('be.visible')
       .and('not.have.attr', 'hidden');
   });
 
   it('Should be able to close the disclosure', function() {
-    cy.get(DISCLOSURE_TOGGLE)
+    cy.get(DISCLOSURE_TOGGLE).first()
       .click()
       .should('have.attr', 'aria-expanded', 'false');
 
-    cy.get(DISCLOSURE_TARGET)
+    cy.get(DISCLOSURE_TARGET).first()
       .should('not.be.visible')
       .and('have.attr', 'hidden');
   });
 
   it('Should be able to close with esc key', function() {
-    cy.get(DISCLOSURE_TOGGLE).click();
+    cy.get(DISCLOSURE_TOGGLE).first().click();
 
     cy.focused().trigger('keydown', { keyCode: ESC, which: ESC });
 
-    cy.get(DISCLOSURE_TARGET).should('not.be.visible');
+    cy.get(DISCLOSURE_TARGET).first().should('not.be.visible');
   });
 
   it('Should be able to open with .open() method', function() {
@@ -73,37 +73,37 @@ describe('Disclosure Interaction', function() {
       .and('have.attr', 'hidden');
   });
 
-  it('Should fire a rvt:disclosureOpened custom event with correct element references', function() {
+  it('Should fire a rvtDisclosureOpened custom event with correct element references', function() {
     cy.window().then(win => {
       var disclosure = win.document.querySelector(DISCLOSURE);
       var eventFired = false;
       var eventDisclosureReference;
-      
-      win.addEventListener('rvt:disclosureOpened', event => {
+
+      win.addEventListener('rvtDisclosureOpened', event => {
         eventFired = true;
         eventDisclosureReference = event.target == disclosure;
       });
-      
+
       disclosure.open();
-      
+
       if (!eventFired) throw new Error('Did not fire disclosureOpened event');
       if (!eventDisclosureReference) throw new Error('Did not pass correct reference to emitting disclosure component element');
     });
   });
 
-  it('Should fire a rvt:disclosureClosed custom event with correct element references', function() {
+  it('Should fire a rvtDisclosureClosed custom event with correct element references', function() {
     cy.window().then(win => {
       var disclosure = win.document.querySelector(DISCLOSURE);
       var eventFired = false;
       var eventDisclosureReference;
-      
-      win.addEventListener('rvt:disclosureClosed', event => {
+
+      win.addEventListener('rvtDisclosureClosed', event => {
         eventFired = true;
         eventDisclosureReference = event.target == disclosure;
       });
-      
+
       disclosure.close();
-      
+
       if (!eventFired) throw new Error('Did not fire disclosureClosed event');
       if (!eventDisclosureReference) throw new Error('Did not pass correct reference to emitting disclosure component element');
     });

--- a/cypress/integration/dropdown_spec.js
+++ b/cypress/integration/dropdown_spec.js
@@ -98,37 +98,37 @@ describe('Dropdown Interaction', function() {
       .and('not.have.attr', 'hidden');
   });
 
-  it('Should fire a rvt:dropdownOpened custom event with correct element references', function() {
+  it('Should fire a rvtDropdownOpened custom event with correct element references', function() {
     cy.window().then(win => {
       var dropdown = win.document.querySelector(DROPDOWN);
       var eventFired = false;
       var eventDropdownReference;
-      
-      win.addEventListener('rvt:dropdownOpened', event => {
+
+      win.addEventListener('rvtDropdownOpened', event => {
         eventFired = true;
         eventDropdownReference = event.target == dropdown;
       });
-      
+
       dropdown.open();
-      
+
       if (!eventFired) throw new Error('Did not fire dropdownOpened event');
       if (!eventDropdownReference) throw new Error('Did not pass correct reference to emitting dropdown component element');
     });
   });
 
-  it('Should fire a rvt:dropdownClosed custom event with correct element references', function() {
+  it('Should fire a rvtDropdownClosed custom event with correct element references', function() {
     cy.window().then(win => {
       var dropdown = win.document.querySelector(DROPDOWN);
       var eventFired = false;
       var eventDropdownReference;
-      
-      win.addEventListener('rvt:dropdownClosed', event => {
+
+      win.addEventListener('rvtDropdownClosed', event => {
         eventFired = true;
         eventDropdownReference = event.target == dropdown;
       });
-      
+
       dropdown.close();
-      
+
       if (!eventFired) throw new Error('Did not fire dropdownClosed event');
       if (!eventDropdownReference) throw new Error('Did not pass correct reference to emitting dropdown component element');
     });

--- a/cypress/integration/sidenav_spec.js
+++ b/cypress/integration/sidenav_spec.js
@@ -14,61 +14,61 @@ describe('Sidenav Interaction', function() {
   it('Should toggle visibility of a nested list', function() {
     cy.get('@list')
       .should('be.hidden');
-      
+
     cy.get('@toggle')
       .should('have.attr', 'aria-expanded', 'false')
       .and('have.attr', 'aria-haspopup', 'true')
       .click()
       .should('have.attr', 'aria-expanded', 'true');
-      
+
     cy.get('@list')
       .should('be.visible');
-      
+
     cy.get('@toggle')
       .should('have.attr', 'aria-expanded', 'true')
       .click()
       .should('have.attr', 'aria-expanded', 'false');
-    
+
     cy.get('@list')
       .should('be.not.visible');
   });
 
-  it('Should fire a rvt:sidenavListOpened custom event with correct element references', function() {
+  it('Should fire a rvtSidenavListOpened custom event with correct element references', function() {
     cy.window().then(win => {
       var sidenav = win.document.querySelector('[data-rvt-sidenav]');
       var eventFired = false;
       var eventSidenavReference;
       var eventListReference;
-      
-      win.addEventListener('rvt:sidenavListOpened', event => {
+
+      win.addEventListener('rvtSidenavListOpened', event => {
         eventFired = true;
         eventSidenavReference = event.target == sidenav;
         eventListReference = event.detail.list.dataset.rvtSidenavList == 'toggle-2';
       });
-      
+
       sidenav.open('toggle-2');
-      
+
       if (!eventFired) throw new Error('Did not fire sidenavListOpened event');
       if (!eventSidenavReference) throw new Error('Did not pass correct reference to emitting sidenav component element');
       if (!eventListReference) throw new Error('Did not pass correct reference to opened list element');
     });
   });
 
-  it('Should fire a rvt:sidenavListClosed custom event with correct element references', function() {
+  it('Should fire a rvtSidenavListClosed custom event with correct element references', function() {
     cy.window().then(win => {
       var sidenav = win.document.querySelector('[data-rvt-sidenav]');
       var eventFired = false;
       var eventSidenavReference;
       var eventListReference;
-      
-      win.addEventListener('rvt:sidenavListClosed', event => {
+
+      win.addEventListener('rvtSidenavListClosed', event => {
         eventFired = true;
         eventSidenavReference = event.target == sidenav;
         eventListReference = event.detail.list.dataset.rvtSidenavList == 'toggle-2';
       });
-      
+
       sidenav.close('toggle-2');
-      
+
       if (!eventFired) throw new Error('Did not fire sidenavListClosed event');
       if (!eventSidenavReference) throw new Error('Did not pass correct reference to emitting sidenav component element');
       if (!eventListReference) throw new Error('Did not pass correct reference to opened list element');

--- a/cypress/integration/tabs_spec.js
+++ b/cypress/integration/tabs_spec.js
@@ -60,21 +60,21 @@ describe('Rivet tab interactions', function () {
     cy.get('[data-rvt-tab-panel="tab-2"]').should('be.visible').should('not.have.attr', 'hidden');
   });
 
-  it('Should fire a rvt:tabActivated custom event with correct element references', function() {
+  it('Should fire a rvtTtabActivated custom event with correct element references', function() {
     cy.window().then(win => {
       var tabs = win.document.querySelector('[data-rvt-tabs="tabset-1"]');
       var eventFired = false;
       var eventTabsReference;
       var eventTabPanelReference;
-      
-      win.addEventListener('rvt:tabActivated', event => {
+
+      win.addEventListener('rvtTtabActivated', event => {
         eventFired = true;
         eventTabsReference = event.target == tabs;
         eventTabPanelReference = event.detail.tab.dataset.rvtTabPanel == 'tab-1';
       });
-      
+
       tabs.activateTab('tab-1');
-      
+
       if (!eventFired) throw new Error('Did not fire tabActivated event');
       if (!eventTabsReference) throw new Error('Did not pass correct reference to emitting tabs component element');
       if (!eventTabPanelReference) throw new Error('Did not pass correct reference to activated tab element');

--- a/src/components/accordion/README.md
+++ b/src/components/accordion/README.md
@@ -87,8 +87,8 @@ If you use the appropriate data attribute/id combination in your markup, accordi
 
 | Event                 | Description                                                                                                                                                                                                                                                                             |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `rvt:accordionOpened` | Emitted when an accordion panel is opened (using the Accordion.open() method, or the data-rvt-accordion-trigger attribute). The value of the accordion id attribute is also passed along via the custom event’s detail property and is available to use in your scripts as event.detail.id  |
-| `rvt:accordionClosed` | Emitted when an accordion panel is closed (using the Accordion.close() method, or the data-rvt-accordion-trigger attribute). The value of the accordion id attribute is also passed along via the custom event’s detail property and is available to use in your scripts as event.detail.id |
+| `rvtAccordionOpened` | Emitted when an accordion panel is opened (using the Accordion.open() method, or the data-rvt-accordion-trigger attribute). The value of the accordion id attribute is also passed along via the custom event’s detail property and is available to use in your scripts as event.detail.id  |
+| `rvtAccordionClosed` | Emitted when an accordion panel is closed (using the Accordion.close() method, or the data-rvt-accordion-trigger attribute). The value of the accordion id attribute is also passed along via the custom event’s detail property and is available to use in your scripts as event.detail.id |
 
 ## Accessibility (a11y) requirements
 

--- a/src/components/disclosure/disclosure.njk
+++ b/src/components/disclosure/disclosure.njk
@@ -1,4 +1,4 @@
-<div class="rvt-disclosure" data-rvt-disclosure="disclosure-1" data-rvt-close-click-outside data-rvt-disclosure-open-on-init>
+<div class="rvt-disclosure" data-rvt-disclosure="disclosure-1" data-rvt-close-click-outside>
   <button class="rvt-disclosure__toggle" data-rvt-disclosure-toggle aria-expanded="false">Disclose more information</button>
   <div class="rvt-disclosure__content" data-rvt-disclosure-target hidden>
     <div class="rvt-prose rvt-flow">

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -320,7 +320,7 @@ export default class Accordion extends Component {
           return
         }
 
-        if (!this._eventDispatched('accordionOpened', this.panelToOpen)) { return }
+        if (!this._eventDispatched('AccordionOpened', this.panelToOpen)) { return }
 
         this._openPanel()
       },
@@ -379,7 +379,7 @@ export default class Accordion extends Component {
           return
         }
 
-        if (!this._eventDispatched('accordionClosed', this.panelToClose)) { return }
+        if (!this._eventDispatched('AccordionClosed', this.panelToClose)) { return }
 
         this._closePanel()
       },

--- a/src/js/components/alert.js
+++ b/src/js/components/alert.js
@@ -129,7 +129,7 @@ export default class Alert extends Component {
 
       _dismissEventDispatched () {
         const dispatched = Component.dispatchCustomEvent(
-          'alertDismissed',
+          'AlertDismissed',
           this.element
         )
 

--- a/src/js/components/component.js
+++ b/src/js/components/component.js
@@ -11,7 +11,7 @@ import { define } from 'wicked-elements'
  *****************************************************************************/
 
 export default class Component {
-  
+
   /****************************************************************************
    * Initializes all current and future instances of the component that are
    * added to the DOM.
@@ -89,7 +89,7 @@ export default class Component {
 
   static dispatchCustomEvent (eventName, element, detail = {}) {
     const prefix = globalSettings.prefix
-    const event = new CustomEvent(`${prefix}:${eventName}`, {
+    const event = new CustomEvent(`${prefix}${eventName}`, {
       bubbles: true,
       cancelable: true,
       detail
@@ -107,7 +107,7 @@ export default class Component {
    ***************************************************************************/
 
   static dispatchComponentAddedEvent (element) {
-    return this.dispatchCustomEvent('componentAdded', document, {
+    return this.dispatchCustomEvent('ComponentAdded', document, {
       component: element
     })
   }
@@ -121,7 +121,7 @@ export default class Component {
    ***************************************************************************/
 
   static dispatchComponentRemovedEvent (element) {
-    return this.dispatchCustomEvent('componentRemoved', document, {
+    return this.dispatchCustomEvent('ComponentRemoved', document, {
       component: element
     })
   }

--- a/src/js/components/dialog.js
+++ b/src/js/components/dialog.js
@@ -89,7 +89,7 @@ export default class Dialog extends Component {
         this.closeButtons = Array.from(
           this.element.querySelectorAll(this.closeButtonSelector)
         )
-        
+
         this.lastClickedTriggerButton = null
       },
 
@@ -459,7 +459,7 @@ export default class Dialog extends Component {
       open () {
         if (this._isOpen()) { return }
 
-        if (!this._eventDispatched('dialogOpened')) { return }
+        if (!this._eventDispatched('DialogOpened')) { return }
 
         this._setOpenState()
         this.focusDialog()
@@ -537,7 +537,7 @@ export default class Dialog extends Component {
       close () {
         if (!this._isOpen()) { return }
 
-        if (!this._eventDispatched('dialogClosed')) { return }
+        if (!this._eventDispatched('DialogClosed')) { return }
 
         this._setClosedState()
 

--- a/src/js/components/disclosure.js
+++ b/src/js/components/disclosure.js
@@ -194,7 +194,7 @@ export default class Disclosure extends Component {
       open () {
         if (this._isDisabled()) { return }
 
-        if (!this._eventDispatched('disclosureOpened')) { return }
+        if (!this._eventDispatched('DisclosureOpened')) { return }
 
         this._setOpenState()
       },
@@ -230,7 +230,7 @@ export default class Disclosure extends Component {
       close () {
         if (!this._isOpen()) { return }
 
-        if (!this._eventDispatched('disclosureClosed')) { return }
+        if (!this._eventDispatched('DisclosureClosed')) { return }
 
         this._setClosedState()
       },

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -14,7 +14,7 @@ import keyCodes from '../utilities/keyCodes'
  *****************************************************************************/
 
 export default class Dropdown extends Component {
-  
+
   /****************************************************************************
    * Gets the dropdown's CSS selector.
    *
@@ -173,7 +173,7 @@ export default class Dropdown extends Component {
       open () {
         if (this._toggleElementIsDisabled()) { return }
 
-        if (!this._eventDispatched('dropdownOpened')) { return }
+        if (!this._eventDispatched('DropdownOpened')) { return }
 
         this._setOpenState()
       },
@@ -210,7 +210,7 @@ export default class Dropdown extends Component {
       close () {
         if (!this._isOpen()) { return }
 
-        if (!this._eventDispatched('dropdownClosed')) { return }
+        if (!this._eventDispatched('DropdownClosed')) { return }
 
         this._setClosedState()
       },
@@ -395,7 +395,7 @@ export default class Dropdown extends Component {
 
       _handleDownKey (event) {
         event.preventDefault()
-        
+
         if (!this._isOpen()) { this.open() }
 
         this._eventOriginatedInsideMenu(event)

--- a/src/js/components/fileInput.js
+++ b/src/js/components/fileInput.js
@@ -138,7 +138,7 @@ export default class FileInput extends Component {
       _attachEventDispatched () {
         const files = Array.from(this.inputElement.files).map(f => f.name)
         const dispatched = Component.dispatchCustomEvent(
-          'fileAttached',
+          'FileAttached',
           this.element,
           { files }
         )

--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -13,7 +13,7 @@ import Component from './component'
  *****************************************************************************/
 
 export default class Sidenav extends Component {
-  
+
   /****************************************************************************
    * Gets the sidenav's CSS selector.
    *
@@ -251,7 +251,7 @@ export default class Sidenav extends Component {
           return
         }
 
-        if (!this._eventDispatched('sidenavListOpened', this.childMenuToOpen)) { return }
+        if (!this._eventDispatched('SidenavListOpened', this.childMenuToOpen)) { return }
 
         this._openChildMenu()
       },
@@ -299,7 +299,7 @@ export default class Sidenav extends Component {
           return
         }
 
-        if (!this._eventDispatched('sidenavListClosed', this.childMenuToClose)) { return }
+        if (!this._eventDispatched('SidenavListClosed', this.childMenuToClose)) { return }
 
         this._closeChildMenu()
       },

--- a/src/js/components/tabs.js
+++ b/src/js/components/tabs.js
@@ -299,7 +299,7 @@ export default class Tabs extends Component {
 
       _tabActivatedEventDispatched () {
         const dispatched = Component.dispatchCustomEvent(
-          'tabActivated',
+          'TabActivated',
           this.element,
           { tab: this.panelToActivate }
         )

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -53,7 +53,9 @@
   }
 
   > :where(dl) {
+    /* stylelint-disable */
     @extend .#{$prefix}-list-description;
+    /* stylelint-enable */
   }
 
   > *:empty:not(hr) {


### PR DESCRIPTION
This PR updates all custom event names to remove colons from the event name. This is a JavaScript API change that needed to be made before the production 2.0.0 release due to the potential for conflict with the way some JavaScript libraries like Vue.js attach event listeners directly in templates like `<div @rvtDisclosureOpened="someComponentMethod" />`. The colon could interfere with other conventions used like data binding via the `<div :class="someProperty" />` shorthand.