### PR TITLE
Added 2px space before last-child dropdown in primary segmented button

### DIFF
--- a/src/sandbox/components/button/preview/button-segmented-dropdown.njk
+++ b/src/sandbox/components/button/preview/button-segmented-dropdown.njk
@@ -1,0 +1,45 @@
+---
+tags: button
+title: Segmented button with dropdown
+layout: layouts/preview.njk
+permalink: /components/preview/{{ title | slug}}/
+padding: true
+order: 7
+---
+<div class="rvt-button-segmented" role="group" aria-label="Dropdown group">
+  <button type="button" class="rvt-button">
+    <svg fill="currentColor" width="16" height="16" viewBox="0 0 16 16"><path d="M2 1h8.414L14 4.586V15H2V1Zm2 2v10h8V7.5H7.5V3H4Zm5.5 0v2.5H12v-.086L9.586 3H9.5Z"></path></svg>
+    <span class="rvt-m-left-xs">Meeting Agenda.pdf</span></button>
+  <div class="rvt-dropdown" data-rvt-dropdown>
+    <button type="button" class="rvt-button rvt-p-right-xs rvt-p-left-xs" data-rvt-dropdown-toggle>
+      <span class="rvt-sr-only">Toggle options menu</span>
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
+      </svg>
+    </button>
+    <div class="rvt-dropdown__menu" data-rvt-dropdown-menu hidden>
+      <button type="button" role="menuitemradio">Preview</button>
+      <button type="button" role="menuitemradio">Open</button>
+      <button type="button" role="menuitemradio">Save As...</button>
+    </div>
+  </div>
+</div>
+<hr>
+<div class="rvt-button-segmented" role="group" aria-label="Dropdown group">
+  <button type="button" class="rvt-button rvt-button--secondary">
+    <svg fill="currentColor" width="16" height="16" viewBox="0 0 16 16"><path d="M2 1h8.414L14 4.586V15H2V1Zm2 2v10h8V7.5H7.5V3H4Zm5.5 0v2.5H12v-.086L9.586 3H9.5Z"></path></svg>
+    <span class="rvt-m-left-xs">Meeting Agenda.pdf</span></button>
+  <div class="rvt-dropdown" data-rvt-dropdown>
+    <button type="button" class="rvt-button rvt-button--secondary rvt-p-right-xs rvt-p-left-xs" data-rvt-dropdown-toggle>
+      <span class="rvt-sr-only">Toggle options menu</span>
+      <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+        <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z"/>
+      </svg>
+    </button>
+    <div class="rvt-dropdown__menu" data-rvt-dropdown-menu hidden>
+      <button type="button" role="menuitemradio">Preview</button>
+      <button type="button" role="menuitemradio">Open</button>
+      <button type="button" role="menuitemradio">Save As...</button>
+    </div>
+  </div>
+</div>

--- a/src/sass/buttons-segmented/_base.scss
+++ b/src/sass/buttons-segmented/_base.scss
@@ -80,4 +80,8 @@
     border-radius: 0;
     margin-left: -2px;
   }
+
+  .#{$prefix}-dropdown:last-child > .#{$prefix}-button:not(.#{$prefix}-button--secondary) {
+    margin-left: 2px;
+  }
 }


### PR DESCRIPTION
This PR adds a 2px spacer before the last dropdown in a segmented button group to help visually distinguish it from the button that precedes it (so that they don't look like a single button). This space is not added to secondary segmented buttons.