### PR TITLE
Updated aria-current selectors in Sass files to be more specific

### DIFF
--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -104,7 +104,7 @@
       }
 
       &.#{$prefix}-is-selected,
-      &[aria-current],
+      &[aria-current]:not([aria-current='false']),
       &[aria-checked='true'] {
         box-shadow: inset $spacing-xxs 0 0 $color-crimson-500;
         background-color: $color-orange-000;

--- a/src/sass/pagination/_base.scss
+++ b/src/sass/pagination/_base.scss
@@ -51,14 +51,14 @@
     }
 
     a:focus,
-    a[aria-current]:focus {
+    a[aria-current='page']:focus {
       border-radius: inherit;
       outline: solid math.div($spacing-xxs, 2) $color-blue-400;
       outline-offset: math.div($spacing-xxs, 2);
       z-index: map.get($z-index, '1000');
     }
 
-    a[aria-current] {
+    a[aria-current='page'] {
       background-color: $color-orange-000;
       box-shadow: 0 $spacing-xxs 0 $color-crimson-500;
     }

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -62,11 +62,11 @@
     position: relative;
     text-decoration: none;
 
-    &[aria-current] {
+    &[aria-current='page'] {
       background-color: $color-orange-000;
     }
 
-    &[aria-current]::before {
+    &[aria-current='page']::before {
       content: '';
       display: block;
       width: .25rem;
@@ -89,11 +89,11 @@
     padding-bottom: $spacing-xxs * 1.2;
   }
 
-  &__item > &__list &__link[aria-current]::before {
+  &__item > &__list &__link[aria-current='page']::before {
     margin-left: -$spacing-xxs;
   }
 
-  &__link[aria-current] + &__toggle {
+  &__link[aria-current='page'] + &__toggle {
     background-color: $color-orange-000;
 
     > svg {
@@ -101,8 +101,8 @@
     }
   }
 
-  &__link[aria-current] + &__toggle:hover,
-  &__link[aria-current] + &__toggle:focus {
+  &__link[aria-current='page'] + &__toggle:hover,
+  &__link[aria-current='page'] + &__toggle:focus {
     color: $color-blue-500;
     background-color: $color-blue-000;
 

--- a/src/sass/step-indicator/_base.scss
+++ b/src/sass/step-indicator/_base.scss
@@ -53,7 +53,7 @@
     flex-direction: column;
   }
 
-  &__item-content[aria-current] &__indicator {
+  &__item-content[aria-current='step'] &__indicator {
     font-weight: 700;
   }
 
@@ -163,7 +163,7 @@ a.#{$prefix}-steps__item-content:focus .#{$prefix}-steps__label {
 
 a.#{$prefix}-steps__item-content:hover .#{$prefix}-steps__indicator,
 a.#{$prefix}-steps__item-content:focus .#{$prefix}-steps__indicator,
-a.#{$prefix}-steps__item-content[aria-current] .#{$prefix}-steps__indicator {
+a.#{$prefix}-steps__item-content[aria-current='step'] .#{$prefix}-steps__indicator {
   background-color: $color-crimson-500;
   color: $color-white-base;
   border-color: $color-crimson-500;

--- a/src/sass/subnav/_base.scss
+++ b/src/sass/subnav/_base.scss
@@ -39,7 +39,7 @@
     }
   }
 
-  &__item a[aria-current] {
+  &__item a[aria-current='page'] {
     background-color: $color-orange-000;
     color: $color-crimson-500;
 
@@ -48,7 +48,7 @@
     }
   }
 
-  &__item a[aria-current]::after,
+  &__item a[aria-current='page']::after,
   &__item a:hover::after {
     content: '';
     display: block;
@@ -60,7 +60,7 @@
     position: absolute;
   }
 
-  &__item a:hover:not([aria-current]),
+  &__item a:hover:not([aria-current='page']),
   &__item button:hover {
     background-color: $color-blue-000;
     color: $color-blue-500;


### PR DESCRIPTION
This PR updates `[aria-current]` selectors in Sass files to be more specific. This helps prevent incorrect styling of elements with `aria-current="false"` attribute values.