### PR TITLE
Add rvt-button, rvt-button-group, rvt-margin

### DIFF
--- a/src/sandbox/components/badge/badge-ce.njk
+++ b/src/sandbox/components/badge/badge-ce.njk
@@ -13,7 +13,7 @@ title: Custom Element Badge
 	<rvt-badge type="danger">Danger</rvt-badge>
 </div>
 
-<div class="rvt-flex rvt-gap-xs rvt-m-top-md">
+<div class="rvt-flex rvt-gap-xs" rvt-margin="b-s:md">
 	<rvt-badge tone="strong">Default</rvt-badge>
 	<rvt-badge type="info" tone="strong">Info</rvt-badge>
 	<rvt-badge type="success" tone="strong">

--- a/src/sandbox/components/badge/badge-ce.njk
+++ b/src/sandbox/components/badge/badge-ce.njk
@@ -1,0 +1,25 @@
+---
+title: Custom Element Badge
+---
+
+<div class="rvt-flex rvt-gap-xs">
+	<rvt-badge>Default</rvt-badge>
+	<rvt-badge type="info">Info</rvt-badge>
+	<rvt-badge type="success">
+		<rvt-icon name="check"></rvt-icon>
+		Success
+	</rvt-badge>
+	<rvt-badge type="warning">Warning</rvt-badge>
+	<rvt-badge type="danger">Danger</rvt-badge>
+</div>
+
+<div class="rvt-flex rvt-gap-xs rvt-m-top-md">
+	<rvt-badge tone="strong">Default</rvt-badge>
+	<rvt-badge type="info" tone="strong">Info</rvt-badge>
+	<rvt-badge type="success" tone="strong">
+		<rvt-icon name="check"></rvt-icon>
+		Success
+	</rvt-badge>
+	<rvt-badge type="warning" tone="strong">Warning</rvt-badge>
+	<rvt-badge type="danger" tone="strong">Danger</rvt-badge>
+</div>

--- a/src/sandbox/components/badge/badge-default.njk
+++ b/src/sandbox/components/badge/badge-default.njk
@@ -1,9 +1,5 @@
 ---
-tags: badge
 title: Badge
-layout: layouts/preview.njk
-permalink: /components/preview/{{ title | slug}}/
-order: 1
 ---
 
 <div class="rvt-flex rvt-gap-xs">

--- a/src/sandbox/components/badge/index.njk
+++ b/src/sandbox/components/badge/index.njk
@@ -1,6 +1,0 @@
----
-title: Badge
-component: badge
-tags: component
-layout: layouts/component.njk
----

--- a/src/sandbox/components/button/button-ce.njk
+++ b/src/sandbox/components/button/button-ce.njk
@@ -1,0 +1,61 @@
+---
+title: Custom Element Button
+---
+
+<style>
+	button[aria-pressed="false"] > rvt-icon:not(:nth-of-type(1)),
+	button[aria-pressed="true"] > rvt-icon:not(:nth-of-type(2)) {
+		display: none;
+	}
+	button[aria-pressed="true"] > rvt-icon {
+		color: var(--rvt-color-theme-accent);
+	}
+</style>
+
+<rvt-button-group>
+	<rvt-button type="form" tone="normal" size="small">
+		<button type="button">
+			<rvt-icon name="plus"></rvt-icon>
+			Add
+		</button>
+	</rvt-button>
+	<!-- Remove type and tone defaults. Use size shorthand. -->
+	<rvt-button size="sm">
+		<button type="button">
+			<rvt-icon name="filter"></rvt-icon>
+			Filter
+		</button>
+	</rvt-button>
+</rvt-button-group>
+
+<rvt-button-group rvt-margin="b-s:md">
+	<rvt-button tone="subtle" size="md">
+		<button type="button" aria-pressed="false">
+			<rvt-icon name="heart"></rvt-icon>
+			<rvt-icon name="heart-solid"></rvt-icon>
+			Favorite
+		</button>
+	</rvt-button>
+	<rvt-button tone="subtle" size="md">
+		<button type="button" aria-pressed="false">
+			<rvt-icon name="bookmark"></rvt-icon>
+			<rvt-icon name="bookmark-solid"></rvt-icon>
+			Bookmark
+		</button>
+	</rvt-button>
+	<rvt-button tone="subtle" size="md">
+		<button type="button">
+			<rvt-icon name="close"></rvt-icon>
+			<rvt-sr-only>Dismiss</rvt-sr-only>
+		</button>
+	</rvt-button>
+</rvt-button-group>
+
+<rvt-button-group rvt-margin="b-s:md">
+	<rvt-button tone="strong" size="lg">
+		<button type="submit">Submit</button>
+	</rvt-button>
+	<rvt-button size="lg">
+		<button type="button">Cancel</button>
+	</rvt-button>
+</rvt-button-group>

--- a/src/sass/badges/_base.scss
+++ b/src/sass/badges/_base.scss
@@ -1,18 +1,17 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
-:is(span, strong).#{$prefix}-badge {
+rvt-badge,
+:is(span, strong).rvt-badge {
 	align-items: center;
 	background-color: var(--color-background);
-	border-radius: $border-radius-circle;
+	border-radius: var(--rvt-border-radius-circle);
 	box-shadow: 0 0 0 calc(1rem / 16) var(--rvt-color-base-ultralight);
 	color: var(--color-text);
 	display: inline-flex;
-	font-size: $ts-xs;
-	font-weight: $font-weight-medium;
-	gap: $spacing-xxs;
+	font-size: var(--rvt-ts-xs);
+	font-weight: var(--rvt-font-weight-medium);
+	gap: var(--rvt-spacing-xxs);
 	letter-spacing: 0.02rem;
 	line-height: 1;
 	padding: 0.25rem 0.5rem;
@@ -22,51 +21,61 @@
 	-osx-font-smoothing: grayscale;
 }
 
-span.#{$prefix}-badge {
+rvt-badge,
+span.rvt-badge {
 	--color-background: var(--rvt-color-base-light);
 	--color-text: var(--rvt-color-base-main);
 
-	&--info {
+	&[type="info"],
+	.rvt-badge--info {
 		--color-background: var(--rvt-color-info-container);
 		--color-text: var(--rvt-color-info-main);
 	}
 
-	&--success {
+	&[type="success"],
+	.rvt-badge--success {
 		--color-background: var(--rvt-color-success-container);
 		--color-text: var(--rvt-color-success-main);
 	}
 
-	&--warning {
+	&[type="warning"],
+	.rvt-badge--warning {
 		--color-background: var(--rvt-color-warning-container);
 		--color-text: var(--rvt-color-base-main);
 	}
 
-	&--danger {
+	&[type="danger"],
+	.rvt-badge--danger {
 		--color-background: var(--rvt-color-danger-container);
 		--color-text: var(--rvt-color-danger-main);
 	}
 }
 
-strong.#{$prefix}-badge {
+rvt-badge[tone="strong"],
+strong.rvt-badge {
 	--color-background: var(--rvt-color-base-main);
 	--color-text: var(--rvt-color-base-ultralight);
 
-	&--info {
+	&[type="info"],
+	&.rvt-badge--info {
 		--color-background: var(--rvt-color-info-main);
 		--color-text: var(--rvt-color-base-ultralight);
 	}
 
-	&--success {
+	&[type="success"],
+	&.rvt-badge--success {
 		--color-background: var(--rvt-color-success-main);
 		--color-text: var(--rvt-color-base-ultralight);
 	}
 
-	&--warning {
+	&[type="warning"],
+	&.rvt-badge--warning {
 		--color-background: var(--rvt-color-warning-main);
 		--color-text: var(--rvt-color-base-main);
 	}
 
-	&--danger {
+	&[type="danger"],
+	&.rvt-badge--danger {
 		--color-background: var(--rvt-color-danger-main);
 		--color-text: var(--rvt-color-base-ultralight);
 	}

--- a/src/sass/buttons/_base.scss
+++ b/src/sass/buttons/_base.scss
@@ -1,6 +1,11 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
+rvt-button {
+	display: inline-flex;
+}
+
+rvt-button > :is(a, button),
 .rvt-button {
 	--color-border: var(--rvt-color-theme-text-strong);
 	--color-background: var(--rvt-color-theme-background);
@@ -71,12 +76,14 @@
 	}
 }
 
+rvt-button:is([size="medium"], [size="md"]) > :is(a, button),
 .rvt-button--medium {
 	--padding-inline-extra: calc(2rem / 16);
 	--size-font: var(--rvt-ts-14);
 	--size-height: 2rem;
 }
 
+rvt-button:is([size="small"], [size="sm"]) > :is(a, button),
 .rvt-button--small {
 	--gap: var(--rvt-spacing-xxs);
 	--padding-inline-extra: calc(4rem / 16);
@@ -89,6 +96,7 @@
 	}
 }
 
+rvt-button[tone="strong"] > :is(a, button),
 .rvt-button--strong {
 	--color-background: var(--rvt-color-theme-background-inverse);
 	--color-background-hover: var(--rvt-color-theme-background-inverse-strong);
@@ -98,6 +106,7 @@
 	--color-text-hover: var(--rvt-color-theme-background);
 }
 
+rvt-button[tone="subtle"] > :is(a, button),
 .rvt-button--subtle {
 	--color-background-hover: var(--rvt-color-theme-background);
 	--color-background-pressed: var(--rvt-color-theme-background-strong);
@@ -106,6 +115,7 @@
 	--color-text-hover: var(--rvt-color-theme-text-strong);
 }
 
+rvt-button[type="cta"] > :is(a, button),
 .rvt-button--cta {
 	--color-background-hover: var(--rvt-color-theme-background-strong);
 	--color-border: var(--rvt-color-theme-accent);
@@ -166,11 +176,15 @@
 	width: 100%;
 }
 
+rvt-button-group,
 .rvt-button-group {
 	display: flex;
 	gap: var(--rvt-spacing-sm);
 	flex-wrap: wrap;
 
+	&:has(
+		rvt-button:is([size="medium"], [size="md"], [size="small"], [size="sm"])
+	),
 	&:has(.rvt-button--medium, .rvt-button--small) {
 		gap: var(--rvt-spacing-xs);
 	}

--- a/src/sass/utilities/_display.scss
+++ b/src/sass/utilities/_display.scss
@@ -7,6 +7,7 @@
  * screenreaders: h5bp.com/v
  */
 
+rvt-sr-only,
 .#{$prefix}-sr-only {
 	border: 0;
 	clip: rect(0 0 0 0);
@@ -26,6 +27,7 @@
  * keyboard: h5bp.com/p
  */
 
+rvt-sr-only[tabindex]:is(:active, :focus),
 .#{$prefix}-sr-only.#{$prefix}-focusable:active,
 .#{$prefix}-sr-only.#{$prefix}-focusable:focus {
 	clip: auto;

--- a/src/sass/utilities/_spacing.scss
+++ b/src/sass/utilities/_spacing.scss
@@ -245,3 +245,26 @@ $spacing-sizes: (
 }
 
 /* stylelint-enable */
+
+/* Attribute utilities */
+[rvt-margin~="md"] {
+	margin: var(--rvt-spacing-md);
+}
+[rvt-margin~="b:md"] {
+	margin-block: var(--rvt-spacing-md);
+}
+[rvt-margin~="b-s:md"] {
+	margin-block-start: var(--rvt-spacing-md);
+}
+[rvt-margin~="b-e:md"] {
+	margin-block-end: var(--rvt-spacing-md);
+}
+[rvt-margin~="i:md"] {
+	margin-inline: var(--rvt-spacing-md);
+}
+[rvt-margin~="i-s:md"] {
+	margin-inline-start: var(--rvt-spacing-md);
+}
+[rvt-margin~="i-e:md"] {
+	margin-inline-end: var(--rvt-spacing-md);
+}


### PR DESCRIPTION
Change:
1. Add custom elements: `<rvt-button>`, `<rvt-button-group>`, `<rvt-badge>`
2. Add custom attribute: `rvt-margin` (medium spacing only so far)

Note:
1. This work is not meant to be comprehensive but rather as a discussion point. I want to also use it to illustrate our explorations for the upcoming Dev CoP meeting.
2. If this is not the direction we go, we can also remove it before 3.0.0 is officially released.
3. If we generally think this is worthy of continuing, I can try to make custom element equivalents for all the components we're working on, in parallel with the traditional BEM convention.
4. Best practice is to isolate all custom attributes under `data-`, but `data-rvt-margin` seems excessively long. I think our `rvt-` namespace is sufficient.
5. Custom attributes on custom elements do not need a namespace, as the element is already namespaced.
6. Because "style" is a reserved attribute name, I categorized strong/normal/subtle as "tone". In terms of "voice and tone" usage: Voice is what is said (the text content). Tone is how it is said (the visual/auditory expression and emphasis).
7. I was unsure about how I'd like nesting `<button>` in a `<rvt-button>` — but I like the style. It promotes composition over inheritance and isolates concerns.
8. Migrating away from BEM-style modifier classes to attributes will make make it easier to document exactly what each custom element offers. "'Medium' is a 'size' option. 'Strong' is a 'tone' option."
9. See article: [*This website has no class*](https://aaadaaam.com/notes/no-class/)
10. See article: [*CSS Classes considered harmful*](https://www.keithcirkel.co.uk/css-classes-considered-harmful/)