### PR TITLE
Updated references to italic fonts

### DIFF
--- a/src/sass/defaults/_fonts.scss
+++ b/src/sass/defaults/_fonts.scss
@@ -18,6 +18,19 @@
 
 @font-face {
   font-family: BentonSans;
+  font-style: italic;
+  font-weight: $font-weight-regular;
+  src: url('https://fonts.iu.edu/fonts/benton-sans-italic.eot');
+  src:
+    url('https://fonts.iu.edu/fonts/benton-sans-italic.eot?#iefix') format('embedded-opentype'),
+    url('https://fonts.iu.edu/fonts/benton-sans-italic.woff') format('woff'),
+    url('https://fonts.iu.edu/fonts/benton-sans-italic.ttf') format('truetype'),
+    url('https://fonts.iu.edu/fonts/benton-sans-italic.svg#BentonSansItalic') format('svg');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: BentonSans;
   font-style: normal;
   font-weight: $font-weight-medium;
   src: url('https://fonts.iu.edu/fonts/benton-sans-medium.eot');
@@ -78,5 +91,18 @@
     url('https://fonts.iu.edu/fonts/georgia-pro-bold.woff') format('woff'),
     url('https://fonts.iu.edu/fonts/georgia-pro-bold.ttf') format('truetype'),
     url('https://fonts.iu.edu/fonts/georgia-pro-bold.svg#GeorgiaProBold') format('svg');
+  font-display: swap;
+}
+
+@font-face {
+  font-family: GeorgiaPro;
+  font-style: italic;
+  font-weight: $font-weight-bold;
+  src: url('https://fonts.iu.edu/fonts/georgia-pro-bold-italic.eot');
+  src:
+    url('https://fonts.iu.edu/fonts/georgia-pro-bold-italic.eot?#iefix') format('embedded-opentype'),
+    url('https://fonts.iu.edu/fonts/georgia-pro-bold-italic.woff') format('woff'),
+    url('https://fonts.iu.edu/fonts/georgia-pro-bold-italic.ttf') format('truetype'),
+    url('https://fonts.iu.edu/fonts/georgia-pro-bold-italic.svg#GeorgiaProBoldItalic') format('svg');
   font-display: swap;
 }

--- a/src/sass/defaults/_fonts.scss
+++ b/src/sass/defaults/_fonts.scss
@@ -51,7 +51,7 @@
     url('https://fonts.iu.edu/fonts/benton-sans-bold.eot?#iefix') format('embedded-opentype'),
     url('https://fonts.iu.edu/fonts/benton-sans-bold.woff') format('woff'),
     url('https://fonts.iu.edu/fonts/benton-sans-bold.ttf') format('truetype'),
-    url('https://fonts.iu.edu/fonts/benton-sans-bold.svg#BentonSansRegular') format('svg');
+    url('https://fonts.iu.edu/fonts/benton-sans-bold.svg#BentonSansBold') format('svg');
   font-display: swap;
 }
 


### PR DESCRIPTION
This was reported to me directly. Apparently we were not importing the bold italic version of Georgia Pro, or the regular italic version of Benton. They should be working as expected now.