### PR TITLE
Added utility classes to remove horizontal and vertical spacing

### DIFF
--- a/src/sandbox/utilities/spacing/examples/remove-margin.njk
+++ b/src/sandbox/utilities/spacing/examples/remove-margin.njk
@@ -1,0 +1,19 @@
+---
+tags: spacing
+title: Remove margin
+layout: layouts/preview.njk
+permalink: /utilities/preview/{{ title | slug}}/
+margin: true
+order: 7
+---
+<div class="rvt-m-all-xxl rvt-m-top-none rvt-bg-black-100">No top margin</div>
+<hr>
+<div class="rvt-m-all-xxl rvt-m-bottom-none rvt-bg-black-100">No bottom margin</div>
+<hr>
+<div class="rvt-m-all-xxl rvt-m-left-none rvt-bg-black-100">No left margin</div>
+<hr>
+<div class="rvt-m-all-xxl rvt-m-right-none rvt-bg-black-100">No right margin</div>
+<hr>
+<div class="rvt-m-all-xxl rvt-m-tb-none rvt-bg-black-100">No vertical margin</div>
+<hr>
+<div class="rvt-m-all-xxl rvt-m-lr-none rvt-bg-black-100">No horizontal margin</div>

--- a/src/sandbox/utilities/spacing/examples/remove-padding.njk
+++ b/src/sandbox/utilities/spacing/examples/remove-padding.njk
@@ -1,0 +1,16 @@
+---
+tags: spacing
+title: Remove padding
+layout: layouts/preview.njk
+permalink: /utilities/preview/{{ title | slug}}/
+padding: true
+order: 6
+---
+<div class="rvt-flow">
+  <div class="rvt-p-all-xxl rvt-p-top-none rvt-border-all">No top padding</div>
+  <div class="rvt-p-all-xxl rvt-p-bottom-none rvt-border-all">No bottom padding</div>
+  <div class="rvt-p-all-xxl rvt-p-left-none rvt-border-all">No left padding</div>
+  <div class="rvt-p-all-xxl rvt-p-right-none rvt-border-all">No right padding</div>
+  <div class="rvt-p-all-xxl rvt-p-tb-none rvt-border-all">No vertical padding</div>
+  <div class="rvt-p-all-xxl rvt-p-lr-none rvt-border-all">No horizontal padding</div>
+</div>

--- a/src/sass/utilities/_spacing.scss
+++ b/src/sass/utilities/_spacing.scss
@@ -32,7 +32,7 @@ $spacing-sizes: (
   -4-xl: $spacing-4-xl
 );
 
-// Super gnarly loop here, but it save sooo much time
+// Super gnarly loop here, but it saves sooo much time
 
 // Based on this great example by Harry Roberts:
 // https://github.com/NHSLeadership/nightingale/blob/develop/utilities/_utilities.spacing.scss#L48
@@ -40,7 +40,7 @@ $spacing-sizes: (
 @each $direction in $spacing-directions {
   @each $size, $value in $spacing-sizes {
     // NOTE: We use !important here because we want these utilities to always
-    // produced the same result.
+    // produce the same result.
 
     // If the direction is "null", add margin to all directions.
     @if $direction == null {
@@ -166,9 +166,33 @@ $spacing-sizes: (
       margin: 0 !important;
     }
 
+    .#{$prefix}-m-tb-remove,
+    .#{$prefix}-m-tb-none {
+      margin-top: 0 !important;
+      margin-bottom: 0 !important;
+    }
+
+    .#{$prefix}-m-lr-remove,
+    .#{$prefix}-m-lr-none {
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+    }
+
     .#{$prefix}-p-all-remove,
     .#{$prefix}-p-all-none {
       padding: 0 !important;
+    }
+
+    .#{$prefix}-p-tb-remove,
+    .#{$prefix}-p-tb-none {
+      padding-top: 0 !important;
+      padding-bottom: 0 !important;
+    }
+
+    .#{$prefix}-p-lr-remove,
+    .#{$prefix}-p-lr-none {
+      padding-left: 0 !important;
+      padding-right: 0 !important;
     }
   }
 


### PR DESCRIPTION
Fixes #733

Implements the following utility classes:

- `rvt-p-tb-none`
- `rvt-p-lr-none`
- `rvt-m-tb-none`
- `rvt-m-lr-none`