### PR TITLE
Added data-rvt-dialog-mount attribute

### DIFF
--- a/src/js/components/dialog.js
+++ b/src/js/components/dialog.js
@@ -125,9 +125,11 @@ export default class Dialog extends Component {
        ***********************************************************************/
 
       _makeDialogFirstElementInBody () {
-        const body = document.body
-        const currentFirstElement = body.firstElementChild
-        body.insertBefore(this.element, currentFirstElement)
+        const mountElement = document.querySelector('[data-rvt-dialog-mount]')
+
+        mountElement
+          ? mountElement.appendChild(this.element)
+          : document.body.insertBefore(this.element, document.body.firstElementChild)
       },
 
       /************************************************************************

--- a/src/js/components/dialog.js
+++ b/src/js/components/dialog.js
@@ -128,7 +128,7 @@ export default class Dialog extends Component {
         const mountElement = document.querySelector('[data-rvt-dialog-mount]')
 
         mountElement
-          ? mountElement.appendChild(this.element)
+          ? mountElement.insertBefore(this.element, mountElement.firstElementChild)
           : document.body.insertBefore(this.element, document.body.firstElementChild)
       },
 

--- a/src/js/components/dialog.js
+++ b/src/js/components/dialog.js
@@ -85,7 +85,7 @@ export default class Dialog extends Component {
         const dialogId = this.element.getAttribute(this.dialogAttribute)
         const mountElement = document.querySelector(this.mountElementSelector)
 
-        this.mountElement = mountElement ? mountElement : document.body
+        this.mountElement = mountElement ?? document.body
 
         this.triggerButtons = Array.from(
           document.querySelectorAll(`[${this.triggerAttribute} = "${dialogId}"]`)

--- a/src/sandbox/components/dialog/variants/dialog-mount.njk
+++ b/src/sandbox/components/dialog/variants/dialog-mount.njk
@@ -6,29 +6,31 @@ permalink: /components/preview/{{ title | slug}}/
 padding: true
 order: 7
 ---
-<div id="app" data-rvt-dialog-mount></div>
-<button type="button" class="rvt-button" data-rvt-dialog-trigger="dialog-example">
-  <span>Dialog example</span>
-</button>
-<div class="rvt-dialog" id="dialog-example" role="dialog" tabindex="-1" aria-labelledby="dialog-title" aria-describedby="dialog-description" data-rvt-dialog="dialog-example" hidden>
-  <header class="rvt-dialog__header">
-    <h1 class="rvt-dialog__title" id="dialog-title">Dialog title</h1>
-  </header>
-  <div class="rvt-dialog__body">
-    <p id="dialog-description">The default dialog appears near the middle of the screen. It does not darken the page behind it and does not close when the user clicks outside of it. You can use data attributes to configure the appearance and behavior of the dialog.</p>
-  </div>
-  <div class="rvt-dialog__controls">
-    <button type="button" class="rvt-button" role="button">
-    <span>OK</span>
-    </button>
-    <button type="button" class="rvt-button rvt-button--secondary" data-rvt-dialog-close="dialog-example" role="button">
-    <span>Cancel</span>
-    </button>
-  </div>
-  <button class="rvt-button rvt-button--plain rvt-dialog__close" data-rvt-dialog-close="dialog-example" role="button">
-    <span class="rvt-sr-only">Close</span>
-    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-      <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z" />
-    </svg>
+<div id="app" data-rvt-dialog-mount>
+  <h1>Some test header</h1>
+  <button type="button" class="rvt-button" data-rvt-dialog-trigger="dialog-example">
+    <span>Dialog example</span>
   </button>
+  <div class="rvt-dialog" id="dialog-example" role="dialog" tabindex="-1" aria-labelledby="dialog-title" aria-describedby="dialog-description" data-rvt-dialog="dialog-example" data-rvt-dialog-disable-page-interaction data-rvt-dialog-darken-page hidden>
+    <header class="rvt-dialog__header">
+      <h1 class="rvt-dialog__title" id="dialog-title">Dialog title</h1>
+    </header>
+    <div class="rvt-dialog__body">
+      <p id="dialog-description">The default dialog appears near the middle of the screen. It does not darken the page behind it and does not close when the user clicks outside of it. You can use data attributes to configure the appearance and behavior of the dialog.</p>
+    </div>
+    <div class="rvt-dialog__controls">
+      <button type="button" class="rvt-button" role="button">
+      <span>OK</span>
+      </button>
+      <button type="button" class="rvt-button rvt-button--secondary" data-rvt-dialog-close="dialog-example" role="button">
+      <span>Cancel</span>
+      </button>
+    </div>
+    <button class="rvt-button rvt-button--plain rvt-dialog__close" data-rvt-dialog-close="dialog-example" role="button">
+      <span class="rvt-sr-only">Close</span>
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z" />
+      </svg>
+    </button>
+  </div>
 </div>

--- a/src/sandbox/components/dialog/variants/dialog-mount.njk
+++ b/src/sandbox/components/dialog/variants/dialog-mount.njk
@@ -1,0 +1,34 @@
+---
+tags: dialog
+title: Mounted dialog
+layout: layouts/preview.njk
+permalink: /components/preview/{{ title | slug}}/
+padding: true
+order: 7
+---
+<div id="app" data-rvt-dialog-mount></div>
+<button type="button" class="rvt-button" data-rvt-dialog-trigger="dialog-example">
+  <span>Dialog example</span>
+</button>
+<div class="rvt-dialog" id="dialog-example" role="dialog" tabindex="-1" aria-labelledby="dialog-title" aria-describedby="dialog-description" data-rvt-dialog="dialog-example" hidden>
+  <header class="rvt-dialog__header">
+    <h1 class="rvt-dialog__title" id="dialog-title">Dialog title</h1>
+  </header>
+  <div class="rvt-dialog__body">
+    <p id="dialog-description">The default dialog appears near the middle of the screen. It does not darken the page behind it and does not close when the user clicks outside of it. You can use data attributes to configure the appearance and behavior of the dialog.</p>
+  </div>
+  <div class="rvt-dialog__controls">
+    <button type="button" class="rvt-button" role="button">
+    <span>OK</span>
+    </button>
+    <button type="button" class="rvt-button rvt-button--secondary" data-rvt-dialog-close="dialog-example" role="button">
+    <span>Cancel</span>
+    </button>
+  </div>
+  <button class="rvt-button rvt-button--plain rvt-dialog__close" data-rvt-dialog-close="dialog-example" role="button">
+    <span class="rvt-sr-only">Close</span>
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <path fill="currentColor" d="M9.41,8l5.29-5.29a1,1,0,0,0-1.41-1.41L8,6.59,2.71,1.29A1,1,0,0,0,1.29,2.71L6.59,8,1.29,13.29a1,1,0,1,0,1.41,1.41L8,9.41l5.29,5.29a1,1,0,0,0,1.41-1.41Z" />
+    </svg>
+  </button>
+</div>


### PR DESCRIPTION
If an element is present in the DOM with the `data-rvt-dialog-mount` attribute, dialogs will be moved to the first child position of that element on connection. Otherwise, dialogs will be moved to the first child position of `body` as normal.