### PR TITLE
Removed aria-haspopup attribute from sidenav and dropdown

### DIFF
--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -81,6 +81,16 @@ export default class Dropdown extends Component {
       },
 
       /************************************************************************
+       * Initializes dropdown state properties.
+       *
+       * @private
+       ***********************************************************************/
+
+      _initProperties () {
+        this.isOpen = false
+      },
+
+      /************************************************************************
        * Initializes a list of menu items in the dropdown.
        *
        * @private
@@ -148,16 +158,6 @@ export default class Dropdown extends Component {
         // non-hyperlink element is present
         
         return this.menuItems.some(i => i.tagName != 'A')
-      },
-
-      /************************************************************************
-       * Initializes dropdown state properties.
-       *
-       * @private
-       ***********************************************************************/
-
-      _initProperties () {
-        this.isOpen = false
       },
 
       /************************************************************************

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -45,9 +45,9 @@ export default class Dropdown extends Component {
       init () {
         this._initSelectors()
         this._initElements()
-        this._initAttributes()
         this._initProperties()
         this._initMenuItems()
+        this._initAttributes()
         this._removeIconFromTabOrder()
         this._bindExternalEventHandlers()
 
@@ -78,6 +78,20 @@ export default class Dropdown extends Component {
       _initElements () {
         this.toggleElement = this.element.querySelector(this.toggleSelector)
         this.menuElement = this.element.querySelector(this.menuSelector)
+      },
+
+      /************************************************************************
+       * Initializes a list of menu items in the dropdown.
+       *
+       * @private
+       ***********************************************************************/
+
+      _initMenuItems () {
+        const focusableElements = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]'
+
+        this.menuItems = Array.from(this.menuElement.querySelectorAll(focusableElements))
+        this.firstMenuItem = this.menuItems[0]
+        this.lastMenuItem = this.menuItems[this.menuItems.length - 1]
       },
 
       /************************************************************************
@@ -113,8 +127,27 @@ export default class Dropdown extends Component {
        ***********************************************************************/
 
       _setAriaAttributes () {
-        this.toggleElement.setAttribute('aria-haspopup', true)
         this.toggleElement.setAttribute('aria-expanded', false)
+
+        if (this._isMenu()) {
+          this.menuElement.setAttribute('role', 'menu')
+          this.toggleElement.setAttribute('aria-haspopup', 'menu')
+        }
+      },
+
+      /************************************************************************
+       * Determines if the dropdown is a menu for the purposes of ARIA
+       * attributes.
+       *
+       * @private
+       * @returns {boolean} Dropdown is menu
+       ***********************************************************************/
+
+      _isMenu () {
+        // Consider the dropdown a menu of action buttons if at least one
+        // non-hyperlink element is present
+        
+        return this.menuItems.some(i => i.tagName != 'A')
       },
 
       /************************************************************************
@@ -125,20 +158,6 @@ export default class Dropdown extends Component {
 
       _initProperties () {
         this.isOpen = false
-      },
-
-      /************************************************************************
-       * Initializes a list of menu items in the dropdown.
-       *
-       * @private
-       ***********************************************************************/
-
-      _initMenuItems () {
-        const focusableElements = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex="0"]'
-
-        this.menuItems = Array.from(this.menuElement.querySelectorAll(focusableElements))
-        this.firstMenuItem = this.menuItems[0]
-        this.lastMenuItem = this.menuItems[this.menuItems.length - 1]
       },
 
       /************************************************************************

--- a/src/js/components/sidenav.js
+++ b/src/js/components/sidenav.js
@@ -140,22 +140,9 @@ export default class Sidenav extends Component {
        ***********************************************************************/
 
       _setInitialChildMenuStates () {
-        this._setChildMenuDefaultAriaAttributes()
         this._shouldOpenAllChildMenus()
           ? this._openAllChildMenus()
           : this._setChildMenuDefaultStates()
-      },
-
-      /************************************************************************
-       * Sets the default ARIA attributes for the sidenav's child menus.
-       *
-       * @private
-       ***********************************************************************/
-
-      _setChildMenuDefaultAriaAttributes () {
-        this.childMenuToggleButtons.forEach(
-          toggleButton => toggleButton.setAttribute('aria-haspopup', 'true')
-        )
       },
 
       /************************************************************************

--- a/src/sandbox/components/dropdown/variants/dropdown-buttons.njk
+++ b/src/sandbox/components/dropdown/variants/dropdown-buttons.njk
@@ -13,7 +13,7 @@ order: 4
       <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z" />
     </svg>
   </button>
-  <div class="rvt-dropdown__menu" id="dropdownButtons" role="menu" hidden data-rvt-dropdown-menu>
+  <div class="rvt-dropdown__menu" id="dropdownButtons" hidden data-rvt-dropdown-menu>
     <button type="button" role="menuitemradio">
       <span>Notify all</span>
     </button>

--- a/src/sandbox/components/dropdown/variants/dropdown-buttons.njk
+++ b/src/sandbox/components/dropdown/variants/dropdown-buttons.njk
@@ -7,7 +7,7 @@ padding: true
 order: 4
 ---
 <div class="rvt-dropdown" data-rvt-dropdown="dropdownButtons">
-  <button type="button" class="rvt-button" data-rvt-dropdown-toggle="dropdownButtons" aria-haspopup="true" aria-expanded="false">
+  <button type="button" class="rvt-button" data-rvt-dropdown-toggle="dropdownButtons" aria-expanded="false">
     <span class="rvt-dropdown__toggle-text">Dropdown with buttons</span>
     <svg aria-hidden="true" class="rvt-m-left-xs" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
       <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z" />

--- a/src/sandbox/components/dropdown/variants/dropdown-groups-headings.njk
+++ b/src/sandbox/components/dropdown/variants/dropdown-groups-headings.njk
@@ -7,7 +7,7 @@ padding: true
 order: 3
 ---
 <div class="rvt-dropdown" data-rvt-dropdown="dropdownHeading">
-  <button type="button" class="rvt-button" data-rvt-dropdown-toggle="dropdownHeading" aria-haspopup="true" aria-expanded="false">
+  <button type="button" class="rvt-button" data-rvt-dropdown-toggle="dropdownHeading" aria-expanded="false">
     <span class="rvt-dropdown__toggle-text">Dropdown with heading</span>
     <svg aria-hidden="true" class="rvt-m-left-xs" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
       <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z" />

--- a/src/sandbox/components/dropdown/variants/right-aligned-dropdown.njk
+++ b/src/sandbox/components/dropdown/variants/right-aligned-dropdown.njk
@@ -7,7 +7,7 @@ padding: true
 order: 2
 ---
 <div class="rvt-dropdown" data-rvt-dropdown="dropdownRight">
-  <button type="button" class="rvt-button" data-rvt-dropdown-toggle="dropdownRight" aria-haspopup="true" aria-expanded="false">
+  <button type="button" class="rvt-button" data-rvt-dropdown-toggle="dropdownRight" aria-expanded="false">
     <span class="rvt-dropdown__toggle-text">Right-aligned dropdown menu</span>
     <svg aria-hidden="true" class="rvt-m-left-xs" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
       <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z" />

--- a/src/sandbox/components/input-group/variants/input-group-button-prepend.njk
+++ b/src/sandbox/components/input-group/variants/input-group-button-prepend.njk
@@ -10,7 +10,7 @@ order: 2
 <div class="rvt-input-group">
   <div class="rvt-input-group__prepend">
     <div class="rvt-dropdown" data-rvt-dropdown="dropdownNavigation">
-      <button type="button" class="rvt-button rvt-button--secondary" data-rvt-dropdown-toggle="dropdownNavigation" aria-haspopup="true" aria-expanded="false">
+      <button type="button" class="rvt-button rvt-button--secondary" data-rvt-dropdown-toggle="dropdownNavigation" aria-expanded="false">
         <span class="rvt-dropdown__toggle-text">All stuff</span>
         <svg aria-hidden="true" class="rvt-m-left-xs" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
           <path fill="currentColor" d="M8,12.46a2,2,0,0,1-1.52-.7L1.24,5.65a1,1,0,1,1,1.52-1.3L8,10.46l5.24-6.11a1,1,0,0,1,1.52,1.3L9.52,11.76A2,2,0,0,1,8,12.46Z" />


### PR DESCRIPTION
This PR removes the `aria-haspopup` attribute from the sidenav and dropdown components, with the exception of dropdown components used as application menus.