### PR TITLE
Fix badge style

### DIFF
--- a/src/sass/badges/_base.scss
+++ b/src/sass/badges/_base.scss
@@ -3,33 +3,25 @@
 
 @use '../core' as *;
 
+$border-radius: 999rem;
+
 .#{$prefix}-badge {
   background-color: $color-black-100;
-  border: 2px solid $color-black-100;
-  border-radius: 999px;
+  border: (2rem/16) solid $color-black-100;
+  border-radius: $border-radius;
   color: $color-black-base;
   display: inline-block;
-
-  /**
-   * We set the type size to a percent here so that if the badge is used
-   * inside another element that uses a "ts-*" type scale utility,
-   * the badge will inherit that size.
-   */
-  font-size: 88%;
+  font-size: $ts-xs;
   font-weight: $font-weight-medium;
   letter-spacing: .02rem;
-  line-height: 1.6;
-
-  /**
-   * Use ems here so that padding stays proportional if parent
-   * element font size changes.
-   */
-  padding: .0313rem .5rem;
+  line-height: 1;
+  padding: (3rem/16) .5rem;
+  white-space: nowrap;
   -webkit-font-smoothing: antialiased;
   -osx-font-smoothing: grayscale;
 
   &--secondary {
-    background-color: transparent;
+    background-color: $color-white-base;
   }
 }
 
@@ -66,7 +58,7 @@ a.#{$prefix}-badge {
   }
 
   &:focus {
-    border-radius: 999px;
+    border-radius: $border-radius;
   }
 }
 
@@ -76,7 +68,7 @@ a.#{$prefix}-badge {
   color: $color-white-base;
 
   &-secondary {
-    background-color: transparent;
+    background-color: $color-white-base;
     border-color: $color-blue-100;
     color: $color-blue-500;
   }
@@ -88,7 +80,7 @@ a.#{$prefix}-badge {
   color: $color-white-base;
 
   &-secondary {
-    background-color: transparent;
+    background-color: $color-white-base;
     border-color: $color-green-100;
     color: $color-green-500;
   }
@@ -100,7 +92,7 @@ a.#{$prefix}-badge {
   color: $color-black-700;
 
   &-secondary {
-    background-color: transparent;
+    background-color: $color-white-base;
     border-color: $color-gold-100;
     color: $color-black-500;
   }
@@ -112,7 +104,7 @@ a.#{$prefix}-badge {
   color: $color-white-base;
 
   &-secondary {
-    background-color: transparent;
+    background-color: $color-white-base;
     border-color: $color-orange-100;
     color: $color-orange-500;
   }

--- a/src/sass/badges/_base.scss
+++ b/src/sass/badges/_base.scss
@@ -7,7 +7,7 @@ $border-radius: 999rem;
 
 .#{$prefix}-badge {
   background-color: $color-black-100;
-  border: (2rem/16) solid $color-black-100;
+  border: calc(2rem/16) solid $color-black-100;
   border-radius: $border-radius;
   color: $color-black-base;
   display: inline-block;
@@ -15,7 +15,7 @@ $border-radius: 999rem;
   font-weight: $font-weight-medium;
   letter-spacing: .02rem;
   line-height: 1;
-  padding: (3rem/16) .5rem;
+  padding: calc(3rem/16) .5rem;
   white-space: nowrap;
   -webkit-font-smoothing: antialiased;
   -osx-font-smoothing: grayscale;


### PR DESCRIPTION
This PR fixes:

1. Height is now effectively `24px` (rather than `27.52px`).
2. Font size is now effectively `14px` (rather than `88%`).
3. Pixel units are replaced with `rem`.
4. Badge content should not wrap, because it should be succinct.
5. Secondary badges now have a white background, to maintain color contrast on non-white backgrounds.

Notes:

1. This removes the ability to scale badges according to its context. However, I've never seen such a use case. That can just lead to some odd uses. If there should be different sizes, there should be new modifiers.
2. Is it reasonable to ensure the badge does not wrap?
3. Values made with `calc()` are compiled by Sass, so it reduces runtime calculations. Neat.