### PR TITLE
Updated accordion component to auto-assign trigger and panel IDs

### DIFF
--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -89,7 +89,59 @@ export default class Accordion extends Component {
        ***********************************************************************/
 
       _initAttributes () {
-        this._setTriggerButtonAttributes()
+        this._assignComponentElementIds()
+        this._setTriggerButtonTypeAttributes()
+      },
+
+      /************************************************************************
+       * Assigns random IDs to the accordion component's child elements if
+       * IDs were not already specified in the markup.
+       *
+       * @private
+       ***********************************************************************/
+
+      _assignComponentElementIds () {
+        this._assignTriggerIds()
+        this._assignPanelIds()
+      },
+
+      /************************************************************************
+       * Assigns a random ID to each trigger.
+       *
+       * @private
+       ***********************************************************************/
+
+      _assignTriggerIds () {
+        this.triggers.forEach(trigger => {
+          const existingTriggerId = trigger.getAttribute(this.triggerAttribute)
+
+          if (!existingTriggerId) {
+            const id = Component.generateUniqueId()
+
+            Component.setAttributeIfNotSpecified(trigger, this.triggerAttribute, id)
+            Component.setAttributeIfNotSpecified(trigger, 'id', `${id}-label`)
+          }
+        })
+      },
+
+      /************************************************************************
+       * Assigns a random ID to each panel.
+       *
+       * @private
+       ***********************************************************************/
+
+      _assignPanelIds () {
+        const numPanels = this.panels.length
+
+        for (let i = 0; i < numPanels; i++) {
+          const trigger = this.triggers[i]
+          const panel = this.panels[i]
+          const panelId = trigger.getAttribute(this.triggerAttribute)
+
+          Component.setAttributeIfNotSpecified(panel, this.panelAttribute, panelId)
+          Component.setAttributeIfNotSpecified(panel, 'id', panelId)
+          Component.setAttributeIfNotSpecified(panel, 'aria-labelledby', `${panelId}-label`)
+        }
       },
 
       /************************************************************************
@@ -98,7 +150,7 @@ export default class Accordion extends Component {
        * @private
        ***********************************************************************/
 
-      _setTriggerButtonAttributes () {
+      _setTriggerButtonTypeAttributes () {
         this.triggers.forEach(trigger => {
           Component.setAttributeIfNotSpecified(trigger, 'type', 'button')
         })

--- a/src/sandbox/components/accordion/variants/default.njk
+++ b/src/sandbox/components/accordion/variants/default.njk
@@ -8,7 +8,7 @@ order: 1
 ---
 <div class="rvt-accordion" data-rvt-accordion="test-accordion">
   <h3 class="rvt-accordion__summary">
-    <button class="rvt-accordion__toggle" id="test-accordion-1-label" data-rvt-accordion-trigger="test-accordion-1">
+    <button class="rvt-accordion__toggle" data-rvt-accordion-trigger>
       <span class="rvt-accordion__toggle-text">Become the best version of yourself at IU</span>
       <div class="rvt-accordion__toggle-icon">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
@@ -20,11 +20,11 @@ order: 1
       </div>
     </button>
   </h3>
-  <div class="rvt-accordion__panel" id="test-accordion-1" aria-labelledby="test-accordion-1-label" data-rvt-accordion-panel="test-accordion-1">
+  <div class="rvt-accordion__panel" data-rvt-accordion-panel>
     <p class="rvt-m-all-remove">Develop the skills you need for a rewarding career, and follow in the footsteps of more than 729,000 IU alumni who are leading organizations, innovating the future, and making an impact on their communities and the world.</p>
   </div>
   <h3 class="rvt-accordion__summary">
-    <button class="rvt-accordion__toggle" id="test-accordion-2-label" data-rvt-accordion-trigger="test-accordion-2">
+    <button class="rvt-accordion__toggle" data-rvt-accordion-trigger>
       <span class="rvt-accordion__toggle-text">Find your calling</span>
       <div class="rvt-accordion__toggle-icon">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
@@ -36,11 +36,11 @@ order: 1
       </div>
     </button>
   </h3>
-  <div class="rvt-accordion__panel" id="test-accordion-2" aria-labelledby="test-accordion-2-label" data-rvt-accordion-panel="test-accordion-2">
+  <div class="rvt-accordion__panel" data-rvt-accordion-panel>
     <p class="rvt-m-all-remove">IU offers more than 2,300 different programs of study. Not sure what to focus on? No problem. Browse by interest area to find options you'd enjoy pursuing.</p>
   </div>
   <h3 class="rvt-accordion__summary">
-    <button class="rvt-accordion__toggle" id="test-accordion-3-label" data-rvt-accordion-trigger="test-accordion-3">
+    <button class="rvt-accordion__toggle" data-rvt-accordion-trigger>
       <span class="rvt-accordion__toggle-text">Pursue your passion or explore the possibilities</span>
       <div class="rvt-accordion__toggle-icon">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
@@ -52,7 +52,7 @@ order: 1
       </div>
     </button>
   </h3>
-  <div class="rvt-accordion__panel" id="test-accordion-3" aria-labelledby="test-accordion-3-label" data-rvt-accordion-panel="test-accordion-3" data-rvt-accordion-panel-init>
+  <div class="rvt-accordion__panel" data-rvt-accordion-panel data-rvt-accordion-panel-init>
     <p class="rvt-m-all-remove">From nursing to criminal justice, epidemiology to environmental science, social work to cybersecurity, and more than 900 academic programs in between, IU gives you the power to study whatever sparks your interest, with the support of world-class professors and faculty who care about your success.</p>
   </div>
 </div>


### PR DESCRIPTION
Similar to tabs, this PR updates the accordion component to auto-assign trigger and panel ID attributes if none are provided. Also generates appropriate `aria-labelledby` attributes.