### PR TITLE
Added new-component utility script for internal use

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "move-example": "node ./tasks/move-example.js",
     "lint": "standard 'src/js'",
     "asset:upload": "npm run build && zip -r rivet-gh-release.zip css js sass tokens index.html",
+    "new-component": "node ./tasks/source-new-component.js",
     "sandbox-new-component": "node ./tasks/sandbox-new-component.js"
   },
   "files": [

--- a/tasks/component-starter-code.js.txt
+++ b/tasks/component-starter-code.js.txt
@@ -1,0 +1,95 @@
+/******************************************************************************
+ * Copyright (C) 2018 The Trustees of Indiana University
+ * SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+import Component from './component'
+
+/******************************************************************************
+ * The {{ lowercaseName }} component does something.
+ *
+ * @see https://v2.rivet.iu.edu/docs/components/{{ slug }}/
+ *****************************************************************************/
+
+export default class {{ className }} extends Component {
+
+  /****************************************************************************
+   * Gets the {{ lowercaseName }}'s CSS selector.
+   *
+   * @static
+   * @returns {string} The CSS selector
+   ***************************************************************************/
+
+  static get selector () {
+    return '[data-rvt-{{ slug }}]'
+  }
+
+  /****************************************************************************
+   * Gets an object containing the methods that should be attached to the
+   * component's root DOM element. Used by wicked-elements to initialize a DOM
+   * element with Web Component-like behavior.
+   *
+   * @static
+   * @returns {Object} Object with component methods
+   ***************************************************************************/
+
+  static get methods () {
+    return {
+
+      /************************************************************************
+       * Initializes the {{ lowercaseName }}.
+       ***********************************************************************/
+
+      init () {
+        this._initSelectors()
+        this._initElements()
+
+        Component.bindMethodToDOMElement(this, 'someMethod', this.someMethod)
+      },
+
+      /************************************************************************
+       * Initializes {{ lowercaseName }} child element selectors.
+       *
+       * @private
+       ***********************************************************************/
+
+      _initSelectors () {
+        // Initialize component child element selectors here
+      },
+
+      /************************************************************************
+       * Initializes {{ lowercaseName }} child elements.
+       *
+       * @private
+       ***********************************************************************/
+
+      _initElements () {
+        // Initialize component child elements here
+      },
+
+      /************************************************************************
+       * Called when the {{ lowercaseName }} is added to the DOM.
+       ***********************************************************************/
+
+      connected () {
+        Component.dispatchComponentAddedEvent(this.element)
+      },
+
+      /************************************************************************
+       * Called when the {{ lowercaseName }} is removed from the DOM.
+       ***********************************************************************/
+
+      disconnected () {
+        Component.dispatchComponentRemovedEvent(this.element)
+      },
+
+      /************************************************************************
+       * Do something with the {{ lowercaseName }}.
+       ***********************************************************************/
+
+      someMethod () {
+        // Do something with the {{ lowercaseName }}
+      }
+    }
+  }
+}

--- a/tasks/component-starter-code.js.txt
+++ b/tasks/component-starter-code.js.txt
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (C) 2018 The Trustees of Indiana University
+ * Copyright (C) 2023 The Trustees of Indiana University
  * SPDX-License-Identifier: BSD-3-Clause
  *****************************************************************************/
 

--- a/tasks/component-starter-code.scss.txt
+++ b/tasks/component-starter-code.scss.txt
@@ -1,0 +1,8 @@
+// Copyright (C) 2023 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
+@use '../core' as *;
+
+.#{$prefix}-{{ slug }} {
+  // Styles here
+}

--- a/tasks/source-new-component.js
+++ b/tasks/source-new-component.js
@@ -1,0 +1,24 @@
+/******************************************************************************
+ * Copyright (C) 2022 The Trustees of Indiana University
+ * SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+const jetpack = require('fs-jetpack')
+const { exec } = require('child_process')
+
+const componentName = process.argv[2].trim()
+const componentSlug = componentName.toLowerCase().replace(/\s/g, '-')
+const componentClassName = componentName.replace(/\s/g, '')
+const componentLowercaseName = componentName.toLowerCase()
+const componentPath = `./src/js/components/${componentSlug}.js`
+const componentStarterCode = jetpack
+                               .read('./tasks/component-starter-code.js.txt')
+                               .replace(/{{ slug }}/gi, componentSlug)
+                               .replace(/{{ className }}/gi, componentClassName)
+                               .replace(/{{ lowercaseName }}/gi, componentLowercaseName)
+
+jetpack.write(componentPath, componentStarterCode)
+
+console.log(`Wrote files for new component "${componentName}" to src/js/components/${componentSlug}.js.`)
+
+exec(`code -r ${componentPath}`)

--- a/tasks/source-new-component.js
+++ b/tasks/source-new-component.js
@@ -6,19 +6,58 @@
 const jetpack = require('fs-jetpack')
 const { exec } = require('child_process')
 
+/******************************************************************************
+ * Should the script only generate Sass files for the new component?
+ *****************************************************************************/
+
+const sassOnly = process.argv.includes('sass-only')
+
+/******************************************************************************
+ * Extract component name and file paths.
+ *****************************************************************************/
+
 const componentName = process.argv[2].trim()
 const componentSlug = componentName.toLowerCase().replace(/\s/g, '-')
 const componentClassName = componentName.replace(/\s/g, '')
 const componentLowercaseName = componentName.toLowerCase()
-const componentPath = `./src/js/components/${componentSlug}.js`
-const componentStarterCode = jetpack
+const componentSassIndexPath = `./src/sass/${componentSlug}/_index.scss`
+const componentSassBasePath = `./src/sass/${componentSlug}/_base.scss`
+const componentJsPath = `./src/js/components/${componentSlug}.js`
+
+const componentSassStarterCode = jetpack
+                                .read('./tasks/component-starter-code.scss.txt')
+                                .replace(/{{ slug }}/gi, componentSlug)
+
+const componentJsStarterCode = jetpack
                                .read('./tasks/component-starter-code.js.txt')
                                .replace(/{{ slug }}/gi, componentSlug)
                                .replace(/{{ className }}/gi, componentClassName)
                                .replace(/{{ lowercaseName }}/gi, componentLowercaseName)
 
-jetpack.write(componentPath, componentStarterCode)
+/******************************************************************************
+ * Create Sass boilerplate files.
+ *****************************************************************************/
 
-console.log(`Wrote files for new component "${componentName}" to src/js/components/${componentSlug}.js.`)
+jetpack.write(componentSassIndexPath, `@forward 'base';`)
+console.log(`Wrote file for new component "${componentName}" to src/sass/${componentSlug}/_index.scss.`)
 
-exec(`code -r ${componentPath}`)
+jetpack.write(componentSassBasePath, componentSassStarterCode)
+console.log(`Wrote file for new component "${componentName}" to src/sass/${componentSlug}/_base.scss.`)
+
+/******************************************************************************
+ * Create JS boilerplate file.
+ *****************************************************************************/
+
+if ( ! sassOnly) {
+  jetpack.write(componentJsPath, componentJsStarterCode)
+  console.log(`Wrote file for new component "${componentName}" to src/js/components/${componentSlug}.js.`)
+}
+
+/******************************************************************************
+ * Open new files in VSCode.
+ *****************************************************************************/
+
+exec(`code -r ${componentSassBasePath}`)
+
+if ( ! sassOnly)
+  exec(`code -r ${componentJsPath}`)


### PR DESCRIPTION
This PR adds a new internal utility script `new-component`. This script creates a boilerplate JS file for a new Rivet component.

The script takes the new component name, capitalized, as an argument:

```
npm run new-component Toast
```

Wrap component names with multiple words with double quotes to avoid ZSH syntax errors:

```
npm run new-component "Progress Bar"
```

This script uses the VS Code `code` command to immediately open the newly generated JS file in a new tab. For this to function, make sure that the `code` command is on your `PATH`. You can set it by going to **View > Command Palette**, typing `shell command`, and selecting "Install 'code' command in PATH".