### PR TITLE
Refine color

### DIFF
--- a/src/sandbox/components/alert/variants/default.njk
+++ b/src/sandbox/components/alert/variants/default.njk
@@ -15,9 +15,7 @@ order: 1
 		aria-labelledby="information-alert-title"
 		data-rvt-alert="info"
 	>
-		<div class="rvt-alert__title" id="information-alert-title">
-			Please note
-		</div>
+		<div class="rvt-alert__title" id="information-alert-title">Please note</div>
 		<div class="rvt-alert__content">
 			<p>
 				Use the default alert to <a href="#">add inline notes</a> to text

--- a/src/sandbox/components/alert/variants/default.njk
+++ b/src/sandbox/components/alert/variants/default.njk
@@ -15,15 +15,9 @@ order: 1
 		aria-labelledby="information-alert-title"
 		data-rvt-alert="info"
 	>
-		{#
 		<div class="rvt-alert__title" id="information-alert-title">
-			Scheduled System Maintenance
+			Please note
 		</div>
-		#} {#
-		<p class="rvt-alert__message">
-			Use the default alert to add inline notes to text content.
-		</p>
-		#}
 		<div class="rvt-alert__content">
 			<p>
 				Use the default alert to <a href="#">add inline notes</a> to text

--- a/src/sandbox/components/alert/variants/default.njk
+++ b/src/sandbox/components/alert/variants/default.njk
@@ -29,17 +29,14 @@ order: 1
 				Use the default alert to <a href="#">add inline notes</a> to text
 				content.
 			</p>
-			<div class="rvt-flex rvt-gap-sm rvt-m-top-sm">
+			<div class="rvt-button-group">
 				<button
 					class="rvt-button rvt-button--medium rvt-button--strong"
 					type="button"
 				>
 					Okay
 				</button>
-				<button
-					class="rvt-button rvt-button--medium rvt-button--secondary"
-					type="button"
-				>
+				<button class="rvt-button rvt-button--medium" type="button">
 					Dismiss
 				</button>
 			</div>
@@ -72,17 +69,14 @@ order: 1
 				</li>
 				<li>Architecto obcaecati vero!</li>
 			</ul>
-			<div class="rvt-flex rvt-gap-sm rvt-m-top-sm">
+			<div class="rvt-button-group">
 				<button
 					class="rvt-button rvt-button--medium rvt-button--strong"
 					type="button"
 				>
 					Okay
 				</button>
-				<button
-					class="rvt-button rvt-button--medium rvt-button--secondary"
-					type="button"
-				>
+				<button class="rvt-button rvt-button--medium" type="button">
 					Dismiss
 				</button>
 			</div>
@@ -105,17 +99,14 @@ order: 1
 				We have <a href="#">received your application</a>. Check your email in a
 				few weeks to find out if you've been admitted.
 			</p>
-			<div class="rvt-flex rvt-gap-sm rvt-m-top-sm">
+			<div class="rvt-button-group">
 				<button
 					class="rvt-button rvt-button--medium rvt-button--strong"
 					type="button"
 				>
 					Okay
 				</button>
-				<button
-					class="rvt-button rvt-button--medium rvt-button--secondary"
-					type="button"
-				>
+				<button class="rvt-button rvt-button--medium" type="button">
 					Dismiss
 				</button>
 			</div>
@@ -138,17 +129,14 @@ order: 1
 				Your changes have <a href="#">not been saved</a>. To save your changes,
 				click 'Save my changes' or click Cancel' to exit without saving.
 			</p>
-			<div class="rvt-flex rvt-gap-sm rvt-m-top-sm">
+			<div class="rvt-button-group">
 				<button
 					class="rvt-button rvt-button--medium rvt-button--strong"
 					type="button"
 				>
 					Okay
 				</button>
-				<button
-					class="rvt-button rvt-button--medium rvt-button--secondary"
-					type="button"
-				>
+				<button class="rvt-button rvt-button--medium" type="button">
 					Dismiss
 				</button>
 			</div>
@@ -173,17 +161,14 @@ order: 1
 				The user ID and password you entered do not match. Please
 				<a href="#">check your entries</a> and try again.
 			</p>
-			<div class="rvt-flex rvt-gap-sm rvt-m-top-sm">
+			<div class="rvt-button-group">
 				<button
 					class="rvt-button rvt-button--medium rvt-button--strong"
 					type="button"
 				>
 					Okay
 				</button>
-				<button
-					class="rvt-button rvt-button--medium rvt-button--secondary"
-					type="button"
-				>
+				<button class="rvt-button rvt-button--medium" type="button">
 					Dismiss
 				</button>
 			</div>

--- a/src/sandbox/components/alert/variants/inline.njk
+++ b/src/sandbox/components/alert/variants/inline.njk
@@ -9,7 +9,7 @@ order: 2
 
 <!-- Default -->
 <div
-	class="rvt-alert rvt-alert--info"
+	class="rvt-alert rvt-alert--medium rvt-alert--info"
 	role="alert"
 	aria-labelledby="information-alert-title"
 	data-rvt-alert="info"
@@ -22,7 +22,7 @@ order: 2
 
 <!-- Success -->
 <div
-	class="rvt-alert rvt-alert--success [ rvt-m-top-md ]"
+	class="rvt-alert rvt-alert--medium rvt-alert--success [ rvt-m-top-md ]"
 	role="alert"
 	aria-labelledby="success-alert-title"
 	data-rvt-alert="success"
@@ -35,7 +35,7 @@ order: 2
 
 <!-- Warning -->
 <div
-	class="rvt-alert rvt-alert--warning [ rvt-m-top-md ]"
+	class="rvt-alert rvt-alert--medium rvt-alert--warning [ rvt-m-top-md ]"
 	role="alert"
 	aria-labelledby="warning-alert-title"
 	data-rvt-alert="warning"
@@ -48,7 +48,7 @@ order: 2
 
 <!-- Error -->
 <div
-	class="rvt-alert rvt-alert--danger [ rvt-m-top-md ]"
+	class="rvt-alert rvt-alert--medium rvt-alert--danger [ rvt-m-top-md ]"
 	role="alert"
 	aria-labelledby="error-alert-title"
 	data-rvt-alert="error"

--- a/src/sandbox/components/callout/variants/default.njk
+++ b/src/sandbox/components/callout/variants/default.njk
@@ -23,12 +23,8 @@ order: 1
 				</p>
 			</div>
 			<div class="rvt-callout__actions">
-				<a href="/#" class="rvt-button rvt-button--cta"
-					>{ Lorem ipsum }</a
-				>
-				<a href="/#" class="rvt-button rvt-button--cta"
-					>{ Lorem ipsum }</a
-				>
+				<a href="/#" class="rvt-button rvt-button--cta">{ Lorem ipsum }</a>
+				<a href="/#" class="rvt-button rvt-button--cta">{ Lorem ipsum }</a>
 			</div>
 		</div>
 	</div>
@@ -51,12 +47,8 @@ order: 1
 				</p>
 			</div>
 			<div class="rvt-callout__actions">
-				<a href="/#" class="rvt-button rvt-button--cta"
-					>{ Lorem ipsum }</a
-				>
-				<a href="/#" class="rvt-button rvt-button--cta"
-					>{ Lorem ipsum }</a
-				>
+				<a href="/#" class="rvt-button rvt-button--cta">{ Lorem ipsum }</a>
+				<a href="/#" class="rvt-button rvt-button--cta">{ Lorem ipsum }</a>
 			</div>
 		</div>
 	</div>

--- a/src/sandbox/components/callout/variants/default.njk
+++ b/src/sandbox/components/callout/variants/default.njk
@@ -23,10 +23,10 @@ order: 1
 				</p>
 			</div>
 			<div class="rvt-callout__actions">
-				<a href="/#" class="rvt-button rvt-button--cta rvt-button--cta"
+				<a href="/#" class="rvt-button rvt-button--cta"
 					>{ Lorem ipsum }</a
 				>
-				<a href="/#" class="rvt-button rvt-button--cta rvt-button--cta"
+				<a href="/#" class="rvt-button rvt-button--cta"
 					>{ Lorem ipsum }</a
 				>
 			</div>
@@ -34,7 +34,7 @@ order: 1
 	</div>
 </div>
 
-<div class="rvt-callout rvt-callout--alt rvt-m-top-sm">
+<div class="rvt-callout rvt-callout--strong rvt-m-top-sm">
 	<div class="rvt-callout__inner">
 		<rvt-sticker name="cap" theme="crimson" size="sm"></rvt-sticker>
 		<div class="rvt-callout__body">
@@ -51,10 +51,10 @@ order: 1
 				</p>
 			</div>
 			<div class="rvt-callout__actions">
-				<a href="/#" class="rvt-button rvt-button--cta rvt-button--cta"
+				<a href="/#" class="rvt-button rvt-button--cta"
 					>{ Lorem ipsum }</a
 				>
-				<a href="/#" class="rvt-button rvt-button--cta rvt-button--cta"
+				<a href="/#" class="rvt-button rvt-button--cta"
 					>{ Lorem ipsum }</a
 				>
 			</div>

--- a/src/sandbox/components/empty-state/variants/empty-state-actions-icon.njk
+++ b/src/sandbox/components/empty-state/variants/empty-state-actions-icon.njk
@@ -22,7 +22,9 @@ order: 3
 		<p>There's nothing here yet.</p>
 	</div>
 	<div class="rvt-empty-state__actions">
-		<button class="rvt-button rvt-button--strong" type="button">Create your first item</button>
+		<button class="rvt-button rvt-button--strong" type="button">
+			Create your first item
+		</button>
 		<a href="#" class="rvt-button rvt-button--cta rvt-button--subtle"
 			>Read the documentation</a
 		>

--- a/src/sandbox/components/empty-state/variants/empty-state-actions-icon.njk
+++ b/src/sandbox/components/empty-state/variants/empty-state-actions-icon.njk
@@ -22,7 +22,7 @@ order: 3
 		<p>There's nothing here yet.</p>
 	</div>
 	<div class="rvt-empty-state__actions">
-		<button class="rvt-button" type="button">Create your first item</button>
+		<button class="rvt-button rvt-button--strong" type="button">Create your first item</button>
 		<a href="#" class="rvt-button rvt-button--cta rvt-button--subtle"
 			>Read the documentation</a
 		>

--- a/src/sandbox/components/empty-state/variants/empty-state-actions.njk
+++ b/src/sandbox/components/empty-state/variants/empty-state-actions.njk
@@ -12,9 +12,9 @@ order: 2
 		<p>There's nothing here yet.</p>
 	</div>
 	<div class="rvt-empty-state__actions">
-		<button class="rvt-button rvt-button--strong" type="button">Create your first item</button>
-		<a href="#" class="rvt-button rvt-button--cta">
-			Read the documentation
-		</a>
+		<button class="rvt-button rvt-button--strong" type="button">
+			Create your first item
+		</button>
+		<a href="#" class="rvt-button rvt-button--cta"> Read the documentation </a>
 	</div>
 </div>

--- a/src/sandbox/components/empty-state/variants/empty-state-actions.njk
+++ b/src/sandbox/components/empty-state/variants/empty-state-actions.njk
@@ -12,9 +12,9 @@ order: 2
 		<p>There's nothing here yet.</p>
 	</div>
 	<div class="rvt-empty-state__actions">
-		<button class="rvt-button" type="button">Create your first item</button>
-		<a href="#" class="rvt-button rvt-button--cta rvt-button--subtle"
-			>Read the documentation</a
-		>
+		<button class="rvt-button rvt-button--strong" type="button">Create your first item</button>
+		<a href="#" class="rvt-button rvt-button--cta">
+			Read the documentation
+		</a>
 	</div>
 </div>

--- a/src/sandbox/components/list-hub/variants/default.njk
+++ b/src/sandbox/components/list-hub/variants/default.njk
@@ -29,7 +29,7 @@ order: 1
 					<li>Session four</li>
 					<li>Session five</li>
 				</ul>
-				<span class="rvt-badge">Test badge</span>
+				<strong class="rvt-badge">Test badge</strong>
 			</div>
 		</li>
 		<li class="rvt-list-hub__item">

--- a/src/sandbox/components/pagination/variants/default.njk
+++ b/src/sandbox/components/pagination/variants/default.njk
@@ -7,7 +7,7 @@ padding: true
 order: 1
 ---
 
-<nav role="navigation" aria-label="More pages of items">
+<nav role="navigation" aria-label="Pages">
 	<ul class="rvt-pagination">
 		<li class="rvt-pagination__item">
 			<a href="#0">
@@ -21,11 +21,12 @@ order: 1
 					<path d="M.586 8 7 14.414 8.414 13l-5-5 5-5L7 1.586.586 8Z" />
 					<path d="M6.586 8 13 14.414 14.414 13l-5-5 5-5L13 1.586 6.586 8Z" />
 				</svg>
-				<span>First</span>
+				First
+				<span class="rvt-sr-only">page</span>
 			</a>
 		</li>
 		<li class="rvt-pagination__item">
-			<a href="#" aria-label="Go to previous page">
+			<a href="#">
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					width="16"
@@ -37,25 +38,28 @@ order: 1
 						d="M9.737.854 3.69 8l6.047 7.146 1.526-1.292L6.31 8l4.953-5.854L9.737.854Z"
 					/>
 				</svg>
+				<span class="rvt-sr-only">Previous page</span>
 			</a>
 		</li>
 		<li class="rvt-pagination__item">
-			<span>6</span>
+			<a href="#0"><span class="rvt-sr-only">Page</span> 6</a>
 		</li>
 		<li class="rvt-pagination__item">
-			<a href="#0" aria-label="Page 7">7</a>
+			<a href="#0"><span class="rvt-sr-only">Page</span> 7</a>
 		</li>
 		<li class="rvt-pagination__item">
-			<a href="#0" aria-label="Page 8" aria-current="page">8</a>
+			<a href="#0" aria-current="page">
+				<span class="rvt-sr-only">Page</span> 8
+			</a>
 		</li>
 		<li class="rvt-pagination__item">
-			<a href="#0" aria-label="Page 9">9</a>
+			<a href="#0"><span class="rvt-sr-only">Page</span> 9</a>
 		</li>
 		<li class="rvt-pagination__item">
-			<a href="#0" aria-label="Page 10">10</a>
+			<a href="#0"><span class="rvt-sr-only">Page</span> 10</a>
 		</li>
 		<li class="rvt-pagination__item">
-			<a href="#0" aria-label="Go to next page">
+			<a href="#0">
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					width="16"
@@ -67,11 +71,13 @@ order: 1
 						d="M6.263 15.146 12.31 8 6.263.854 4.737 2.146 9.69 8l-4.953 5.854 1.526 1.292Z"
 					/>
 				</svg>
+				<span class="rvt-sr-only">Next page</span>
 			</a>
 		</li>
 		<li class="rvt-pagination__item">
 			<a href="#0">
-				<span>Last</span>
+				Last
+				<span class="rvt-sr-only">page</span>
 				<svg
 					xmlns="http://www.w3.org/2000/svg"
 					width="16"

--- a/src/sandbox/components/table/variants/default.njk
+++ b/src/sandbox/components/table/variants/default.njk
@@ -46,7 +46,7 @@ order: 1
 		</tbody>
 	</table>
 
-	<table class="rvt-table rvt-table-feature rvt-table-cells">
+	<table class="rvt-table rvt-table--subtle rvt-table-cells">
 		<caption class="rvt-sr-only">
 			Default table
 		</caption>

--- a/src/sandbox/components/timeline/variants/centered-timeline.njk
+++ b/src/sandbox/components/timeline/variants/centered-timeline.njk
@@ -38,7 +38,8 @@ order: 3
 						{% endfor %}
 					</dl>
 				</div>
-				<div class="rvt-timeline__item-actions">
+				<div class="rvt-timeline__item-actions rvt-button-group">
+					<a href="/google" class="rvt-button rvt-button--cta">Apply now</a>
 					<a href="/google" class="rvt-button rvt-button--cta">Apply now</a>
 				</div>
 			</div>

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -19,7 +19,9 @@
 	--size-padding: var(--rvt-spacing-sm);
 	background-color: var(--color-background);
 	border: calc(1rem / 16) solid var(--color-border);
-	padding-inline-start: calc(var(--size-padding) + var(--size-icon) + var(--size-gap));
+	padding-inline-start: calc(
+		var(--size-padding) + var(--size-icon) + var(--size-gap)
+	);
 	padding-inline-end: var(--size-padding);
 	padding-block: var(--size-padding);
 	position: relative;
@@ -151,7 +153,13 @@
 
 	&__dismiss {
 		--coordinate: calc(var(--size-padding) + var(--size-offset));
-		--size-offset: calc((var(--size-icon) - var(--size-icon-shape) - var(--size-icon-padding) * 2) / 2);
+		--size-offset: calc(
+			(
+					var(--size-icon) - var(--size-icon-shape) - var(--size-icon-padding) *
+						2
+				) /
+				2
+		);
 		--size-icon-shape: var(--rvt-spacing-sm);
 		--size-icon-padding: var(--rvt-spacing-xxs);
 		background-color: transparent;

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -7,76 +7,89 @@
 
 .#{$prefix}-alert {
 	@extend .rvt-theme-light;
+	--color-background: var(--rvt-color-base-extralight);
+	--color-border: var(--rvt-color-base-medium);
+	--color-container: var(--rvt-color-base-light);
+	--color-icon: var(--rvt-color-base-ultralight);
+	--color-icon-background: var(--rvt-color-base-main);
+	--color-main: var(--rvt-color-base-main);
+	--icon: var(--rvt-icon-bell);
+	--size-gap: var(--rvt-spacing-xs);
+	--size-icon: var(--rvt-spacing-lg);
+	--size-padding: var(--rvt-spacing-sm);
 	background-color: var(--color-background);
-	border: $spacing-xxs * 0.25 solid var(--color-border);
-	padding-inline-start: $spacing-xxl * 0.9;
-	padding-inline-end: $spacing-sm;
-	padding-block: $spacing-sm;
+	border: calc(1rem / 16) solid var(--color-border);
+	padding-inline-start: calc(var(--size-padding) + var(--size-icon) + var(--size-gap));
+	padding-inline-end: var(--size-padding);
+	padding-block: var(--size-padding);
 	position: relative;
-
-	&,
-	&--default {
-		--color-background: var(--rvt-color-base-extralight);
-		--color-border: var(--rvt-color-base-medium);
-		--color-container: var(--rvt-color-base-light);
-		--color-main: var(--rvt-color-base-main);
-		--icon: var(--rvt-icon-bell);
-	}
 
 	&--danger {
 		--color-background: var(--rvt-color-danger-background);
 		--color-border: var(--rvt-color-danger-border);
 		--color-container: var(--rvt-color-danger-container);
+		--color-icon: var(--rvt-color-base-ultralight);
+		--color-icon-background: var(--rvt-color-danger-main);
 		--color-main: var(--rvt-color-danger-main);
-		--icon: var(--rvt-icon-exclamation-mark-circle);
+		--icon: var(--rvt-icon-exclamation);
 	}
 
 	&--info {
 		--color-background: var(--rvt-color-info-background);
 		--color-border: var(--rvt-color-info-border);
 		--color-container: var(--rvt-color-info-container);
+		--color-icon: var(--rvt-color-base-ultralight);
+		--color-icon-background: var(--rvt-color-info-main);
 		--color-main: var(--rvt-color-info-main);
-		--icon: var(--rvt-icon-info-circle);
+		--icon: var(--rvt-icon-info);
 	}
 
 	&--success {
 		--color-background: var(--rvt-color-success-background);
 		--color-border: var(--rvt-color-success-border);
 		--color-container: var(--rvt-color-success-container);
+		--color-icon: var(--rvt-color-base-ultralight);
+		--color-icon-background: var(--rvt-color-success-main);
 		--color-main: var(--rvt-color-success-main);
-		--icon: var(--rvt-icon-check-circle);
+		--icon: var(--rvt-icon-check);
 	}
 
 	&--warning {
 		--color-background: var(--rvt-color-warning-background);
 		--color-border: var(--rvt-color-warning-border);
 		--color-container: var(--rvt-color-warning-container);
+		--color-icon: var(--rvt-color-base-main);
+		--color-icon-background: var(--rvt-color-warning-main);
 		--color-main: var(--rvt-color-base-main);
-		--icon: var(--rvt-icon-minus-circle);
+		--icon: var(--rvt-icon-minus);
 	}
 
 	&::before {
-		background-color: var(--color-container);
+		background-color: var(--color-icon-background);
 		border-radius: $border-radius-circle;
 		content: "";
 		display: block;
-		height: $spacing-lg;
-		left: calc(14rem / 16);
+		height: var(--size-icon);
+		left: var(--size-padding);
 		position: absolute;
-		top: calc(12rem / 16);
-		width: $spacing-lg;
+		left: var(--size-padding);
+		width: var(--size-icon);
 	}
 
 	&::after {
-		background-color: var(--color-main);
+		--coordinate: calc(var(--size-padding) + var(--size-icon-padding-side));
+		--size-icon-shape: var(--rvt-spacing-sm);
+		--size-icon-padding-total: calc(var(--size-icon) - var(--size-icon-shape));
+		--size-icon-padding-side: calc(var(--size-icon-padding-total) / 2);
+		background-color: var(--color-icon);
 		display: block;
 		clip-path: path(var(--icon));
 		content: "";
-		height: $spacing-sm;
-		left: calc(22rem / 16);
+		height: var(--size-icon-shape);
+		left: var(--coordinate);
 		position: absolute;
-		top: calc(20rem / 16);
-		width: $spacing-sm;
+		top: var(--coordinate);
+		width: var(--size-icon-shape);
 	}
 
 	&__title {
@@ -86,8 +99,9 @@
 		font-variation-settings:
 			"wdth" 135,
 			"YTLC" 540;
-		line-height: 1.3;
-		padding-inline-end: $spacing-md;
+		line-height: var(--rvt-line-height-title);
+		padding-block-start: calc(calc(var(--size-icon) - 1lh) / 2);
+		padding-inline-end: $spacing-xl;
 		position: relative;
 	}
 
@@ -136,30 +150,40 @@
 	}
 
 	&__dismiss {
+		--coordinate: calc(var(--size-padding) + var(--size-offset));
+		--size-offset: calc((var(--size-icon) - var(--size-icon-shape) - var(--size-icon-padding) * 2) / 2);
+		--size-icon-shape: var(--rvt-spacing-sm);
+		--size-icon-padding: var(--rvt-spacing-xxs);
 		background-color: transparent;
 		border: none;
 		border-radius: 50%;
 		color: var(--rvt-color-theme-text-strong);
 		cursor: pointer;
 		display: block;
-		padding: $spacing-xxs;
+		padding: var(--size-icon-padding);
 		position: absolute;
-		right: $spacing-sm;
-		top: $spacing-sm;
+		right: var(--coordinate);
+		top: var(--coordinate);
 
 		&::before {
 			background-color: var(--color-main);
 			content: "";
 			clip-path: path(var(--rvt-icon-close));
 			display: block;
-			height: $spacing-sm;
-			width: $spacing-sm;
+			height: var(--size-icon-shape);
+			width: var(--size-icon-shape);
 		}
 
 		&:hover::before {
 			background-color: var(--rvt-color-base-dark);
 		}
 	}
+}
+
+.rvt-alert--medium {
+	--size-icon: var(--rvt-spacing-md);
+	--size-gap: var(--rvt-spacing-xs);
+	--size-padding: var(--rvt-spacing-xxs);
 }
 
 /**

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -241,7 +241,8 @@
 	input[type="week"]:focus,
 	textarea,
 	select {
-		box-shadow: 0 0 0 calc(var(--rvt-spacing-xxs) / 2) var(--rvt-color-danger-border);
+		box-shadow: 0 0 0 calc(var(--rvt-spacing-xxs) / 2)
+			var(--rvt-color-danger-border);
 		border-color: var(--rvt-color-danger-border);
 	}
 }

--- a/src/sass/avatar/_base.scss
+++ b/src/sass/avatar/_base.scss
@@ -28,9 +28,9 @@ $avatar-widths: (
 	--size-xl: calc(var(--rvt-spacing-lg) * 5);
 	--size: var(--size-rg);
 	align-items: center;
-	background-color: var(--rvt-color-theme-accent);
+	background-color: var(--rvt-color-brand-light);
 	border-radius: 999rem;
-	color: var(--rvt-color-theme-text-inverse);
+	color: var(--rvt-color-brand-main);
 	display: flex;
 	flex-shrink: 0;
 	font-size: $ts-20;

--- a/src/sass/billboard/_base.scss
+++ b/src/sass/billboard/_base.scss
@@ -1,12 +1,8 @@
 @use "../core" as *;
 
 .#{$prefix}-billboard {
-	background-color: var(--rvt-color-theme-background-strong);
+	background-color: var(--rvt-color-theme-background-accent);
 	position: relative;
-
-	.#{$prefix}-theme-light & {
-		background-color: var(--rvt-color-theme-accent-inverse);
-	}
 
 	& + & {
 		margin-top: $spacing-lg;

--- a/src/sass/buttons-segmented/_base.scss
+++ b/src/sass/buttons-segmented/_base.scss
@@ -73,16 +73,13 @@
 		border-bottom-right-radius: var(--rvt-spacing-xxs);
 	}
 
-	.dropdown:not(:first-child):not(:last-child)
-		> .rvt-button:only-of-type,
-	.rvt-dropdown:not(:first-child):not(:last-child)
-		> .rvt-button:only-of-type {
+	.dropdown:not(:first-child):not(:last-child) > .rvt-button:only-of-type,
+	.rvt-dropdown:not(:first-child):not(:last-child) > .rvt-button:only-of-type {
 		border-radius: 0;
 		margin-left: -2px;
 	}
 
-	.rvt-dropdown:last-child
-		> .rvt-button:not(.rvt-button--secondary) {
+	.rvt-dropdown:last-child > .rvt-button:not(.rvt-button--secondary) {
 		margin-left: 2px;
 	}
 }

--- a/src/sass/buttons/_base.scss
+++ b/src/sass/buttons/_base.scss
@@ -24,7 +24,6 @@
 	align-items: center;
 	background: var(--color-background);
 	border: var(--size-border) solid var(--color-border);
-	color: var(--color-text);
 	cursor: pointer;
 	display: inline-flex;
 	font-size: var(--size-font);
@@ -36,7 +35,13 @@
 	padding-inline: calc(var(--padding-block) + var(--padding-inline-extra));
 	text-decoration: none;
 
-	&:hover {
+	&,
+	&:is(a:visited) {
+		color: var(--color-text);
+	}
+
+	&:hover,
+	&:is(a:visited:hover) {
 		background-color: var(--color-background-hover);
 		color: var(--color-text-hover);
 	}
@@ -56,14 +61,6 @@
 		--translate-x: 0;
 		cursor: not-allowed;
 		opacity: 0.4;
-	}
-
-	&:is(a:visited) {
-		color: var(--color-text);
-
-		&:hover {
-			color: var(--color-text-hover);
-		}
 	}
 
 	&.rvt-button--icon-only {

--- a/src/sass/buttons/_base.scss
+++ b/src/sass/buttons/_base.scss
@@ -60,6 +60,10 @@
 
 	&:is(a:visited) {
 		color: var(--color-text);
+
+		&:hover {
+			color: var(--color-text-hover);
+		}
 	}
 
 	&.rvt-button--icon-only {
@@ -107,10 +111,10 @@
 }
 
 .rvt-button--cta {
-	--color-background-hover: var(--rvt-color-theme-background-strong);
+	--color-background-hover: var(--rvt-color-theme-background-accent);
 	--color-border: var(--rvt-color-theme-accent);
 	--color-text: var(--rvt-color-theme-accent);
-	--color-text-hover: var(--rvt-color-theme-accent-strong);
+	--color-text-hover: var(--rvt-color-theme-accent);
 	--rotate: 0;
 	--translate-x: var(--rvt-spacing-xxs);
 
@@ -120,10 +124,6 @@
 
 	&[href^="http"] {
 		--rotate: -45deg;
-	}
-
-	:where(.rvt-theme-light) & {
-		--color-background-hover: var(--rvt-color-theme-accent-inverse);
 	}
 
 	&:hover::after {

--- a/src/sass/buttons/_base.scss
+++ b/src/sass/buttons/_base.scss
@@ -3,7 +3,7 @@
 
 .rvt-button {
 	--color-border: var(--rvt-color-theme-text-strong);
-	--color-background: var(--rvt-color-theme-background);
+	--color-background: transparent;
 	--color-background-hover: var(--rvt-color-theme-background-strong);
 	--color-background-pressed: var(--rvt-color-theme-background-strong);
 	--color-text: var(--rvt-color-theme-text-strong);
@@ -13,7 +13,7 @@
 	--padding-block-total: calc(
 		var(--size-height) - var(--size-line-height) - var(--size-border-total)
 	);
-	--padding-inline-extra: 0rem;
+	--padding-inline-extra: var(--rvt-spacing-xs);
 	--size-border: calc(1rem / 16);
 	--size-border-total: calc(var(--size-border) * 2);
 	--size-font: var(--rvt-ts-16);
@@ -58,7 +58,6 @@
 	&:is(a:not([href]), button[aria-disabled="true"], button:disabled) {
 		--color-background-hover: var(--color-background);
 		--color-text-hover: var(--color-text);
-		--translate-x: 0;
 		cursor: not-allowed;
 		opacity: 0.4;
 	}
@@ -73,7 +72,6 @@
 }
 
 .rvt-button--medium {
-	--padding-inline-extra: calc(2rem / 16);
 	--size-font: var(--rvt-ts-14);
 	--size-height: 2rem;
 }
@@ -81,12 +79,11 @@
 .rvt-button--small {
 	--color-border: var(--rvt-color-theme-ui-strong);
 	--gap: var(--rvt-spacing-xxs);
-	--padding-inline-extra: calc(4rem / 16);
 	--size-font: var(--rvt-ts-14);
 	--size-height: 1.5rem;
 	--size-pressed: calc(1rem / 16);
 
-	rvt-icon svg {
+	&:not(.rvt-button--subtle) rvt-icon svg {
 		transform: scale(calc(12 / 16));
 	}
 }
@@ -109,12 +106,11 @@
 }
 
 .rvt-button--cta {
-	--color-background-hover: var(--rvt-color-theme-background-accent);
+	--color-background-hover: var(--rvt-color-theme-background-accent-strong);
 	--color-border: var(--rvt-color-theme-accent);
 	--color-text: var(--rvt-color-theme-accent);
 	--color-text-hover: var(--rvt-color-theme-accent);
 	--rotate: 0;
-	--translate-x: var(--rvt-spacing-xxs);
 
 	&[href*="#"] {
 		--rotate: 90deg;
@@ -122,10 +118,6 @@
 
 	&[href^="http"] {
 		--rotate: -45deg;
-	}
-
-	&:hover::after {
-		transform: rotate(var(--rotate)) translateX(var(--translate-x));
 	}
 
 	&::after {
@@ -136,12 +128,7 @@
 		flex-shrink: 0;
 		height: var(--rvt-spacing-sm);
 		transform: rotate(var(--rotate));
-		transition: all 0.2s ease;
 		width: var(--rvt-spacing-sm);
-	}
-
-	&:is(.rvt-button--medium, .rvt-button--small) {
-		--translate-x: calc(2rem / 16);
 	}
 
 	&.rvt-button--strong {

--- a/src/sass/buttons/_base.scss
+++ b/src/sass/buttons/_base.scss
@@ -79,6 +79,7 @@
 }
 
 .rvt-button--small {
+	--color-border: var(--rvt-color-theme-ui-strong);
 	--gap: var(--rvt-spacing-xxs);
 	--padding-inline-extra: calc(4rem / 16);
 	--size-font: var(--rvt-ts-14);

--- a/src/sass/callout/_base.scss
+++ b/src/sass/callout/_base.scss
@@ -2,19 +2,21 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 @use "../core" as *;
+@use "../defaults" as *;
 
 // Temp Callout component
 .#{$prefix}-callout {
-	border: 1px solid var(--rvt-color-theme-accent-inverse);
-	background-color: var(--rvt-color-theme-accent-inverse);
-	color: var(--rvt-color-theme-text-accent);
+	border: 1px solid var(--rvt-color-theme-ui);
+	background-color: var(--rvt-color-theme-background);
+	color: var(--rvt-color-theme-text);
 	container-name: callout;
 	container-type: inline-size;
 
-	&--alt {
-		background-color: var(--rvt-color-theme-background);
-		border-color: var(--rvt-color-theme-ui);
-		color: var(--rvt-color-theme-text);
+	&--strong {
+		@extend .rvt-theme-light;
+		background-color: var(--rvt-color-theme-background-accent);
+		border-color: transparent;
+		color: var(--rvt-color-theme-text-accent);
 	}
 
 	&__inner {

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:math";
 
-.#{$prefix}-checkbox {
+.rvt-checkbox {
 	display: inline-block;
 	padding-left: $spacing-lg;
 	position: relative;
@@ -39,7 +39,7 @@
 		--color-background: var(--rvt-color-theme-background);
 		--color-background-accent: var(--rvt-color-theme-accent);
 		--color-border: var(--rvt-color-theme-text-strong);
-		--color-icon: var(--rvt-color-theme-text-inverse);
+		--color-icon: var(--rvt-color-theme-background);
 		--display-icon: none;
 		cursor: pointer;
 		display: inline-block;
@@ -82,14 +82,11 @@
 	}
 
 	input[type="checkbox"]:disabled ~ label {
-		--color-background: var(--rvt-color-theme-background-strong);
-		--color-border: var(--rvt-color-theme-ui-strong);
 		cursor: not-allowed;
-	}
 
-	input[type="checkbox"]:disabled:checked ~ label {
-		--color-background: var(--rvt-color-theme-ui-strong);
-		--color-icon: var(--rvt-color-theme-background);
+		&::before {
+			opacity: 0.4;
+		}
 	}
 
 	input[type="checkbox"]:focus ~ label::before {

--- a/src/sass/defaults/_themes.scss
+++ b/src/sass/defaults/_themes.scss
@@ -7,6 +7,7 @@
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-dark);
 	--rvt-color-theme-background: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-background-accent: var(--rvt-color-brand-extralight);
+	--rvt-color-theme-background-accent-strong: var(--rvt-color-brand-light);
 	--rvt-color-theme-background-strong: var(--rvt-color-base-extralight);
 	--rvt-color-theme-background-inverse: var(--rvt-color-base-main);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultradark);
@@ -24,6 +25,7 @@
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-light);
 	--rvt-color-theme-background: var(--rvt-color-base-main);
 	--rvt-color-theme-background-accent: var(--rvt-color-base-dark);
+	--rvt-color-theme-background-accent-strong: var(--rvt-color-base-ultradark);
 	--rvt-color-theme-background-strong: var(--rvt-color-base-dark);
 	--rvt-color-theme-background-inverse: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultralight);
@@ -41,6 +43,7 @@
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-light);
 	--rvt-color-theme-background: var(--rvt-color-brand-main);
 	--rvt-color-theme-background-accent: var(--rvt-color-brand-dark);
+	--rvt-color-theme-background-accent-strong: var(--rvt-color-brand-extradark);
 	--rvt-color-theme-background-strong: var(--rvt-color-brand-dark);
 	--rvt-color-theme-background-inverse: var(--rvt-color-brand-extralight);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultralight);

--- a/src/sass/defaults/_themes.scss
+++ b/src/sass/defaults/_themes.scss
@@ -7,7 +7,6 @@
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-dark);
 	--rvt-color-theme-background: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-background-accent: var(--rvt-color-brand-extralight);
-	--rvt-color-theme-background-accent-strong: var(--rvt-color-brand-main);
 	--rvt-color-theme-background-strong: var(--rvt-color-base-extralight);
 	--rvt-color-theme-background-inverse: var(--rvt-color-base-main);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultradark);
@@ -25,7 +24,6 @@
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-light);
 	--rvt-color-theme-background: var(--rvt-color-base-main);
 	--rvt-color-theme-background-accent: var(--rvt-color-base-dark);
-	--rvt-color-theme-background-accent-strong: var(--rvt-color-base-ultradark);
 	--rvt-color-theme-background-strong: var(--rvt-color-base-dark);
 	--rvt-color-theme-background-inverse: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultralight);
@@ -43,7 +41,6 @@
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-light);
 	--rvt-color-theme-background: var(--rvt-color-brand-main);
 	--rvt-color-theme-background-accent: var(--rvt-color-brand-dark);
-	--rvt-color-theme-background-accent-strong: var(--rvt-color-brand-dark);
 	--rvt-color-theme-background-strong: var(--rvt-color-brand-dark);
 	--rvt-color-theme-background-inverse: var(--rvt-color-brand-extralight);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultralight);

--- a/src/sass/defaults/_themes.scss
+++ b/src/sass/defaults/_themes.scss
@@ -1,14 +1,12 @@
 // Copyright (C) 2024 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 :root,
-.#{$prefix}-theme-light {
+.rvt-theme-light {
 	--rvt-color-theme-accent: var(--rvt-color-brand-main);
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-dark);
-	--rvt-color-theme-accent-inverse: var(--rvt-color-brand-extralight);
 	--rvt-color-theme-background: var(--rvt-color-base-ultralight);
+	--rvt-color-theme-background-accent: var(--rvt-color-brand-extralight);
 	--rvt-color-theme-background-strong: var(--rvt-color-base-extralight);
 	--rvt-color-theme-background-inverse: var(--rvt-color-base-main);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultradark);
@@ -16,15 +14,16 @@
 	--rvt-color-theme-ui-strong: var(--rvt-color-base-medium);
 	--rvt-color-theme-text: var(--rvt-color-base-body);
 	--rvt-color-theme-text-accent: var(--rvt-color-brand-main);
+	--rvt-color-theme-text-accent-inverse: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-text-strong: var(--rvt-color-base-main);
 	--rvt-color-theme-text-inverse: var(--rvt-color-base-ultralight);
 }
 
-.#{$prefix}-theme-dark {
+.rvt-theme-dark {
 	--rvt-color-theme-accent: var(--rvt-color-brand-extralight);
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-light);
-	--rvt-color-theme-accent-inverse: var(--rvt-color-brand-main);
 	--rvt-color-theme-background: var(--rvt-color-base-main);
+	--rvt-color-theme-background-accent: var(--rvt-color-base-dark);
 	--rvt-color-theme-background-strong: var(--rvt-color-base-dark);
 	--rvt-color-theme-background-inverse: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultralight);
@@ -32,15 +31,16 @@
 	--rvt-color-theme-ui-strong: var(--rvt-color-base-ultradark);
 	--rvt-color-theme-text: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-text-accent: var(--rvt-color-base-ultralight);
+	--rvt-color-theme-text-accent-inverse: var(--rvt-color-brand-main);
 	--rvt-color-theme-text-strong: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-text-inverse: var(--rvt-color-base-main);
 }
 
-.#{$prefix}-theme-crimson {
+.rvt-theme-crimson {
 	--rvt-color-theme-accent: var(--rvt-color-brand-extralight);
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-light);
-	--rvt-color-theme-accent-inverse: var(--rvt-color-brand-main);
 	--rvt-color-theme-background: var(--rvt-color-brand-main);
+	--rvt-color-theme-background-accent: var(--rvt-color-brand-dark);
 	--rvt-color-theme-background-strong: var(--rvt-color-brand-dark);
 	--rvt-color-theme-background-inverse: var(--rvt-color-brand-extralight);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultralight);
@@ -48,13 +48,14 @@
 	--rvt-color-theme-ui-strong: var(--rvt-color-brand-extradark);
 	--rvt-color-theme-text: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-text-accent: var(--rvt-color-base-ultralight);
+	--rvt-color-theme-text-accent-inverse: var(--rvt-color-brand-main);
 	--rvt-color-theme-text-strong: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-text-inverse: var(--rvt-color-base-main);
 }
 
-.#{$prefix}-theme-light,
-.#{$prefix}-theme-dark,
-.#{$prefix}-theme-crimson {
+.rvt-theme-light,
+.rvt-theme-dark,
+.rvt-theme-crimson {
 	background-color: var(--rvt-color-theme-background);
 	color: var(--rvt-color-theme-text);
 }

--- a/src/sass/defaults/_themes.scss
+++ b/src/sass/defaults/_themes.scss
@@ -7,6 +7,7 @@
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-dark);
 	--rvt-color-theme-background: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-background-accent: var(--rvt-color-brand-extralight);
+	--rvt-color-theme-background-accent-strong: var(--rvt-color-brand-main);
 	--rvt-color-theme-background-strong: var(--rvt-color-base-extralight);
 	--rvt-color-theme-background-inverse: var(--rvt-color-base-main);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultradark);
@@ -24,6 +25,7 @@
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-light);
 	--rvt-color-theme-background: var(--rvt-color-base-main);
 	--rvt-color-theme-background-accent: var(--rvt-color-base-dark);
+	--rvt-color-theme-background-accent-strong: var(--rvt-color-base-ultradark);
 	--rvt-color-theme-background-strong: var(--rvt-color-base-dark);
 	--rvt-color-theme-background-inverse: var(--rvt-color-base-ultralight);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultralight);
@@ -41,6 +43,7 @@
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-light);
 	--rvt-color-theme-background: var(--rvt-color-brand-main);
 	--rvt-color-theme-background-accent: var(--rvt-color-brand-dark);
+	--rvt-color-theme-background-accent-strong: var(--rvt-color-brand-dark);
 	--rvt-color-theme-background-strong: var(--rvt-color-brand-dark);
 	--rvt-color-theme-background-inverse: var(--rvt-color-brand-extralight);
 	--rvt-color-theme-background-inverse-strong: var(--rvt-color-base-ultralight);

--- a/src/sass/disclosure/_base.scss
+++ b/src/sass/disclosure/_base.scss
@@ -4,6 +4,9 @@
 @use "../core" as *;
 
 .#{$prefix}-disclosure {
+	background-color: var(--rvt-color-theme-background-strong);
+	padding: var(--rvt-spacing-sm);
+
 	&__toggle {
 		align-items: center;
 		background-color: transparent;
@@ -34,7 +37,6 @@
 	}
 
 	&__content {
-		box-shadow: calc(2rem / 16) 0 0 var(--rvt-color-theme-ui) inset;
 		margin-left: $spacing-xs;
 		margin-top: $spacing-xs;
 		padding-left: $spacing-sm;

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -20,13 +20,10 @@
 		background-color: var(--rvt-color-theme-background);
 		box-shadow: $shadow-standard;
 		min-width: 12.5rem;
-		padding-bottom: $spacing-xs;
-		padding-top: $spacing-xs;
 		position: absolute;
 		// Aligning this right by default so that dropdowns do not
 		// go offscreen when close to the edge of the viewport.
 		right: 0;
-		top: 115%;
 		z-index: map.get($z-index, "1000");
 
 		//In some cases, you may need to align the dropdown menu
@@ -49,27 +46,29 @@
 		button {
 			background-color: transparent;
 			border: none;
+			border-left: 0.25rem solid transparent;
 			display: block;
 			color: var(--rvt-color-theme-text-strong);
-			font-size: $ts-14;
-			/**
-       * This padding-top and bottom value is a magic number.
-       */
-			padding: 0.375rem $spacing-sm;
+			cursor: pointer;
+			font-size: var(--rvt-ts-14);
+			line-height: var(--rvt-ts-base);
+			padding-block: calc(12rem / 16);
+			padding-inline-start: calc(12rem / 16);
+			padding-inline-end: var(--rvt-spacing-sm);
 			text-align: left;
 			text-decoration: none;
 			width: 100%;
 
 			&:hover {
 				background-color: var(--rvt-color-theme-background-strong);
-				color: var(--rvt-color-theme-accent);
+				color: inherit;
 				text-decoration: none;
 			}
 
 			&.#{$prefix}-is-selected,
 			&[aria-current]:not([aria-current="false"]),
 			&[aria-checked="true"] {
-				background-color: var(--rvt-color-theme-background-strong);
+				border-color: var(--rvt-color-theme-accent);
 				color: var(--rvt-color-theme-accent);
 				font-weight: $font-weight-medium;
 

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:map";
 
-.#{$prefix}-dropdown {
+.rvt-dropdown {
 	display: inline-block;
 	position: relative;
 

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -65,6 +65,10 @@
 				text-decoration: none;
 			}
 
+			&:visited {
+				color: inherit;
+			}
+
 			&.#{$prefix}-is-selected,
 			&[aria-current]:not([aria-current="false"]),
 			&[aria-checked="true"] {

--- a/src/sass/empty-state/_base.scss
+++ b/src/sass/empty-state/_base.scss
@@ -2,8 +2,7 @@
 
 .#{$prefix}-empty-state {
 	background-color: var(--rvt-color-theme-background-strong);
-	border: $spacing-xxs dashed var(--rvt-color-theme-ui);
-	border-radius: $spacing-xs;
+	border: calc(2rem / 16) dashed var(--rvt-color-theme-ui);
 	display: flex;
 	flex-direction: column;
 	padding: $spacing-xxl $spacing-md;

--- a/src/sass/footer-system/_footer-base.scss
+++ b/src/sass/footer-system/_footer-base.scss
@@ -13,7 +13,7 @@
 	}
 
 	&__logo {
-		color: var(--rvt-color-theme-accent);
+		color: var(--rvt-color-theme-text-accent);
 		margin: 0 auto;
 	}
 

--- a/src/sass/footer-system/_footer-social.scss
+++ b/src/sass/footer-system/_footer-social.scss
@@ -12,16 +12,15 @@
 	align-items: center;
 	border: 1px solid var(--rvt-color-theme-ui);
 	border-radius: $border-radius-circle;
+	color: var(--rvt-color-theme-text);
 	display: flex;
 	height: $spacing-sm * 2.25;
 	justify-content: center;
 	width: $spacing-sm * 2.25;
 
 	&:hover {
-		background-color: var(--rvt-color-theme-accent);
-		border-color: var(--rvt-color-theme-accent);
-		color: var(--rvt-color-theme-text-inverse);
-		transition: all 0.2s ease;
+		background-color: var(--rvt-color-theme-background-strong);
+		color: inherit;
 	}
 
 	&::before {

--- a/src/sass/header-system/_base.scss
+++ b/src/sass/header-system/_base.scss
@@ -32,7 +32,7 @@
 	&__button {
 		align-items: center;
 		background-color: var(--rvt-color-theme-background-strong);
-		border: 1px solid var(--rvt-color-theme-ui);
+		border: none;
 		border-radius: 999rem;
 		color: var(--rvt-color-theme-text-strong);
 		cursor: pointer;
@@ -107,24 +107,23 @@
 		transition: 0.2s;
 	}
 
-	&-menu__item:hover button,
-	&-menu__item:hover &-menu__link {
-		color: var(--rvt-color-theme-accent);
-	}
-
 	&-menu__link {
 		color: var(--rvt-color-theme-text-strong);
 		font-size: $ts-14;
 		font-weight: $font-weight-medium;
 		padding-block: $spacing-xs;
 		text-decoration: none;
+
+		&:visited {
+			color: inherit;
+		}
 	}
 
 	&-menu__more {
 		> button {
 			align-items: center;
-			background-color: var(--rvt-color-theme-ui);
-			border: 1px solid var(--rvt-color-theme-ui);
+			background-color: var(--rvt-color-theme-background-strong);
+			border: none;
 			border-radius: 999rem;
 			color: var(--rvt-color-theme-text-strong);
 			cursor: pointer;

--- a/src/sass/header-system/_base.scss
+++ b/src/sass/header-system/_base.scss
@@ -226,8 +226,8 @@
 
 	&__tab {
 		align-items: center;
-		background-color: var(--rvt-color-theme-accent);
-		color: var(--rvt-color-theme-background);
+		background-color: var(--rvt-color-theme-text-accent);
+		color: var(--rvt-color-theme-text-accent-inverse);
 		display: flex;
 		height: 52px;
 		justify-content: center;

--- a/src/sass/list-hub/_base.scss
+++ b/src/sass/list-hub/_base.scss
@@ -37,7 +37,7 @@
 
 	&__eyebrow {
 		@include eyebrow;
-		color: var(--rvt-color-theme-accent);
+		color: var(--rvt-color-theme-text-accent);
 		padding-inline-start: $spacing-md;
 	}
 

--- a/src/sass/list-hub/_base.scss
+++ b/src/sass/list-hub/_base.scss
@@ -55,6 +55,10 @@
 		line-height: 1.3;
 		position: relative;
 		text-decoration: none;
+
+		&:visited {
+			color: inherit;
+		}
 	}
 
 	&__link {

--- a/src/sass/lists/_base.scss
+++ b/src/sass/lists/_base.scss
@@ -5,12 +5,12 @@
 
 .rvt-list {
 
-	li {
-		list-style-type: square;
+	li::marker {
+		color: var(--rvt-color-theme-text-accent);
+	}
 
-		&::marker {
-			color: var(--rvt-color-theme-text-accent);
-		}
+	&:is(ul) li {
+		list-style-type: square;
 	}
 }
 

--- a/src/sass/lists/_base.scss
+++ b/src/sass/lists/_base.scss
@@ -3,6 +3,17 @@
 
 @use "../core" as *;
 
+.rvt-list {
+
+	li {
+		list-style-type: square;
+
+		&::marker {
+			color: var(--rvt-color-theme-text-accent);
+		}
+	}
+}
+
 .#{$prefix}-list,
 .#{$prefix}-list-inline,
 .#{$prefix}-list-plain {

--- a/src/sass/lists/_base.scss
+++ b/src/sass/lists/_base.scss
@@ -4,7 +4,6 @@
 @use "../core" as *;
 
 .rvt-list {
-
 	li::marker {
 		color: var(--rvt-color-theme-text-accent);
 	}

--- a/src/sass/pagination/_base.scss
+++ b/src/sass/pagination/_base.scss
@@ -3,9 +3,8 @@
 
 @use "../core" as *;
 @use "sass:map";
-@use "sass:math";
 
-.#{$prefix}-pagination {
+.rvt-pagination {
 	display: flex;
 	gap: $spacing-xs;
 	list-style: none;
@@ -14,14 +13,9 @@
 
 	&__item {
 		align-items: center;
-		border: 1px solid var(--rvt-color-theme-ui);
 		display: flex;
 		justify-content: center;
 		margin-top: 0;
-
-		&:has([aria-current="page"]) {
-			border-color: var(--rvt-color-theme-accent);
-		}
 
 		svg {
 			flex-shrink: 0;
@@ -43,6 +37,7 @@
 		}
 
 		a {
+			border: calc(1rem / 16) solid var(--rvt-color-theme-ui);
 			color: var(--rvt-color-theme-text);
 			display: flex;
 			flex-grow: 1;
@@ -56,20 +51,12 @@
 
 		a:hover {
 			background-color: var(--rvt-color-theme-background-strong);
-			box-shadow: inset 0 ($spacing-xxs * -0.5) 0 var(--rvt-color-theme-accent);
-			color: var(--rvt-color-theme-accent);
-		}
-
-		a:focus,
-		a[aria-current="page"]:focus {
-			border-radius: inherit;
-			z-index: map.get($z-index, "1000");
 		}
 
 		a[aria-current="page"] {
-			background-color: var(--rvt-color-theme-accent);
-			border-color: var(--rvt-color-theme-accent);
-			color: var(--rvt-color-theme-background);
+			background-color: var(--rvt-color-theme-background-accent-strong);
+			border-color: transparent;
+			color: var(--rvt-color-base-ultralight);
 		}
 	}
 }

--- a/src/sass/pagination/_base.scss
+++ b/src/sass/pagination/_base.scss
@@ -54,9 +54,9 @@
 		}
 
 		a[aria-current="page"] {
-			background-color: var(--rvt-color-theme-background-accent-strong);
+			background-color: var(--rvt-color-theme-accent);
 			border-color: transparent;
-			color: var(--rvt-color-base-ultralight);
+			color: var(--rvt-color-theme-background);
 		}
 	}
 }

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -20,7 +20,7 @@
 	}
 
 	&__text {
-		color: var(--rvt-color-theme-accent);
+		color: var(--rvt-color-theme-text-accent);
 		font-family: $font-family-condensed;
 		font-weight: 850;
 		font-variation-settings: "wdth" 140;

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -7,7 +7,7 @@
 	gap: 1rem;
 
 	&::before {
-		background-color: var(--rvt-color-theme-accent);
+		background-color: var(--rvt-color-theme-text-accent);
 		clip-path: path(var(--rvt-icon-quote-open));
 		display: block;
 		content: "";
@@ -39,7 +39,7 @@
 
 	&__title,
 	&__subtitle {
-		color: var(--rvt-color-theme-accent);
+		color: var(--rvt-color-theme-text-accent);
 		display: block;
 	}
 

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -13,8 +13,8 @@
 		clip-path: path(var(--rvt-icon-quote-open));
 		display: block;
 		content: "";
-		height: calc(50/16 * var(--rvt-spacing-sm));
-		width: calc(65/16 * var(--rvt-spacing-sm));
+		height: calc(50 / 16 * var(--rvt-spacing-sm));
+		width: calc(65 / 16 * var(--rvt-spacing-sm));
 	}
 
 	&--image::before {

--- a/src/sass/radios/_base.scss
+++ b/src/sass/radios/_base.scss
@@ -6,7 +6,7 @@
 
 $padding: math.div(3rem, 16);
 
-.#{$prefix}-radio {
+.rvt-radio {
 	display: inline-block;
 	padding-left: $spacing-lg;
 	position: relative;
@@ -76,13 +76,7 @@ $padding: math.div(3rem, 16);
 	}
 
 	input[type="radio"]:disabled ~ label::before {
-		background-color: var(--rvt-color-theme-background-strong);
-		border-color: var(--rvt-color-theme-ui-strong);
-		box-shadow: inset 0 0 0 $padding var(--rvt-color-theme-background-strong);
-	}
-
-	input[type="radio"]:disabled:checked ~ label::before {
-		background-color: var(--rvt-color-theme-ui);
+		opacity: 0.4;
 	}
 
 	&__description {

--- a/src/sass/radios/_base.scss
+++ b/src/sass/radios/_base.scss
@@ -41,7 +41,8 @@
 
 	input[type="radio"] ~ label::before {
 		background-color: var(--rvt-color-theme-background);
-		border: calc(var(--rvt-spacing-xxs) / 4) solid var(--rvt-color-theme-text-strong);
+		border: calc(var(--rvt-spacing-xxs) / 4) solid
+			var(--rvt-color-theme-text-strong);
 		border-radius: var(--rvt-spacing-sm);
 		box-shadow: inset 0 0 0 var(--padding) var(--rvt-color-theme-background);
 		content: "";

--- a/src/sass/rivet.scss
+++ b/src/sass/rivet.scss
@@ -44,6 +44,7 @@
 @use "stat-group";
 @use "step-indicator";
 @use "series-nav";
+@use "sticker";
 @use "subnav";
 @use "switch";
 @use "tables";

--- a/src/sass/section-intro/_base.scss
+++ b/src/sass/section-intro/_base.scss
@@ -9,7 +9,7 @@
 	text-align: center;
 
 	&__title {
-		color: var(--rvt-color-theme-accent);
+		color: var(--rvt-color-theme-text-accent);
 		font-family: $font-family-condensed;
 		font-size: $ts-36;
 		font-weight: $font-weight-black;
@@ -22,7 +22,7 @@
 
 	&__eyebrow {
 		@include eyebrow;
-		color: var(--rvt-color-theme-accent);
+		color: var(--rvt-color-theme-text-accent);
 	}
 
 	&__teaser {
@@ -47,7 +47,7 @@
 	}
 
 	&--feature::before {
-		background-color: var(--rvt-color-theme-accent);
+		background-color: var(--rvt-color-theme-text-accent);
 		clip-path: path(var(--rvt-icon-logo-iu));
 		content: "";
 		display: block;
@@ -63,14 +63,14 @@
 	}
 
 	&--feature &__teaser {
-		color: var(--rvt-color-theme-accent);
+		color: var(--rvt-color-theme-text-accent);
 		padding-top: $spacing-xl;
 		position: relative;
 		text-align: left;
 	}
 
 	&--feature &__teaser::before {
-		background-color: var(--rvt-color-theme-accent);
+		background-color: var(--rvt-color-theme-text-accent);
 		content: "";
 		display: block;
 		height: $spacing-lg;

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -77,7 +77,7 @@
 	}
 
 	&__link[aria-current="page"] + &__toggle {
-		background-color: var(--rvt-color-theme-accent-inverse);
+		background-color: var(--rvt-color-theme-background-accent);
 
 		> svg {
 			color: var(--rvt-color-theme-accent);
@@ -87,7 +87,7 @@
 	&__link[aria-current="page"] + &__toggle:hover,
 	&__link[aria-current="page"] + &__toggle:focus {
 		color: var(--rvt-color-theme-accent);
-		background-color: var(--rvt-color-theme-accent-inverse);
+		background-color: var(--rvt-color-theme-background-accent);
 
 		> svg {
 			color: var(--rvt-color-theme-accent);
@@ -168,7 +168,7 @@
 		}
 
 		&[aria-current] {
-			background-color: var(--rvt-color-theme-accent-inverse);
+			background-color: var(--rvt-color-theme-background-accent);
 		}
 	}
 

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -61,37 +61,19 @@
 		position: relative;
 		text-decoration: none;
 
-		&[aria-current="page"] {
+		&:is([aria-current="page"], [aria-current="page"]:hover) {
 			border-color: currentColor;
 			color: var(--rvt-color-theme-accent);
 		}
 
 		&:hover {
-			color: var(--rvt-color-theme-accent-strong);
-			text-decoration: underline;
+			background-color: var(--rvt-color-theme-background-strong);
+			color: inherit;
 		}
 	}
 
 	&__item &__item &__link {
 		font-weight: $font-weight-regular;
-	}
-
-	&__link[aria-current="page"] + &__toggle {
-		background-color: var(--rvt-color-theme-background-accent);
-
-		> svg {
-			color: var(--rvt-color-theme-accent);
-		}
-	}
-
-	&__link[aria-current="page"] + &__toggle:hover,
-	&__link[aria-current="page"] + &__toggle:focus {
-		color: var(--rvt-color-theme-accent);
-		background-color: var(--rvt-color-theme-background-accent);
-
-		> svg {
-			color: var(--rvt-color-theme-accent);
-		}
 	}
 
 	&__toggle {
@@ -127,7 +109,6 @@
 
 		&:hover {
 			background-color: var(--rvt-color-theme-background-strong);
-			color: var(--rvt-color-theme-accent);
 		}
 	}
 

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -68,6 +68,9 @@
 
 		&:hover {
 			background-color: var(--rvt-color-theme-background-strong);
+		}
+
+		&:is(:hover, :visited) {
 			color: inherit;
 		}
 	}

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -26,7 +26,7 @@
 	}
 
 	&__number {
-		color: var(--rvt-color-theme-accent);
+		color: var(--rvt-color-theme-text-accent);
 		font-family: $font-family-mono;
 		font-size: $ts-41;
 		font-variation-settings: "wdth" 150;
@@ -34,7 +34,7 @@
 	}
 
 	&__description {
-		color: var(--rvt-color-theme-accent);
+		color: var(--rvt-color-theme-text-accent);
 		font-size: $ts-14;
 		letter-spacing: 0.025rem;
 	}

--- a/src/sass/step-indicator/_base.scss
+++ b/src/sass/step-indicator/_base.scss
@@ -20,7 +20,8 @@
 		text-align: center;
 
 		&::before {
-			box-shadow: 0 calc(var(--rvt-spacing-sm) * 2.9) 0 1px var(--rvt-color-theme-ui);
+			box-shadow: 0 calc(var(--rvt-spacing-sm) * 2.9) 0 1px
+				var(--rvt-color-theme-ui);
 			content: "";
 			display: block;
 			width: 100%;
@@ -127,7 +128,8 @@
 	}
 
 	&--vertical &__item::before {
-		box-shadow: calc(var(--rvt-spacing-xxs) / -2) 0 0 0 var(--rvt-color-theme-ui);
+		box-shadow: calc(var(--rvt-spacing-xxs) / -2) 0 0 0
+			var(--rvt-color-theme-ui);
 		height: 100%;
 		left: calc(var(--rvt-spacing-sm) * 1.125);
 		position: absolute;
@@ -161,8 +163,7 @@ a.rvt-steps__item-content:hover .rvt-steps__label {
 
 a.rvt-steps__item-content:hover .rvt-steps__indicator,
 a.rvt-steps__item-content:focus .rvt-steps__indicator,
-a.rvt-steps__item-content[aria-current="step"]
-	.rvt-steps__indicator {
+a.rvt-steps__item-content[aria-current="step"] .rvt-steps__indicator {
 	background-color: var(--rvt-color-theme-accent);
 	color: var(--rvt-color-theme-text-inverse);
 	border-color: transparent;

--- a/src/sass/sticker/_base.scss
+++ b/src/sass/sticker/_base.scss
@@ -1,0 +1,4 @@
+rvt-sticker[name] {
+	--bg: var(--rvt-color-brand-light);
+	--color: var(--rvt-color-brand-main);
+}

--- a/src/sass/sticker/_index.scss
+++ b/src/sass/sticker/_index.scss
@@ -1,0 +1,1 @@
+@forward "base";

--- a/src/sass/subnav/_base.scss
+++ b/src/sass/subnav/_base.scss
@@ -22,8 +22,7 @@
 		margin: 0;
 	}
 
-	&__item a,
-	&__item button {
+	&__item :is(a, button) {
 		align-items: center;
 		appearance: none;
 		border: none;
@@ -40,7 +39,6 @@
 	}
 
 	&__item a[aria-current="page"] {
-		background-color: var(--rvt-color-theme-background-strong);
 		color: var(--rvt-color-theme-accent);
 	}
 
@@ -55,8 +53,7 @@
 		width: 100%;
 	}
 
-	&__item a:hover:not([aria-current="page"]),
-	&__item button:hover {
+	&__item :is(a, button):hover {
 		background-color: var(--rvt-color-theme-background-strong);
 	}
 }

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -21,13 +21,15 @@ table,
 }
 
 tr th {
-	font-weight: $font-weight-regular;
+	color: var(--rvt-color-theme-text-strong);
+	font-weight: var(--rvt-font-weight-medium);
 }
 
 thead {
-	background-color: var(--rvt-color-theme-background-strong);
+	background-color: var(--rvt-color-theme-accent);
 
 	tr th {
+		color: var(--rvt-color-theme-text-inverse);
 		padding-block: $spacing-sm;
 		padding-inline: $spacing-md;
 	}
@@ -54,6 +56,10 @@ tbody tr th {
 	thead {
 		background-color: transparent;
 		border-bottom: none;
+
+		th {
+			color: inherit;
+		}
 	}
 
 	tr {
@@ -90,11 +96,13 @@ tbody tr th {
 	}
 }
 
-.#{$prefix}-table-crimson,
-.#{$prefix}-table-feature {
+.#{$prefix}-table--subtle {
 	thead {
-		background-color: var(--rvt-color-theme-accent);
-		color: var(--rvt-color-theme-background);
+		background-color: var(--rvt-color-theme-background-strong);
+
+		th {
+			color: var(--rvt-color-theme-text);
+		}
 	}
 }
 

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -29,7 +29,7 @@ thead {
 	background-color: var(--rvt-color-theme-accent);
 
 	tr th {
-		color: var(--rvt-color-theme-text-inverse);
+		color: var(--rvt-color-theme-background);
 		padding-block: $spacing-sm;
 		padding-inline: $spacing-md;
 	}

--- a/src/sass/tabs/_base.scss
+++ b/src/sass/tabs/_base.scss
@@ -33,16 +33,7 @@
 
 		&:hover {
 			background-color: var(--rvt-color-theme-background-strong);
-			color: var(--rvt-color-theme-accent);
 		}
-	}
-
-	&__tab[aria-selected="true"] {
-		background-color: var(--rvt-color-theme-background-strong);
-	}
-
-	&__tab[aria-selected="true"]:hover {
-		color: var(--rvt-color-theme-text-strong);
 	}
 
 	&__tab[aria-selected="true"]::after {

--- a/src/sass/timeline/_base.scss
+++ b/src/sass/timeline/_base.scss
@@ -82,7 +82,7 @@
 
 	&__item-dates-icon {
 		align-items: center;
-		background-color: var(--rvt-color-theme-background-strong);
+		background-color: var(--rvt-color-theme-background-accent);
 		border-radius: $border-radius-circle;
 		color: var(--rvt-color-theme-accent);
 		display: flex;

--- a/src/sass/timeline/_base.scss
+++ b/src/sass/timeline/_base.scss
@@ -56,7 +56,7 @@
 
 	&__label {
 		background-color: var(--rvt-color-theme-accent);
-		color: var(--rvt-color-theme-text-inverse);
+		color: var(--rvt-color-theme-background);
 		font-family: $font-family-mono;
 		font-size: $ts-14;
 		padding-block: $spacing-sm;


### PR DESCRIPTION
Changes:
1. Renamed `.rvt-callout--alt` to `.rvt-callout--strong`.
2. `rvt-table` is now by default the "feature/crimson" style. Replaced `rvt-table-feature` with `rvt-table--subtle`.
3. Added `rvt-alert--medium`.

Future work:
- Dialog
- Hero (will be done in PR #801)
- Link Hub (depreciated?)
- Step indicator
- Switch
- Validation
- Recommendation to pair `rvt-button-group` with `rvt-timeline__item-actions` (although we could make it inherit `rvt-button-group`?).
- Replace `rvt-inline-alert` with `rvt-alert--medium`.