### PR TITLE
Refactored methods for auto-assigning attributes

### DIFF
--- a/src/js/components/accordion.js
+++ b/src/js/components/accordion.js
@@ -113,14 +113,10 @@ export default class Accordion extends Component {
 
       _assignTriggerIds () {
         this.triggers.forEach(trigger => {
-          const existingTriggerId = trigger.getAttribute(this.triggerAttribute)
+          const id = Component.generateUniqueId()
 
-          if (!existingTriggerId) {
-            const id = Component.generateUniqueId()
-
-            Component.setAttributeIfNotSpecified(trigger, this.triggerAttribute, id)
-            Component.setAttributeIfNotSpecified(trigger, 'id', `${id}-label`)
-          }
+          Component.setAttributeIfNotSpecified(trigger, this.triggerAttribute, id)
+          Component.setAttributeIfNotSpecified(trigger, 'id', `${id}-label`)
         })
       },
 

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -101,9 +101,9 @@ export default class Dropdown extends Component {
       _assignComponentElementIds () {
         const id = Component.generateUniqueId()
 
-        this.toggleElement.setAttribute(this.toggleAttribute, id)
-        this.menuElement.setAttribute('id', id)
-        this.menuElement.setAttribute(this.menuAttribute, id)
+        Component.setAttributeIfNotSpecified(this.toggleElement, this.toggleAttribute, id)
+        Component.setAttributeIfNotSpecified(this.menuElement, this.menuAttribute, id)
+        Component.setAttributeIfNotSpecified(this.menuElement, 'id', id)
       },
 
       /************************************************************************

--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -111,11 +111,7 @@ export default class Sidenav extends Component {
 
       _assignToggleIds () {
         this.childMenuToggleButtons.forEach(toggle => {
-          const existingToggleId = toggle.getAttribute(this.toggleAttribute)
-
-          if (!existingToggleId) {
-            Component.setAttributeIfNotSpecified(toggle, this.toggleAttribute, Component.generateUniqueId())
-          }
+          Component.setAttributeIfNotSpecified(toggle, this.toggleAttribute, Component.generateUniqueId())
         })
       },
 

--- a/src/js/components/tabs.js
+++ b/src/js/components/tabs.js
@@ -131,12 +131,8 @@ export default class Tabs extends Component {
 
       _assignTabIds () {
         this.tabs.forEach(tab => {
-          const existingTabId = tab.getAttribute('data-rvt-tab')
-
-          if (!existingTabId) {
-            Component.setAttributeIfNotSpecified(tab, 'data-rvt-tab', Component.generateUniqueId())
-            Component.setAttributeIfNotSpecified(tab, 'id', Component.generateUniqueId())
-          }
+          Component.setAttributeIfNotSpecified(tab, this.tabAttribute, Component.generateUniqueId())
+          Component.setAttributeIfNotSpecified(tab, 'id', Component.generateUniqueId())
         })
       },
 
@@ -152,9 +148,9 @@ export default class Tabs extends Component {
         for (let i = 0; i < numPanels; i++) {
           const tab = this.tabs[i]
           const panel = this.panels[i]
-          const panelId = tab.getAttribute('data-rvt-tab')
+          const panelId = tab.getAttribute(this.tabAttribute)
 
-          Component.setAttributeIfNotSpecified(panel, 'data-rvt-tab-panel', panelId)
+          Component.setAttributeIfNotSpecified(panel, this.panelAttribute, panelId)
           Component.setAttributeIfNotSpecified(panel, 'id', panelId)
         }
       },


### PR DESCRIPTION
Mostly removed redundant conditional statements to check if ID/attribute value was already set, as the static `Component.setAttributeIfNotSpecified()` method already does this.