### PR TITLE
Removed right margin from button-like component text

### DIFF
--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -34,10 +34,6 @@
       text-decoration: underline;
     }
 
-    &-text {
-      margin-right: $spacing-xs;
-    }
-
     &[aria-expanded='true'] > svg {
       transform: rotate(180deg);
     }

--- a/src/sass/file-input/_base.scss
+++ b/src/sass/file-input/_base.scss
@@ -25,10 +25,6 @@
     flex-grow: 0;
     width: inherit;
     display: flex;
-
-    span {
-      margin-right: $spacing-xs;
-    }
   }
 
   input[type='file']:focus + label {
@@ -51,7 +47,6 @@
     span {
       font-weight: $font-weight-bold;
       line-height: $line-height-base;
-      margin-right: $spacing-sm;
       display: inline-block;
     }
   }


### PR DESCRIPTION
The `2.6.0` release added a `gap` property to Rivet buttons, which added space between button text and icons. Two components, the dropdown and file input, had `margin-right` styles to add this gap, resulting in a doubling up of space between text and icons.

This PR removes the unneeded `margin-right` styles from the file input button text and dropdown toggle text.