### PR TITLE
Updated components to refresh internal lists of child elements on DOM change

### DIFF
--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -148,23 +148,7 @@ export default class Accordion extends Component {
 
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
-
-        this._watchForDOMChanges()
-      },
-
-      /************************************************************************
-       * Watches the component's DOM and updates references to child elements
-       * if the DOM changes.
-       *
-       * @private
-       ***********************************************************************/
-
-      _watchForDOMChanges () {
-        this.observer = new MutationObserver((mutationList, observer) => {
-          this._initElements()
-        })
-
-        this.observer.observe(this.element, { childList: true, subtree: true })
+        Component.watchForDOMChanges(self)
       },
 
       /************************************************************************
@@ -173,18 +157,7 @@ export default class Accordion extends Component {
 
       disconnected () {
         Component.dispatchComponentRemovedEvent(this.element)
-
-        this._stopWatchingForDOMChanges()
-      },
-
-      /************************************************************************
-       * Stop watching the component's DOM for changes.
-       *
-       * @private
-       ***********************************************************************/
-
-      _stopWatchingForDOMChanges () {
-        this.observer.disconnect()
+        Component.stopWatchingForDOMChanges(self)
       },
 
       /************************************************************************

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -148,6 +148,23 @@ export default class Accordion extends Component {
 
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
+
+        this._watchForDOMChanges()
+      },
+
+      /************************************************************************
+       * Watches the component's DOM and updates references to child elements
+       * if the DOM changes.
+       *
+       * @private
+       ***********************************************************************/
+
+      _watchForDOMChanges () {
+        this.observer = new MutationObserver((mutationList, observer) => {
+          this._initElements()
+        })
+
+        this.observer.observe(this.element, { childList: true, subtree: true })
       },
 
       /************************************************************************
@@ -156,6 +173,18 @@ export default class Accordion extends Component {
 
       disconnected () {
         Component.dispatchComponentRemovedEvent(this.element)
+
+        this._stopWatchingForDOMChanges()
+      },
+
+      /************************************************************************
+       * Stop watching the component's DOM for changes.
+       *
+       * @private
+       ***********************************************************************/
+
+      _stopWatchingForDOMChanges () {
+        this.observer.disconnect()
       },
 
       /************************************************************************

--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -148,7 +148,7 @@ export default class Accordion extends Component {
 
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
-        Component.watchForDOMChanges(self)
+        Component.watchForDOMChanges(this)
       },
 
       /************************************************************************
@@ -157,7 +157,7 @@ export default class Accordion extends Component {
 
       disconnected () {
         Component.dispatchComponentRemovedEvent(this.element)
-        Component.stopWatchingForDOMChanges(self)
+        Component.stopWatchingForDOMChanges(this)
       },
 
       /************************************************************************

--- a/src/js/components/component.js
+++ b/src/js/components/component.js
@@ -128,15 +128,21 @@ export default class Component {
 
   /****************************************************************************
    * Watches the component's DOM and updates references to child elements
-   * if the DOM changes.
+   * if the DOM changes. Accepts an optional callback to perform additional
+   * updates to the component on DOM change.
    *
    * @static
    * @param {Object} self - Component instance
+   * @param {Function} callback - Optional callback
    ***************************************************************************/
 
-  static watchForDOMChanges (self) {
+  static watchForDOMChanges (self, callback = null) {
     self.observer = new MutationObserver((mutationList, observer) => {
       self._initElements()
+
+      if (callback) {
+        callback()
+      }
     })
 
     self.observer.observe(self.element, { childList: true, subtree: true })

--- a/src/js/components/component.js
+++ b/src/js/components/component.js
@@ -125,4 +125,32 @@ export default class Component {
       component: element
     })
   }
+
+  /****************************************************************************
+   * Watches the component's DOM and updates references to child elements
+   * if the DOM changes.
+   *
+   * @static
+   * @param {Object} self - Component instance
+   ***************************************************************************/
+
+  static watchForDOMChanges (self) {
+    self.observer = new MutationObserver((mutationList, observer) => {
+      self._initElements()
+    })
+
+    self.observer.observe(self.element, { childList: true, subtree: true })
+  }
+
+  /****************************************************************************
+   * Stop watching the component's DOM for changes.
+   *
+   * @static
+   * @param {Object} self - Component instance
+   ***************************************************************************/
+
+  static stopWatchingForDOMChanges (self) {
+    self.observer.disconnect()
+  }
+
 }

--- a/src/js/components/dialog.js
+++ b/src/js/components/dialog.js
@@ -148,6 +148,7 @@ export default class Dialog extends Component {
 
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
+        Component.watchForDOMChanges(this)
 
         this._addTriggerEventHandlers()
         this._addDocumentEventHandlers()
@@ -209,6 +210,7 @@ export default class Dialog extends Component {
 
       disconnected () {
         Component.dispatchComponentRemovedEvent(this.element)
+        Component.stopWatchingForDOMChanges(this)
 
         this._removeTriggerEventHandlers()
         this._removeDocumentEventHandlers()

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -60,7 +60,7 @@ export default class Dropdown extends Component {
        * @private
        ***********************************************************************/
 
-       _initSelectors () {
+      _initSelectors () {
         this.toggleAttribute = 'data-rvt-dropdown-toggle'
         this.menuAttribute = 'data-rvt-dropdown-menu'
 
@@ -101,8 +101,6 @@ export default class Dropdown extends Component {
         this.menuItems = Array.from(this.menuElement.querySelectorAll(focusableElements))
         this.firstMenuItem = this.menuItems[0]
         this.lastMenuItem = this.menuItems[this.menuItems.length - 1]
-
-        console.log(this.menuItems)
       },
 
       /************************************************************************
@@ -307,7 +305,7 @@ export default class Dropdown extends Component {
        ***********************************************************************/
 
       _clickOriginatedOutsideDropdown (event) {
-        return ! this.element.contains(event.target)
+        return !this.element.contains(event.target)
       },
 
       /************************************************************************

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -132,6 +132,7 @@ export default class Dropdown extends Component {
 
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
+        Component.watchForDOMChanges(this)
 
         this._addDocumentEventHandlers()
       },
@@ -152,6 +153,7 @@ export default class Dropdown extends Component {
 
       disconnected () {
         Component.dispatchComponentRemovedEvent(this.element)
+        Component.stopWatchingForDOMChanges(this)
 
         this._removeDocumentEventHandlers()
       },

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -101,6 +101,8 @@ export default class Dropdown extends Component {
         this.menuItems = Array.from(this.menuElement.querySelectorAll(focusableElements))
         this.firstMenuItem = this.menuItems[0]
         this.lastMenuItem = this.menuItems[this.menuItems.length - 1]
+
+        console.log(this.menuItems)
       },
 
       /************************************************************************
@@ -132,7 +134,7 @@ export default class Dropdown extends Component {
 
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
-        Component.watchForDOMChanges(this)
+        Component.watchForDOMChanges(this, () => this._initMenuItems())
 
         this._addDocumentEventHandlers()
       },

--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -154,6 +154,7 @@ export default class Sidenav extends Component {
 
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
+        Component.watchForDOMChanges(this)
       },
 
       /************************************************************************
@@ -162,6 +163,7 @@ export default class Sidenav extends Component {
 
       disconnected () {
         Component.dispatchComponentRemovedEvent(this.element)
+        Component.stopWatchingForDOMChanges(this)
       },
 
       /************************************************************************

--- a/src/js/components/tabs.js
+++ b/src/js/components/tabs.js
@@ -84,7 +84,23 @@ export default class Tabs extends Component {
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
 
+        this._watchForDOMChanges()
         this._activateInitialTab()
+      },
+
+      /************************************************************************
+       * Watches the component's DOM and updates references to child elements
+       * if the DOM changes.
+       *
+       * @private
+       ***********************************************************************/
+
+      _watchForDOMChanges () {
+        this.observer = new MutationObserver((mutationList, observer) => {
+          this._initElements()
+        })
+
+        this.observer.observe(this.element, { childList: true, subtree: true })
       },
 
       /************************************************************************
@@ -109,6 +125,18 @@ export default class Tabs extends Component {
 
       disconnected () {
         Component.dispatchComponentRemovedEvent(this.element)
+
+        this._stopWatchingForDOMChanges()
+      },
+
+      /************************************************************************
+       * Stop watching the component's DOM for changes.
+       *
+       * @private
+       ***********************************************************************/
+
+      _stopWatchingForDOMChanges () {
+        this.observer.disconnect()
       },
 
       /************************************************************************

--- a/src/js/components/tabs.js
+++ b/src/js/components/tabs.js
@@ -83,24 +83,9 @@ export default class Tabs extends Component {
 
       connected () {
         Component.dispatchComponentAddedEvent(this.element)
+        Component.watchForDOMChanges(this)
 
-        this._watchForDOMChanges()
         this._activateInitialTab()
-      },
-
-      /************************************************************************
-       * Watches the component's DOM and updates references to child elements
-       * if the DOM changes.
-       *
-       * @private
-       ***********************************************************************/
-
-      _watchForDOMChanges () {
-        this.observer = new MutationObserver((mutationList, observer) => {
-          this._initElements()
-        })
-
-        this.observer.observe(this.element, { childList: true, subtree: true })
       },
 
       /************************************************************************
@@ -125,18 +110,7 @@ export default class Tabs extends Component {
 
       disconnected () {
         Component.dispatchComponentRemovedEvent(this.element)
-
-        this._stopWatchingForDOMChanges()
-      },
-
-      /************************************************************************
-       * Stop watching the component's DOM for changes.
-       *
-       * @private
-       ***********************************************************************/
-
-      _stopWatchingForDOMChanges () {
-        this.observer.disconnect()
+        Component.stopWatchingForDOMChanges(self)
       },
 
       /************************************************************************

--- a/src/js/components/tabs.js
+++ b/src/js/components/tabs.js
@@ -110,7 +110,7 @@ export default class Tabs extends Component {
 
       disconnected () {
         Component.dispatchComponentRemovedEvent(this.element)
-        Component.stopWatchingForDOMChanges(self)
+        Component.stopWatchingForDOMChanges(this)
       },
 
       /************************************************************************

--- a/src/js/components/tabs.js
+++ b/src/js/components/tabs.js
@@ -56,8 +56,8 @@ export default class Tabs extends Component {
        ***********************************************************************/
 
       _initSelectors () {
-        this.tabAttribute = `data-rvt-tab`
-        this.panelAttribute = `data-rvt-tab-panel`
+        this.tabAttribute = 'data-rvt-tab'
+        this.panelAttribute = 'data-rvt-tab-panel'
 
         this.tabSelector = `[${this.tabAttribute}]`
         this.panelSelector = `[${this.panelAttribute}]`


### PR DESCRIPTION
Many components track an internal list of child elements, such as tabs or dropdown menu items.

However, this list was only built on first initialization, so if a child element (such as a tab) was added or removed, the internal list would fall out of sync and cause errors.

This PR updates several components to refresh their internal lists of child elements when the component's DOM changes. This is accomplished via `MutationObserver`.

Fixes #647 