### PR TITLE
Reduced width of current nav item red border to more closely match width of link text

### DIFF
--- a/src/sass/header-system/_header-menu.scss
+++ b/src/sass/header-system/_header-menu.scss
@@ -196,6 +196,10 @@
       position: relative;
     }
 
+    &__item--current {
+      padding-left: 0;
+    }
+
     &__item--current &__link {
       color: $color-crimson-500;
     }
@@ -208,7 +212,7 @@
       content: '';
       display: block;
       background-color: $color-crimson-500;
-      width: 92.5%;
+      width: 100%;
       height: $spacing-xxs * 1.2;
       position: absolute;
       bottom: -$spacing-md * 1.1;

--- a/src/sass/header-system/_header-menu.scss
+++ b/src/sass/header-system/_header-menu.scss
@@ -208,7 +208,7 @@
       content: '';
       display: block;
       background-color: $color-crimson-500;
-      width: 100%;
+      width: 92.5%;
       height: $spacing-xxs * 1.2;
       position: absolute;
       bottom: -$spacing-md * 1.1;


### PR DESCRIPTION
Fixes #651.

The problem in the linked issue with the padding under the identity module on mobile is not a Rivet CSS issue, but instead an error in the layout code. That will be fixed in a separate PR on the documentation site repo.