### PR TITLE
Retain rounded corners on segmented buttons. Fixes #782

### DIFF
--- a/src/sandbox/components/button/preview/button-segmented-dropdown.njk
+++ b/src/sandbox/components/button/preview/button-segmented-dropdown.njk
@@ -4,7 +4,7 @@ title: Segmented button with dropdown
 layout: layouts/preview.njk
 permalink: /components/preview/{{ title | slug}}/
 padding: true
-order: 8
+order: 9
 ---
 <div class="rvt-button-segmented" role="group" aria-label="Dropdown group">
   <button type="button" class="rvt-button">

--- a/src/sandbox/components/button/preview/button-segmented.njk
+++ b/src/sandbox/components/button/preview/button-segmented.njk
@@ -1,0 +1,29 @@
+---
+tags: button
+title: Segmented button
+layout: layouts/preview.njk
+permalink: /components/preview/{{ title | slug}}/
+padding: true
+order: 8
+---
+<div class="rvt-button-segmented rvt-m-top-sm" role="group" aria-label="Primary controls">
+  <button type="button" class="rvt-button">Primary one</button>
+  <button type="button" class="rvt-button">Primary two</button>
+  <button type="button" class="rvt-button">Primary three</button>
+</div>
+<br>
+<div class="rvt-button-segmented rvt-m-top-sm" role="group" aria-label="Secondary controls">
+  <button type="button" class="rvt-button rvt-button--secondary">Secondary one</button>
+  <button type="button" class="rvt-button rvt-button--secondary">Secondary two</button>
+  <button type="button" class="rvt-button rvt-button--secondary">Secondary three</button>
+</div>
+<br>
+<div class="rvt-button-segmented rvt-m-top-sm" role="group" aria-label="Secondary controls">
+  <button type="button" class="rvt-button rvt-button--secondary">Secondary one</button>
+</div>
+<br>
+<div class="rvt-button-segmented rvt-button-segmented--fitted rvt-m-top-sm" role="group" aria-label="Primary controls">
+  <button type="button" class="rvt-button rvt-button--secondary">Primary one</button>
+  <button type="button" class="rvt-button rvt-button--secondary">Primary two</button>
+  <button type="button" class="rvt-button rvt-button--secondary">Primary three</button>
+</div>

--- a/src/sass/buttons-segmented/_base.scss
+++ b/src/sass/buttons-segmented/_base.scss
@@ -28,12 +28,12 @@
     text-align: center;
   }
 
-  .#{$prefix}-button:first-child {
+  .#{$prefix}-button:not(:last-child) {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
 
-  .#{$prefix}-button:last-child {
+  .#{$prefix}-button:not(:first-child) {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     margin-left: -2px;


### PR DESCRIPTION
**Fixes: Segmented button with single item loses rounded corners**

This PR addresses issue #782.

**Problem:**

When a `.rvt-button-segmented` group contains only a single button, the button incorrectly loses its rounded corners. This is due to the `:first-child` and `:last-child` CSS selectors unintentionally removing all `border-radius` when an element is both the first and last child.

**Solution:**

The CSS selectors have been updated to use `:not(:first-child)` and `:not(:last-child)`. This ensures that if a button is the sole child within the segmented group, the specific rules for overriding corner radii are not applied, allowing the button to retain its default rounded corners. This resolves the issue with a pure CSS fix, avoiding the need for conditional server-side logic to manage button wrapping.

Additionally, this PR includes the `button-segmented.njk` file, for testing or demonstration of this fix, alongside other common implementations of the segmented button. 

<img width="1004" alt="Screen Shot 2025-06-03 at 23 02 01" src="https://github.com/user-attachments/assets/59cc7fcf-f27c-4cfa-a219-51278d77ac3f" />
