### PR TITLE
Added repo filter to build-changelog workflow action

### DIFF
--- a/gh-actions/build-changelog/index.js
+++ b/gh-actions/build-changelog/index.js
@@ -6,7 +6,7 @@ async function run() {
     const myToken = core.getInput('GITHUB_TOKEN');
     const tag = core.getInput('tag_name', { required: true });
     const label = tag.substr(10, tag.length - 1);
-    const query = `type:pr+label:${label}`;
+    const query = `repo:indiana-university/rivet-source+type:pr+label:${label}`;
     const octokit = new GitHub(myToken);
 
     const { data: pullRequest } = await octokit.search.issuesAndPullRequests({


### PR DESCRIPTION
This PR fixes a bug with the `build-changelog` workflow action that caused it to fetch pull requests from *all* repos, rather than just `rivet-source`.