### PR TITLE
Added .rvt-font-mono utility class

### DIFF
--- a/src/components/01-utilities/text.njk
+++ b/src/components/01-utilities/text.njk
@@ -11,3 +11,8 @@
 <h2 class="rvt-ts-29">Font utilities</h2>
 <p class="rvt-font-sans">Benton sans</p>
 <p class="rvt-font-serif">Georgia Pro</p>
+
+<div class="rvt-prose rvt-flow">
+  <h2>Title</h2>
+  <p>This is some <code>text hello</code>.</p>
+</div>

--- a/src/components/01-utilities/text.njk
+++ b/src/components/01-utilities/text.njk
@@ -11,6 +11,7 @@
 <h2 class="rvt-ts-29">Font utilities</h2>
 <p class="rvt-font-sans">Benton sans</p>
 <p class="rvt-font-serif">Georgia Pro</p>
+<p class="rvt-font-mono">Monospace text</p>
 
 <div class="rvt-prose rvt-flow">
   <h2>Title</h2>

--- a/src/sass/utilities/_prose.scss
+++ b/src/sass/utilities/_prose.scss
@@ -1,5 +1,6 @@
 @use '../core' as *;
 @use '../lists';
+@use '../utilities/elements';
 
 .rvt-prose {
   // Benton sans feels really compact and can benefit from a little extra
@@ -55,6 +56,12 @@
   > :where(dl) {
     /* stylelint-disable */
     @extend .#{$prefix}-list-description;
+    /* stylelint-enable */
+  }
+
+  :where(code) {
+    /* stylelint-disable */
+    @extend .#{$prefix}-code;
     /* stylelint-enable */
   }
 

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -61,6 +61,6 @@
   font-family: $font-serif;
 }
 
-.#{prefix}-font-mono {
+.#{$prefix}-font-mono {
   font-family: $font-mono;
 }

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -60,3 +60,7 @@
 .#{$prefix}-font-serif {
   font-family: $font-serif;
 }
+
+.#{prefix}-font-mono {
+  font-family: $font-mono;
+}

--- a/src/tokens/fonts.json
+++ b/src/tokens/fonts.json
@@ -9,6 +9,9 @@
     "serif": {
       "value": "'GeorgiaPro', Georgia, 'Times New Roman', Times, serif"
     },
+    "mono": {
+      "value": "monospace"
+    },
     "weight": {
       "bold": {
         "value": "700"


### PR DESCRIPTION
This PR also updates the `.rvt-prose` utility class to support the `code` element. _(At present, the `.rvt-prose` paragraph styles overrides the browser default `code` styles.)_