### PR TITLE
Switch: Adjust height, add medium variant

### DIFF
--- a/src/sandbox/components/switch/variants/config-page.njk
+++ b/src/sandbox/components/switch/variants/config-page.njk
@@ -4,7 +4,7 @@ title: Switch configuration page
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true
-order: 5
+order: 6
 ---
 <div class="rvt-width-3-xl">
   <div class="rvt-flex rvt-justify-space-between rvt-items-center rvt-border-top rvt-border-bottom rvt-p-tb-md">

--- a/src/sandbox/components/switch/variants/danger.njk
+++ b/src/sandbox/components/switch/variants/danger.njk
@@ -4,7 +4,7 @@ title: Danger switch
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true
-order: 4
+order: 5
 ---
 <button class="rvt-switch rvt-switch--danger" data-rvt-switch="example-switch" role="switch">
   <span class="rvt-switch__on">On</span>

--- a/src/sandbox/components/switch/variants/medium.njk
+++ b/src/sandbox/components/switch/variants/medium.njk
@@ -1,6 +1,6 @@
 ---
 tags: switch
-title: Medium switch
+title: Medium switch (draft)
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true

--- a/src/sandbox/components/switch/variants/medium.njk
+++ b/src/sandbox/components/switch/variants/medium.njk
@@ -1,12 +1,12 @@
 ---
 tags: switch
-title: Small switch
+title: Medium switch
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true
-order: 4
+order: 3
 ---
-<button class="rvt-switch rvt-switch--small" data-rvt-switch="example-switch" role="switch">
+<button class="rvt-switch rvt-switch--medium" data-rvt-switch="example-switch" role="switch">
   <span class="rvt-switch__on">On</span>
   <span class="rvt-switch__off">Off</span>
 </button>

--- a/src/sass/switch/_base.scss
+++ b/src/sass/switch/_base.scss
@@ -12,7 +12,7 @@
   border-radius: $border-radius-circle;
   color: $color-black-100;
   display: flex;
-  gap: $spacing-xs;
+  gap: 0.75rem;
   height: $spacing-xl;
   line-height: 1;
   padding: 0 0.75rem;
@@ -74,7 +74,7 @@
 
   &--medium {
     height: $spacing-lg;
-    gap: 0;
+    gap: 0.25rem;
 
     &::after {
       height: $spacing-md;

--- a/src/sass/switch/_base.scss
+++ b/src/sass/switch/_base.scss
@@ -72,6 +72,8 @@
     }
   }
 
+// Medium variant is in review.
+/*
   &--medium {
     height: $spacing-lg;
     gap: 0.25rem;
@@ -85,6 +87,7 @@
       left: calc(100% - ($spacing-md + $spacing-xxs));
     }
   }
+*/
 
   &--small {
     font-size: $ts-14;

--- a/src/sass/switch/_base.scss
+++ b/src/sass/switch/_base.scss
@@ -8,13 +8,14 @@
   align-items: center;
   background: none;
   background-color: $color-black-400;
-  border: math.div($spacing-xxs, 2) solid $color-black-400;
+  border: none;
   border-radius: $border-radius-circle;
   color: $color-black-100;
   display: flex;
-  height: $spacing-xl + $spacing-xxs;
-  line-height: 1.1;
-  padding: $spacing-xxs;
+  gap: $spacing-xs;
+  height: $spacing-xl;
+  line-height: 1;
+  padding: 0 0.75rem;
   position: relative;
   -webkit-appearance: none;
 
@@ -29,8 +30,7 @@
     height: $spacing-lg;
     left: $spacing-xxs;
     position: absolute;
-    top: $spacing-xxs;
-    transition: transform .2s ease;
+    transition: left .2s ease;
     width: $spacing-lg;
   }
 
@@ -55,22 +55,7 @@
 
   &[aria-checked="true"]::after {
     background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="%23056E41" viewBox="0 0 16 16"><path d="m14.914 4-9.47 9.47L1.09 8.393 2.608 7.09l2.948 3.44L13.5 2.585 14.914 4Z"></path></svg>');
-    transform: translate($spacing-xl, 0);
-  }
-
-  &__on,
-  &__off {
-    border-radius: $border-radius-circle;
-    padding: ($spacing-xxs + .15) $spacing-xs;
-    transition: all .1s ease;
-  }
-
-  &__on {
-    padding-right: ($spacing-xxs + .15);
-  }
-
-  &__off {
-    padding-left: ($spacing-xxs + .15);
+    left: calc(100% - ($spacing-lg + $spacing-xxs));
   }
 
   &--danger[aria-checked="true"] {
@@ -87,46 +72,39 @@
     }
   }
 
+  &--medium {
+    height: $spacing-lg;
+    gap: 0;
+
+    &::after {
+      height: $spacing-md;
+      width: $spacing-md;
+    }
+
+    &[aria-checked="true"]::after {
+      left: calc(100% - ($spacing-md + $spacing-xxs));
+    }
+  }
+
   &--small {
+    font-size: $ts-14;
     height: $spacing-md;
-    padding: math.div($spacing-xxs, 2);
+    gap: 0;
+    padding: 0 $spacing-xs;
 
     &::after {
       background-size: ($spacing-sm * .75) ($spacing-sm * .75);
       height: $spacing-sm;
-      left: math.div($spacing-xxs, 2);
-      top: math.div($spacing-xxs, 2);
       width: $spacing-sm;
     }
 
     &[aria-checked="true"]::after {
-      /**
-       * NOTE: This is a magic number to make spacing around the small switch
-       * "handle" appear optically the same on all sides.
-       */
-      transform: translate($spacing-md * 1.25, 0);
+      left: calc(100% - ($spacing-sm + $spacing-xxs));
     }
   }
 
-  &--small &__on,
-  &--small &__off {
-    font-size: $ts-14;
-    padding: math.div($spacing-xxs, 2) $spacing-xxs;
-  }
-
-  &--small &__on {
-    padding-right: 0;
-  }
-
-  &--small &__off {
-    padding-left: 0;
-  }
-
+  &[aria-checked="false"] &__on,
   &[aria-checked="true"] &__off {
-    visibility: hidden;
-  }
-
-  &[aria-checked="false"] &__on {
     visibility: hidden;
   }
 }


### PR DESCRIPTION
Notes:

1. Adjusted the default height from `44px` to `40px` to match the height of buttons.
2. Added a `medium` variant at `32px` in height.
3. Cleaned up styles to minimize overrides for variants.
4. Replaced "On" icon transition from `translate` to `left`. This allows it to animate flush right regardless of the width of the button container. With `left`, percentage values are relative to its container. With `translate`, percentage values are relative to itself.
5. This has been visually tested in Chrome, Firefox, and Safari.
