### PR TITLE
Fix Sass depreciation warnings

### DIFF
--- a/src/sass/header-system/_base.scss
+++ b/src/sass/header-system/_base.scss
@@ -18,10 +18,10 @@
   padding-block: $spacing-sm;
 
   &__inner {
-    @include container;
     align-items: center;
     display: flex;
     gap: $spacing-sm;
+    @include container;
   }
 
   &__controls {

--- a/src/sass/hero-area/_base.scss
+++ b/src/sass/hero-area/_base.scss
@@ -6,10 +6,10 @@
 .#{$prefix}-hero {
 
   &__inner {
-    @include container;
     display: flex;
     flex-direction: column;
     gap: $spacing-lg;
+    @include container;
   }
 
   &__eyebrow {
@@ -78,10 +78,10 @@
   }
 
   &--feature &__banner {
-    @include container();
     display: flex;
     flex-direction: column;
     gap: $spacing-lg;
+    @include container();
   }
 
   &--profile &__subtitle {

--- a/src/sass/layout/_layout-base.scss
+++ b/src/sass/layout/_layout-base.scss
@@ -15,9 +15,9 @@
 }
 
 .#{$prefix}-layout-base {
-  @include container;
   display: grid;
   gap: $spacing-md;
+  @include container;
 
   &__sidebar {
     padding-block-start: $spacing-lg;


### PR DESCRIPTION
Follow up to #788.

To resolve the [mixed declarations warning](https://sass-lang.com/documentation/breaking-changes/mixed-decls/), I just needed to declare the `@include` rules after the other rules.