### PR TITLE
Added sandbox deployment scripts

### DIFF
--- a/deploy-sandbox.sh
+++ b/deploy-sandbox.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Load environment variables
+
+set -a
+source .env
+set +a
+
+# Set production flag to FALSE by default
+
+production=false
+
+# Set production flag to TRUE if -P flag was passed
+
+while getopts ':P' opt; do
+  case ${opt} in
+    P) production=true
+  esac
+done
+
+if [[ "$production" = true ]]; then
+  
+  # Require confirmation for production deployment
+
+  echo "[rsync] Confirm production sandbox deployment by entering 'ok', enter 'no' to cancel:"
+  
+  read ok_no
+  
+  if [[ "$ok_no" = "ok" ]]; then
+
+    # Deployment confirmed, deploy to Sitehost
+
+    echo "[rsync] Deploying sandbox to Sitehost..."
+    rsync -av --delete ./dist/ $RSYNC_LIVE
+  
+  else
+
+    # Deployment cancelled
+
+    echo "[rsync] Deployment cancelled"
+  
+  fi
+
+else
+
+  # Deploy to Sitehost-Test
+
+  echo "[rsync] Deploying sandbox to Sitehost-Test..."
+  rsync -av --delete ./dist/ $RSYNC_TEST
+
+fi

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "lint": "standard 'src/js'",
     "asset:upload": "npm run build && zip -r rivet-gh-release.zip css js sass tokens index.html",
     "new-component": "node ./tasks/source-new-component.js",
-    "sandbox-new-component": "node ./tasks/sandbox-new-component.js"
+    "sandbox-new-component": "node ./tasks/sandbox-new-component.js",
+    "sandbox-deploy:test": "sh deploy-sandbox.sh",
+    "sandbox-deploy:live": "sh deploy-sandbox.sh -P"
   },
   "files": [
     "css/**/*",

--- a/src/sandbox/_includes/layouts/base.njk
+++ b/src/sandbox/_includes/layouts/base.njk
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
   <title>{{ title }}</title>
   <link href="https://unpkg.com/prismjs@v1.x/themes/prism.min.css" rel="stylesheet">
   <link rel="stylesheet" href="/css/sandbox.css">


### PR DESCRIPTION
The Rivet development sandbox can now be deployed to a private Sitehost account using the following commands:

- `npm run sandbox-deploy:test`
- `npm run sandbox-deploy:live`

An `.env` file for these deployment scripts has been provided via Secure Share.