### PR TITLE
Integrate CSS custom properties into core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ cypress/screenshots
 /src/sass/core/maps/*.scss
 !/src/sass/core/maps/_index.scss
 /src/sass/core/variables.scss
+/src/sass/core/css-custom-properties.scss

--- a/.tokens.config.js
+++ b/.tokens.config.js
@@ -13,6 +13,17 @@ module.exports = {
         }
       ]
     },
+    "src/sass/core/css": {
+      transformGroup: 'scss',
+      buildPath: 'src/sass/core/',
+      prefix: 'rvt',
+      files: [
+        {
+          destination: 'css-custom-properties.scss',
+          format: 'css/variables'
+        }
+      ]
+    },
     "tokens/sass": {
       transformGroup: 'scss',
       buildPath: 'tokens/sass/',

--- a/.tokens.config.js
+++ b/.tokens.config.js
@@ -13,7 +13,7 @@ module.exports = {
         }
       ]
     },
-    "src/sass/core/css": {
+    "src/sass/core/css-custom-properties": {
       transformGroup: 'scss',
       buildPath: 'src/sass/core/',
       prefix: 'rvt',

--- a/src/sass/core/_index.scss
+++ b/src/sass/core/_index.scss
@@ -1,3 +1,4 @@
+@forward 'css-custom-properties';
 @forward 'maps';
 @forward 'mixins';
 @forward 'variables';


### PR DESCRIPTION
Notes:

1. Should the generated file base name be `css-custom-properties`?
2. Should the generated file extension be `.scss` or `.css`? Either works, since it doesn't produce any Sass-specific syntax.
3. Should the platform name in the config be `src/sass/core/css`? The [platform name](https://amzn.github.io/style-dictionary/#/config?id=platform) can be anything.