### PR TITLE
Preserve top/bottom whitespace when adjusting gutters. Fixes #750

### DIFF
--- a/src/sass/grid/_base.scss
+++ b/src/sass/grid/_base.scss
@@ -101,7 +101,8 @@ $gutter: math.div($spacing-md, 2);
   }
 
   &--loose {
-    margin: 0 ($gutter * -2);
+    margin-left: $gutter * -2;
+    margin-right: $gutter * -2;
   }
 
   &--loose > [class^='#{$prefix}-cols'] {
@@ -109,7 +110,8 @@ $gutter: math.div($spacing-md, 2);
   }
 
   &--tight {
-    margin: 0 ($gutter * -.75);
+    margin-left: $gutter * -.75;
+    margin-right: $gutter * -.75;
   }
 
   &--tight > [class^='#{$prefix}-cols'] {

--- a/src/sass/grid/_base.scss
+++ b/src/sass/grid/_base.scss
@@ -85,7 +85,8 @@ $gutter: math.div($spacing-md, 2);
   flex-basis: 0;
   flex-grow: 1;
   max-width: 100%;
-  padding: 0 $gutter;
+  padding-left: $gutter;
+  padding-right: $gutter;
   position: relative;
 }
 
@@ -106,7 +107,8 @@ $gutter: math.div($spacing-md, 2);
   }
 
   &--loose > [class^='#{$prefix}-cols'] {
-    padding: 0 ($gutter * 2);
+    padding-left: $gutter * 2;
+    padding-right: $gutter * 2;
   }
 
   &--tight {
@@ -115,7 +117,8 @@ $gutter: math.div($spacing-md, 2);
   }
 
   &--tight > [class^='#{$prefix}-cols'] {
-    padding: 0 ($gutter * .75);
+    padding-left: $gutter * .75;
+    padding-right: $gutter * .75;
   }
 
   [class^='#{$prefix}-cols'] {
@@ -172,7 +175,8 @@ $gutter: math.div($spacing-md, 2);
  */
 
 %cols-properties {
-  padding: 0 $gutter;
+  padding-left: $gutter;
+  padding-right: $gutter;
   position: relative;
   width: 100%;
 }


### PR DESCRIPTION
This PR fixes Rivet Grid gutter logic to ensure top and bottom whitespace (padding and margin) remains unaffected when using `rvt-cols` and `rvt-cols-*` classes, or when adjusting gutter widths using `rvt-row--tight` or `rvt-row--loose`.

This solves issue #750 when using `rvt-row--tight` or `rvt-row--loose` modifier classes inside a `rvt-flow` container.  See issue #750 for further details.