### PR TITLE
Button style enhancements

### DIFF
--- a/src/sandbox/components/button/preview/button-full-width.njk
+++ b/src/sandbox/components/button/preview/button-full-width.njk
@@ -4,7 +4,7 @@ title: Full-width button
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true
-order: 4
+order: 5
 ---
 <button class="rvt-button rvt-button--full-width">Primary</button>
 <button class="rvt-button rvt-button--success rvt-button--full-width">Success</button>

--- a/src/sandbox/components/button/preview/button-group-right.njk
+++ b/src/sandbox/components/button/preview/button-group-right.njk
@@ -4,7 +4,7 @@ title: Right-aligned button group
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true
-order: 6
+order: 7
 ---
 <div class="rvt-button-group rvt-button-group--right">
   <button class="rvt-button">Primary</button>

--- a/src/sandbox/components/button/preview/button-icons.njk
+++ b/src/sandbox/components/button/preview/button-icons.njk
@@ -11,7 +11,7 @@ order: 6
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
       <path fill="currentColor" d="M14,7H9V2A1,1,0,0,0,7,2V7H2A1,1,0,0,0,2,9H7v5a1,1,0,0,0,2,0V9h5a1,1,0,0,0,0-2Z"/>
     </svg>
-    <span class="rvt-m-left-xs">Add item</span>
+    Add item
   </button>
   <button type="button" class="rvt-button">
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
@@ -20,7 +20,7 @@ order: 6
         <path d="M14,16H8a2,2,0,0,1-2-2V7A2,2,0,0,1,8,5h6a2,2,0,0,1,2,2v7A2,2,0,0,1,14,16ZM8,7v7h6V7Z"/>
       </g>
     </svg>
-    <span class="rvt-m-left-xs">Copy</span>
+    Copy
   </button>
   <button type="button" class="rvt-button rvt-button--danger">
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
@@ -29,7 +29,7 @@ order: 6
         <path d="M10.83,5.17a1,1,0,0,0-1.41,0L8,6.59,6.59,5.17A1,1,0,0,0,5.17,6.59L6.59,8,5.17,9.41a1,1,0,1,0,1.41,1.41L8,9.41l1.41,1.41a1,1,0,0,0,1.41-1.41L9.41,8l1.41-1.41A1,1,0,0,0,10.83,5.17Z"/>
       </g>
     </svg>
-    <span class="rvt-m-left-xs">Delete</span>
+    Delete
   </button>
   <button type="button" class="rvt-button rvt-button--secondary">
     <span class="rvt-sr-only">Edit entry</span>
@@ -43,7 +43,7 @@ order: 6
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
       <path fill="currentColor" d="M14,7H9V2A1,1,0,0,0,7,2V7H2A1,1,0,0,0,2,9H7v5a1,1,0,0,0,2,0V9h5a1,1,0,0,0,0-2Z"/>
     </svg>
-    <span class="rvt-m-left-xs">Add item</span>
+    Add item
   </button>
   <button type="button" class="rvt-button rvt-button--medium">
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
@@ -52,7 +52,7 @@ order: 6
         <path d="M14,16H8a2,2,0,0,1-2-2V7A2,2,0,0,1,8,5h6a2,2,0,0,1,2,2v7A2,2,0,0,1,14,16ZM8,7v7h6V7Z"/>
       </g>
     </svg>
-    <span class="rvt-m-left-xs">Copy</span>
+    Copy
   </button>
   <button type="button" class="rvt-button rvt-button--medium rvt-button--danger">
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
@@ -61,7 +61,7 @@ order: 6
         <path d="M10.83,5.17a1,1,0,0,0-1.41,0L8,6.59,6.59,5.17A1,1,0,0,0,5.17,6.59L6.59,8,5.17,9.41a1,1,0,1,0,1.41,1.41L8,9.41l1.41,1.41a1,1,0,0,0,1.41-1.41L9.41,8l1.41-1.41A1,1,0,0,0,10.83,5.17Z"/>
       </g>
     </svg>
-    <span class="rvt-m-left-xs">Delete</span>
+    Delete
   </button>
   <button type="button" class="rvt-button rvt-button--medium rvt-button--secondary">
     <span class="rvt-sr-only">Edit entry</span>
@@ -75,7 +75,7 @@ order: 6
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
       <path fill="currentColor" d="M14,7H9V2A1,1,0,0,0,7,2V7H2A1,1,0,0,0,2,9H7v5a1,1,0,0,0,2,0V9h5a1,1,0,0,0,0-2Z"/>
     </svg>
-    <span class="rvt-m-left-xs">Add item</span>
+    Add item
   </button>
   <button type="button" class="rvt-button rvt-button--small">
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
@@ -84,7 +84,7 @@ order: 6
         <path d="M14,16H8a2,2,0,0,1-2-2V7A2,2,0,0,1,8,5h6a2,2,0,0,1,2,2v7A2,2,0,0,1,14,16ZM8,7v7h6V7Z"/>
       </g>
     </svg>
-    <span class="rvt-m-left-xs">Copy</span>
+    Copy
   </button>
   <button type="button" class="rvt-button rvt-button--small rvt-button--danger">
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
@@ -93,7 +93,7 @@ order: 6
         <path d="M10.83,5.17a1,1,0,0,0-1.41,0L8,6.59,6.59,5.17A1,1,0,0,0,5.17,6.59L6.59,8,5.17,9.41a1,1,0,1,0,1.41,1.41L8,9.41l1.41,1.41a1,1,0,0,0,1.41-1.41L9.41,8l1.41-1.41A1,1,0,0,0,10.83,5.17Z"/>
       </g>
     </svg>
-    <span class="rvt-m-left-xs">Delete</span>
+    Delete
   </button>
   <button type="button" class="rvt-button rvt-button--small rvt-button--secondary">
     <span class="rvt-sr-only">Edit entry</span>

--- a/src/sandbox/components/button/preview/button-icons.njk
+++ b/src/sandbox/components/button/preview/button-icons.njk
@@ -4,7 +4,7 @@ title: Button with icons
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true
-order: 4
+order: 6
 ---
 <div class="rvt-button-group">
   <button type="button" class="rvt-button">
@@ -32,6 +32,70 @@ order: 4
     <span class="rvt-m-left-xs">Delete</span>
   </button>
   <button type="button" class="rvt-button rvt-button--secondary">
+    <span class="rvt-sr-only">Edit entry</span>
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <path fill="currentColor" d="M14.62,4.19,11.74,1.34a1.1,1.1,0,0,0-1.55,0L0,11.62,0,16l4.45,0L14.64,5.73A1.1,1.1,0,0,0,14.62,4.19ZM3.62,14H2V12.44l6-6L9.58,8ZM11,6.57,9.4,5,11,3.4,12.57,5Z"/>
+    </svg>
+  </button>
+</div>
+<div class="rvt-button-group rvt-m-top-sm">
+  <button type="button" class="rvt-button rvt-button--medium">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <path fill="currentColor" d="M14,7H9V2A1,1,0,0,0,7,2V7H2A1,1,0,0,0,2,9H7v5a1,1,0,0,0,2,0V9h5a1,1,0,0,0,0-2Z"/>
+    </svg>
+    <span class="rvt-m-left-xs">Add item</span>
+  </button>
+  <button type="button" class="rvt-button rvt-button--medium">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <g fill="currentColor">
+        <path d="M4,10.23H1.92V2H8V3h2V2A2,2,0,0,0,8,0H1.92a2,2,0,0,0-2,2v8.23a2,2,0,0,0,2,2H4Z"/>
+        <path d="M14,16H8a2,2,0,0,1-2-2V7A2,2,0,0,1,8,5h6a2,2,0,0,1,2,2v7A2,2,0,0,1,14,16ZM8,7v7h6V7Z"/>
+      </g>
+    </svg>
+    <span class="rvt-m-left-xs">Copy</span>
+  </button>
+  <button type="button" class="rvt-button rvt-button--medium rvt-button--danger">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <g fill="currentColor">
+        <path d="M8,0a8,8,0,1,0,8,8A8,8,0,0,0,8,0ZM8,14a6,6,0,1,1,6-6A6,6,0,0,1,8,14Z"/>
+        <path d="M10.83,5.17a1,1,0,0,0-1.41,0L8,6.59,6.59,5.17A1,1,0,0,0,5.17,6.59L6.59,8,5.17,9.41a1,1,0,1,0,1.41,1.41L8,9.41l1.41,1.41a1,1,0,0,0,1.41-1.41L9.41,8l1.41-1.41A1,1,0,0,0,10.83,5.17Z"/>
+      </g>
+    </svg>
+    <span class="rvt-m-left-xs">Delete</span>
+  </button>
+  <button type="button" class="rvt-button rvt-button--medium rvt-button--secondary">
+    <span class="rvt-sr-only">Edit entry</span>
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <path fill="currentColor" d="M14.62,4.19,11.74,1.34a1.1,1.1,0,0,0-1.55,0L0,11.62,0,16l4.45,0L14.64,5.73A1.1,1.1,0,0,0,14.62,4.19ZM3.62,14H2V12.44l6-6L9.58,8ZM11,6.57,9.4,5,11,3.4,12.57,5Z"/>
+    </svg>
+  </button>
+</div>
+<div class="rvt-button-group rvt-m-top-sm">
+  <button type="button" class="rvt-button rvt-button--small">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <path fill="currentColor" d="M14,7H9V2A1,1,0,0,0,7,2V7H2A1,1,0,0,0,2,9H7v5a1,1,0,0,0,2,0V9h5a1,1,0,0,0,0-2Z"/>
+    </svg>
+    <span class="rvt-m-left-xs">Add item</span>
+  </button>
+  <button type="button" class="rvt-button rvt-button--small">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <g fill="currentColor">
+        <path d="M4,10.23H1.92V2H8V3h2V2A2,2,0,0,0,8,0H1.92a2,2,0,0,0-2,2v8.23a2,2,0,0,0,2,2H4Z"/>
+        <path d="M14,16H8a2,2,0,0,1-2-2V7A2,2,0,0,1,8,5h6a2,2,0,0,1,2,2v7A2,2,0,0,1,14,16ZM8,7v7h6V7Z"/>
+      </g>
+    </svg>
+    <span class="rvt-m-left-xs">Copy</span>
+  </button>
+  <button type="button" class="rvt-button rvt-button--small rvt-button--danger">
+    <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+      <g fill="currentColor">
+        <path d="M8,0a8,8,0,1,0,8,8A8,8,0,0,0,8,0ZM8,14a6,6,0,1,1,6-6A6,6,0,0,1,8,14Z"/>
+        <path d="M10.83,5.17a1,1,0,0,0-1.41,0L8,6.59,6.59,5.17A1,1,0,0,0,5.17,6.59L6.59,8,5.17,9.41a1,1,0,1,0,1.41,1.41L8,9.41l1.41,1.41a1,1,0,0,0,1.41-1.41L9.41,8l1.41-1.41A1,1,0,0,0,10.83,5.17Z"/>
+      </g>
+    </svg>
+    <span class="rvt-m-left-xs">Delete</span>
+  </button>
+  <button type="button" class="rvt-button rvt-button--small rvt-button--secondary">
     <span class="rvt-sr-only">Edit entry</span>
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
       <path fill="currentColor" d="M14.62,4.19,11.74,1.34a1.1,1.1,0,0,0-1.55,0L0,11.62,0,16l4.45,0L14.64,5.73A1.1,1.1,0,0,0,14.62,4.19ZM3.62,14H2V12.44l6-6L9.58,8ZM11,6.57,9.4,5,11,3.4,12.57,5Z"/>

--- a/src/sandbox/components/button/preview/button-medium.njk
+++ b/src/sandbox/components/button/preview/button-medium.njk
@@ -1,6 +1,6 @@
 ---
 tags: button
-title: Medium button
+title: Medium button (draft)
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true

--- a/src/sandbox/components/button/preview/button-medium.njk
+++ b/src/sandbox/components/button/preview/button-medium.njk
@@ -1,0 +1,14 @@
+---
+tags: button
+title: Medium button
+layout: layouts/preview.njk
+permalink: /components/preview/{{ title | slug}}/
+padding: true
+order: 3
+---
+<div class="rvt-button-group">
+  <button class="rvt-button rvt-button--medium">Primary</button>
+  <button class="rvt-button rvt-button--success rvt-button--medium">Success</button>
+  <button class="rvt-button rvt-button--danger rvt-button--medium">Danger</button>
+  <button class="rvt-button rvt-button--plain rvt-button--medium">Plain</button>
+</div>

--- a/src/sandbox/components/button/preview/button-segmented-dropdown.njk
+++ b/src/sandbox/components/button/preview/button-segmented-dropdown.njk
@@ -9,7 +9,7 @@ order: 8
 <div class="rvt-button-segmented" role="group" aria-label="Dropdown group">
   <button type="button" class="rvt-button">
     <svg fill="currentColor" width="16" height="16" viewBox="0 0 16 16"><path d="M2 1h8.414L14 4.586V15H2V1Zm2 2v10h8V7.5H7.5V3H4Zm5.5 0v2.5H12v-.086L9.586 3H9.5Z"></path></svg>
-    <span class="rvt-m-left-xs">Meeting Agenda.pdf</span></button>
+    Meeting Agenda.pdf</button>
   <div class="rvt-dropdown" data-rvt-dropdown>
     <button type="button" class="rvt-button rvt-p-right-xs rvt-p-left-xs" data-rvt-dropdown-toggle>
       <span class="rvt-sr-only">Toggle options menu</span>
@@ -28,7 +28,7 @@ order: 8
 <div class="rvt-button-segmented" role="group" aria-label="Dropdown group">
   <button type="button" class="rvt-button rvt-button--secondary">
     <svg fill="currentColor" width="16" height="16" viewBox="0 0 16 16"><path d="M2 1h8.414L14 4.586V15H2V1Zm2 2v10h8V7.5H7.5V3H4Zm5.5 0v2.5H12v-.086L9.586 3H9.5Z"></path></svg>
-    <span class="rvt-m-left-xs">Meeting Agenda.pdf</span></button>
+    Meeting Agenda.pdf</button>
   <div class="rvt-dropdown" data-rvt-dropdown>
     <button type="button" class="rvt-button rvt-button--secondary rvt-p-right-xs rvt-p-left-xs" data-rvt-dropdown-toggle>
       <span class="rvt-sr-only">Toggle options menu</span>

--- a/src/sandbox/components/button/preview/button-segmented-dropdown.njk
+++ b/src/sandbox/components/button/preview/button-segmented-dropdown.njk
@@ -4,7 +4,7 @@ title: Segmented button with dropdown
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true
-order: 7
+order: 8
 ---
 <div class="rvt-button-segmented" role="group" aria-label="Dropdown group">
   <button type="button" class="rvt-button">

--- a/src/sandbox/components/button/preview/button-small.njk
+++ b/src/sandbox/components/button/preview/button-small.njk
@@ -4,7 +4,7 @@ title: Small button
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true
-order: 3
+order: 4
 ---
 <div class="rvt-button-group">
   <button class="rvt-button rvt-button--small">Primary</button>

--- a/src/sass/buttons/_base.scss
+++ b/src/sass/buttons/_base.scss
@@ -167,7 +167,7 @@
   }
 }
 
-// Medium buttons are in review.
+// Medium variant is in review.
 /*
 .#{$prefix}-button--medium {
   height: $spacing-lg;

--- a/src/sass/buttons/_base.scss
+++ b/src/sass/buttons/_base.scss
@@ -13,6 +13,7 @@
   cursor: pointer;
   display: inline-flex;
   font-weight: $font-weight-medium;
+  gap: $spacing-xs;
   height: $spacing-xl;
   line-height: 1;
   padding: 0 math.div(10rem, 16);
@@ -166,15 +167,18 @@
   }
 }
 
+// Medium buttons are in review.
+/*
 .#{$prefix}-button--medium {
   height: $spacing-lg;
   padding: 0 math.div(6rem, 16);
 }
+*/
 
 .#{$prefix}-button--small {
   font-size: $ts-14;
   height: $spacing-md;
-  padding: 0 math.div(2rem, 16);
+  padding: 0 math.div(6rem, 16);
 }
 
 .#{$prefix}-button--plain {

--- a/src/sass/buttons/_base.scss
+++ b/src/sass/buttons/_base.scss
@@ -5,19 +5,20 @@
 @use 'sass:math';
 
 .#{$prefix}-button {
+  align-items: center;
   background-color: $color-blue-500;
   border: math.div($spacing-xxs, 2) solid $color-blue-500;
   border-radius: $spacing-xxs;
   color: $color-white-base;
   cursor: pointer;
-  font-weight: $font-weight-medium;
-  line-height: 1;
-  text-decoration: none;
-  position: relative;
-  height: $spacing-xl;
-  padding: 0 $spacing-sm * .75;
   display: inline-flex;
-  align-items: center;
+  font-weight: $font-weight-medium;
+  height: $spacing-xl;
+  line-height: 1;
+  padding: 0 math.div(10rem, 16);
+  position: relative;
+  text-decoration: none;
+  white-space: nowrap;
 
   // Initially hide any loaders if they're being used inside buttons.
 
@@ -55,7 +56,7 @@
 }
 
 .#{$prefix}-button--secondary {
-  background-color: transparent;
+  background-color: $color-white-base;
   border-color: $color-blue-100;
   color: $color-blue-500;
 
@@ -99,7 +100,7 @@
 }
 
 .#{$prefix}-button--success-secondary {
-  background-color: transparent;
+  background-color: $color-white-base;
   border-color: $color-green-100;
   color: $color-green-500;
 
@@ -143,7 +144,7 @@
 }
 
 .#{$prefix}-button--danger-secondary {
-  background-color: transparent;
+  background-color: $color-white-base;
   border-color: $color-orange-100;
   color: $color-orange-500;
 
@@ -165,13 +166,15 @@
   }
 }
 
+.#{$prefix}-button--medium {
+  height: $spacing-lg;
+  padding: 0 math.div(6rem, 16);
+}
+
 .#{$prefix}-button--small {
   font-size: $ts-14;
   height: $spacing-md;
-  line-height: 1.1;
-  vertical-align: bottom;
-  padding-right: $spacing-xs;
-  padding-left: $spacing-xs;
+  padding: 0 math.div(2rem, 16);
 }
 
 .#{$prefix}-button--plain {


### PR DESCRIPTION
Notes:
1. Added white backgrounds to secondary buttons, so contrast is maintained on non-white backgrounds. See similar changes in #728.
2. Button content should not wrap, because it should be succinct. See similar changes in #728.
3. Reduced left and right button padding by `2px` on each side, so that normal-sized icon buttons are 40 square pixels.
4. Added `rvt-button--medium` variant, with `32px` height.
5. Added new medium and small variant examples in the "Button with icons" page.

Questions:
1. Should buttons use gap for icon button spacing, instead of `rvt-m-left-xs`? Or does that presume too much about the contents of buttons and how they should be used?
2. The `2px` horizontal padding for small buttons seems insufficient, in order to ensure that small icon buttons remain 24 square pixels. Does this indicate that perhaps the padding should be dynamic, according to if the visible content is an icon only verses icon with label verses just label?
3. We may want to consider later enhancing icon buttons so that there is a tooltip-style label that shows when it is in focus or on hover. The problem is how do we control the placement of such a thing? The new [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) would be great, but it is not yet available in Firefox. The upcoming [anchor positioning CSS property](https://developer.chrome.com/blog/introducing-popover-api/) is still being [drafted](https://drafts.csswg.org/css-anchor-position-1/). So, it would likely require the user to just pre-determine the position (bottom or top) and call it good enough.
4. Perhaps I should do more exemplar research. But the [Adobe Spectrum button](https://spectrum.adobe.com/page/button/) has a lot of useful variants.