### PR TITLE
Fixed bug where cards displayed incorrectly inside of some grid items

### DIFF
--- a/src/sass/grid/_base.scss
+++ b/src/sass/grid/_base.scss
@@ -122,6 +122,7 @@ $gutter: math.div($spacing-md, 2);
      * big for their parent .#{$prefix}-row__cols.
      */
     min-width: 0;
+    display: block;
   }
 }
 


### PR DESCRIPTION
This should fix the card list bug in safari based on the testing I did locally.