### PR TITLE
Fixes accidental publish of wrong version to latest branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rivet-core",
   "description": "Indiana University design system",
   "homepage": "https://rivet.iu.edu",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a hot fix patch release that only bumps the version number of the package from 2.9.0 to 2.9.1. There are no other code changes. A newer alpha version of the code was accidentally published to the latest tag on npm.