### PR TITLE
Export default

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -63,3 +63,16 @@ export {
 	Tabs,
 	init,
 };
+
+export default {
+	Accordion,
+	Alert,
+	Dialog,
+	Disclosure,
+	Dropdown,
+	FileInput,
+	Sidenav,
+	Switch,
+	Tabs,
+	init,
+};

--- a/src/sandbox/rivet.js
+++ b/src/sandbox/rivet.js
@@ -1,4 +1,4 @@
 import "../sass/rivet.scss";
-import { init } from "../js/index.js";
+import Rivet from "../js/index.js";
 
-init();
+Rivet.init();


### PR DESCRIPTION
This makes it so you can use both of these syntaxes:

```js
// Option 1 (current)
import { init } from "rivet.js";
init();

// Option 2 (new)
import Rivet from "rivet.js";
Rivet.init();
```

Future work:
1. Test tree shaking. I suspect tree shaking won't work because the root file imports all component modules for `init()`.