### PR TITLE
Replace Sass variables

### DIFF
--- a/src/sass/accordion/_base.scss
+++ b/src/sass/accordion/_base.scss
@@ -49,7 +49,7 @@
 		font-variation-settings:
 			"wdth" 135,
 			"YTLC" 540;
-		font-weight: $font-weight-bold;
+		font-weight: var(--rvt-font-weight-bold);
 		line-height: 1.3;
 		padding-right: var(--rvt-spacing-sm);
 	}

--- a/src/sass/accordion/_base.scss
+++ b/src/sass/accordion/_base.scss
@@ -1,9 +1,6 @@
 // Copyright (C) 2020 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:math";
-
 .rvt-accordion {
 	background-color: var(--rvt-color-theme-background);
 	border: 1px solid var(--rvt-color-theme-ui);

--- a/src/sass/accordion/_base.scss
+++ b/src/sass/accordion/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:math";
 
-.#{$prefix}-accordion {
+.rvt-accordion {
 	background-color: var(--rvt-color-theme-background);
 	border: 1px solid var(--rvt-color-theme-ui);
 	color: var(--rvt-color-theme-text);

--- a/src/sass/accordion/_base.scss
+++ b/src/sass/accordion/_base.scss
@@ -45,7 +45,7 @@
 	}
 
 	&__toggle-text {
-		font-size: $ts-18;
+		font-size: var(--rvt-ts-18);
 		font-variation-settings:
 			"wdth" 135,
 			"YTLC" 540;

--- a/src/sass/accordion/_base.scss
+++ b/src/sass/accordion/_base.scss
@@ -20,7 +20,7 @@
 		border: none;
 		color: var(--rvt-color-theme-text-strong);
 		display: flex;
-		padding: $spacing-md;
+		padding: var(--rvt-spacing-md);
 		text-align: left;
 		width: 100%;
 
@@ -28,9 +28,9 @@
 			background-color: currentColor;
 			clip-path: path(var(--rvt-icon-plus));
 			content: "";
-			height: $spacing-sm;
+			height: var(--rvt-spacing-sm);
 			margin-left: auto;
-			width: $spacing-sm;
+			width: var(--rvt-spacing-sm);
 		}
 	}
 
@@ -51,11 +51,11 @@
 			"YTLC" 540;
 		font-weight: $font-weight-bold;
 		line-height: 1.3;
-		padding-right: $spacing-sm;
+		padding-right: var(--rvt-spacing-sm);
 	}
 
 	&__panel {
-		padding: 0 $spacing-md $spacing-md;
+		padding: 0 var(--rvt-spacing-md) var(--rvt-spacing-md);
 	}
 
 	&__panel > * {

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -57,7 +57,7 @@
 
 	&::before {
 		background-color: var(--color-container);
-		border-radius: $border-radius-circle;
+		border-radius: var(--rvt-border-radius-circle);
 		content: "";
 		display: block;
 		height: var(--rvt-spacing-lg);

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -81,7 +81,7 @@
 
 	&__title {
 		color: var(--color-main);
-		font-size: $ts-18;
+		font-size: var(--rvt-ts-18);
 		font-weight: $font-weight-bold;
 		font-variation-settings:
 			"wdth" 135,

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -5,7 +5,7 @@
 @use "../defaults" as *;
 @use "sass:math";
 
-.#{$prefix}-alert {
+.rvt-alert {
 	@extend .rvt-theme-light;
 	background-color: var(--color-background);
 	border: $spacing-xxs * 0.25 solid var(--color-border);
@@ -166,7 +166,7 @@
  * Alert lists
  */
 
-.#{$prefix}-alert-list {
+.rvt-alert-list {
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -180,7 +180,7 @@
 	}
 }
 
-.#{$prefix}-input-error > {
+.rvt-input-error > {
 	input[type="color"],
 	input[type="color"]:focus,
 	input[type="date"],

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -1,9 +1,7 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
 @use "../defaults" as *;
-@use "sass:math";
 
 .rvt-alert {
 	@extend .rvt-theme-light;
@@ -211,7 +209,7 @@
 	input[type="week"]:focus,
 	textarea,
 	select {
-		box-shadow: 0 0 0 math.div(var(--rvt-spacing-xxs), 2) var(--rvt-color-danger-border);
+		box-shadow: 0 0 0 calc(var(--rvt-spacing-xxs) / 2) var(--rvt-color-danger-border);
 		border-color: var(--rvt-color-danger-border);
 	}
 }

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -172,7 +172,7 @@
 	padding: 0;
 
 	&__item {
-		line-height: $line-height-base;
+		line-height: var(--rvt-line-height-base);
 	}
 
 	&__item:not(first-child) {

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -8,10 +8,10 @@
 .rvt-alert {
 	@extend .rvt-theme-light;
 	background-color: var(--color-background);
-	border: $spacing-xxs * 0.25 solid var(--color-border);
-	padding-inline-start: $spacing-xxl * 0.9;
-	padding-inline-end: $spacing-sm;
-	padding-block: $spacing-sm;
+	border: calc(var(--rvt-spacing-xxs) * 0.25) solid var(--color-border);
+	padding-inline-start: calc(var(--rvt-spacing-xxl) * 0.9);
+	padding-inline-end: var(--rvt-spacing-sm);
+	padding-block: var(--rvt-spacing-sm);
 	position: relative;
 
 	&,
@@ -60,11 +60,11 @@
 		border-radius: $border-radius-circle;
 		content: "";
 		display: block;
-		height: $spacing-lg;
+		height: var(--rvt-spacing-lg);
 		left: calc(14rem / 16);
 		position: absolute;
 		top: calc(12rem / 16);
-		width: $spacing-lg;
+		width: var(--rvt-spacing-lg);
 	}
 
 	&::after {
@@ -72,11 +72,11 @@
 		display: block;
 		clip-path: path(var(--icon));
 		content: "";
-		height: $spacing-sm;
+		height: var(--rvt-spacing-sm);
 		left: calc(22rem / 16);
 		position: absolute;
 		top: calc(20rem / 16);
-		width: $spacing-sm;
+		width: var(--rvt-spacing-sm);
 	}
 
 	&__title {
@@ -87,7 +87,7 @@
 			"wdth" 135,
 			"YTLC" 540;
 		line-height: 1.3;
-		padding-inline-end: $spacing-md;
+		padding-inline-end: var(--rvt-spacing-md);
 		position: relative;
 	}
 
@@ -95,12 +95,12 @@
 	&__message {
 		margin-top: 0;
 		margin-bottom: 0;
-		padding-inline-end: $spacing-md;
+		padding-inline-end: var(--rvt-spacing-md);
 	}
 
 	&__title + &__message,
 	&__title + &__content {
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 	}
 
 	&__content {
@@ -109,7 +109,7 @@
 		}
 
 		> * + * {
-			margin-block-start: $spacing-sm;
+			margin-block-start: var(--rvt-spacing-sm);
 		}
 
 		a {
@@ -122,7 +122,7 @@
 
 		> ul,
 		> ol {
-			padding-left: $spacing-sm;
+			padding-left: var(--rvt-spacing-sm);
 		}
 
 		ul {
@@ -131,7 +131,7 @@
 
 		ul > li,
 		ol > li {
-			margin-top: $spacing-sm;
+			margin-top: var(--rvt-spacing-sm);
 		}
 	}
 
@@ -142,18 +142,18 @@
 		color: var(--rvt-color-theme-text-strong);
 		cursor: pointer;
 		display: block;
-		padding: $spacing-xxs;
+		padding: var(--rvt-spacing-xxs);
 		position: absolute;
-		right: $spacing-sm;
-		top: $spacing-sm;
+		right: var(--rvt-spacing-sm);
+		top: var(--rvt-spacing-sm);
 
 		&::before {
 			background-color: var(--color-main);
 			content: "";
 			clip-path: path(var(--rvt-icon-close));
 			display: block;
-			height: $spacing-sm;
-			width: $spacing-sm;
+			height: var(--rvt-spacing-sm);
+			width: var(--rvt-spacing-sm);
 		}
 
 		&:hover::before {
@@ -176,7 +176,7 @@
 	}
 
 	&__item:not(first-child) {
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 	}
 }
 
@@ -211,7 +211,7 @@
 	input[type="week"]:focus,
 	textarea,
 	select {
-		box-shadow: 0 0 0 math.div($spacing-xxs, 2) var(--rvt-color-danger-border);
+		box-shadow: 0 0 0 math.div(var(--rvt-spacing-xxs), 2) var(--rvt-color-danger-border);
 		border-color: var(--rvt-color-danger-border);
 	}
 }

--- a/src/sass/alerts/_base.scss
+++ b/src/sass/alerts/_base.scss
@@ -82,7 +82,7 @@
 	&__title {
 		color: var(--color-main);
 		font-size: var(--rvt-ts-18);
-		font-weight: $font-weight-bold;
+		font-weight: var(--rvt-font-weight-bold);
 		font-variation-settings:
 			"wdth" 135,
 			"YTLC" 540;

--- a/src/sass/avatar/_base.scss
+++ b/src/sass/avatar/_base.scss
@@ -11,12 +11,12 @@ $avatar-fonts: (
 );
 
 $avatar-widths: (
-	"xs": $spacing-lg,
-	"sm": $spacing-lg * 1.5,
-	"rg": $spacing-lg * 2,
-	"md": $spacing-lg * 3,
-	"lg": $spacing-lg * 4,
-	"xl": $spacing-lg * 5,
+	"xs": var(--rvt-spacing-lg),
+	"sm": calc(var(--rvt-spacing-lg) * 1.5),
+	"rg": calc(var(--rvt-spacing-lg) * 2),
+	"md": calc(var(--rvt-spacing-lg) * 3),
+	"lg": calc(var(--rvt-spacing-lg) * 4),
+	"xl": calc(var(--rvt-spacing-lg) * 5),
 );
 
 .rvt-avatar {

--- a/src/sass/avatar/_base.scss
+++ b/src/sass/avatar/_base.scss
@@ -19,7 +19,7 @@ $avatar-widths: (
 	"xl": $spacing-lg * 5,
 );
 
-.#{$prefix}-avatar {
+.rvt-avatar {
 	--size-xs: var(--rvt-spacing-lg);
 	--size-sm: calc(var(--rvt-spacing-lg) * 1.5);
 	--size-rg: calc(var(--rvt-spacing-lg) * 2);
@@ -75,7 +75,7 @@ $avatar-widths: (
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
 		@each $pixels, $rems in $avatar-widths {
-			.#{$prefix}-avatar--#{$pixels}-#{$variable}-up {
+			.rvt-avatar--#{$pixels}-#{$variable}-up {
 				font-size: map.get($avatar-fonts, $pixels);
 				height: $rems !important;
 				width: $rems !important;

--- a/src/sass/avatar/_base.scss
+++ b/src/sass/avatar/_base.scss
@@ -2,12 +2,12 @@
 @use "sass:map";
 
 $avatar-fonts: (
-	"xs": $ts-14,
-	"sm": $ts-16,
-	"rg": $ts-20,
-	"md": $ts-23,
-	"lg": $ts-32,
-	"xl": $ts-41,
+	"xs": var(--rvt-ts-14),
+	"sm": var(--rvt-ts-16),
+	"rg": var(--rvt-ts-20),
+	"md": var(--rvt-ts-23),
+	"lg": var(--rvt-ts-32),
+	"xl": var(--rvt-ts-41),
 );
 
 $avatar-widths: (
@@ -33,7 +33,7 @@ $avatar-widths: (
 	color: var(--rvt-color-theme-text-inverse);
 	display: flex;
 	flex-shrink: 0;
-	font-size: $ts-20;
+	font-size: var(--rvt-ts-20);
 	font-weight: 700;
 	height: var(--size);
 	justify-content: center;
@@ -48,27 +48,27 @@ $avatar-widths: (
 
 	&--xs {
 		--size: var(--size-xs);
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 	}
 
 	&--sm {
 		--size: var(--size-sm);
-		font-size: $ts-16;
+		font-size: var(--rvt-ts-16);
 	}
 
 	&--md {
 		--size: var(--size-md);
-		font-size: $ts-23;
+		font-size: var(--rvt-ts-23);
 	}
 
 	&--lg {
 		--size: var(--size-lg);
-		font-size: $ts-32;
+		font-size: var(--rvt-ts-32);
 	}
 
 	&--xl {
 		--size: var(--size-xl);
-		font-size: $ts-41;
+		font-size: var(--rvt-ts-41);
 	}
 }
 

--- a/src/sass/badges/_base.scss
+++ b/src/sass/badges/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 :is(span, strong).rvt-badge {
 	align-items: center;
 	background-color: var(--color-background);

--- a/src/sass/badges/_base.scss
+++ b/src/sass/badges/_base.scss
@@ -12,7 +12,7 @@
 	display: inline-flex;
 	font-size: $ts-xs;
 	font-weight: $font-weight-medium;
-	gap: $spacing-xxs;
+	gap: var(--rvt-spacing-xxs);
 	letter-spacing: 0.02rem;
 	line-height: 1;
 	padding: 0.25rem 0.5rem;

--- a/src/sass/badges/_base.scss
+++ b/src/sass/badges/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-:is(span, strong).#{$prefix}-badge {
+:is(span, strong).rvt-badge {
 	align-items: center;
 	background-color: var(--color-background);
 	border-radius: $border-radius-circle;
@@ -22,7 +22,7 @@
 	-osx-font-smoothing: grayscale;
 }
 
-span.#{$prefix}-badge {
+span.rvt-badge {
 	--color-background: var(--rvt-color-base-light);
 	--color-text: var(--rvt-color-base-main);
 
@@ -47,7 +47,7 @@ span.#{$prefix}-badge {
 	}
 }
 
-strong.#{$prefix}-badge {
+strong.rvt-badge {
 	--color-background: var(--rvt-color-base-main);
 	--color-text: var(--rvt-color-base-ultralight);
 

--- a/src/sass/badges/_base.scss
+++ b/src/sass/badges/_base.scss
@@ -6,7 +6,7 @@
 :is(span, strong).rvt-badge {
 	align-items: center;
 	background-color: var(--color-background);
-	border-radius: $border-radius-circle;
+	border-radius: var(--rvt-border-radius-circle);
 	box-shadow: 0 0 0 calc(1rem / 16) var(--rvt-color-base-ultralight);
 	color: var(--color-text);
 	display: inline-flex;

--- a/src/sass/badges/_base.scss
+++ b/src/sass/badges/_base.scss
@@ -10,7 +10,7 @@
 	box-shadow: 0 0 0 calc(1rem / 16) var(--rvt-color-base-ultralight);
 	color: var(--color-text);
 	display: inline-flex;
-	font-size: $ts-xs;
+	font-size: var(--rvt-ts-xs);
 	font-weight: $font-weight-medium;
 	gap: var(--rvt-spacing-xxs);
 	letter-spacing: 0.02rem;

--- a/src/sass/badges/_base.scss
+++ b/src/sass/badges/_base.scss
@@ -11,7 +11,7 @@
 	color: var(--color-text);
 	display: inline-flex;
 	font-size: var(--rvt-ts-xs);
-	font-weight: $font-weight-medium;
+	font-weight: var(--rvt-font-weight-medium);
 	gap: var(--rvt-spacing-xxs);
 	letter-spacing: 0.02rem;
 	line-height: 1;

--- a/src/sass/billboard/_base.scss
+++ b/src/sass/billboard/_base.scss
@@ -9,7 +9,7 @@
 	}
 
 	& + & {
-		margin-top: $spacing-lg;
+		margin-top: var(--rvt-spacing-lg);
 	}
 
 	&__eyebrow {
@@ -19,7 +19,7 @@
 	}
 
 	&__eyebrow + &__title {
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 	}
 
 	&__title {
@@ -33,13 +33,13 @@
 	}
 
 	&__body {
-		margin-top: $spacing-md;
-		padding: $spacing-md;
+		margin-top: var(--rvt-spacing-md);
+		padding: var(--rvt-spacing-md);
 	}
 
 	&__content {
 		color: var(--rvt-color-theme-text);
-		margin-top: $spacing-lg;
+		margin-top: var(--rvt-spacing-lg);
 	}
 
 	&__content > * {
@@ -47,7 +47,7 @@
 	}
 
 	&__content > * + * {
-		margin-top: $spacing-lg;
+		margin-top: var(--rvt-spacing-lg);
 	}
 
 	&__image {
@@ -66,7 +66,7 @@
 		flex-direction: row-reverse;
 
 		& + & {
-			margin-top: $spacing-xxl;
+			margin-top: var(--rvt-spacing-xxl);
 		}
 
 		&__title {
@@ -90,8 +90,8 @@
 			flex-grow: 1;
 			justify-content: flex-end;
 			margin-top: 0;
-			padding-bottom: $spacing-xxl;
-			padding-inline: $spacing-xxl;
+			padding-bottom: var(--rvt-spacing-xxl);
+			padding-inline: var(--rvt-spacing-xxl);
 		}
 
 		&--reverse {
@@ -105,8 +105,8 @@
 
 		&--compact &__body {
 			justify-content: center;
-			padding-block: $spacing-md;
-			padding-inline: $spacing-xxl;
+			padding-block: var(--rvt-spacing-md);
+			padding-inline: var(--rvt-spacing-xxl);
 		}
 
 		&--compact &__body,

--- a/src/sass/billboard/_base.scss
+++ b/src/sass/billboard/_base.scss
@@ -24,7 +24,7 @@
 
 	&__title {
 		color: var(--rvt-color-theme-text-accent);
-		font-family: $font-family-condensed;
+		font-family: var(--rvt-font-family-condensed);
 		font-size: var(--rvt-ts-26);
 		font-weight: var(--rvt-font-weight-black);
 		letter-spacing: 0.04rem;

--- a/src/sass/billboard/_base.scss
+++ b/src/sass/billboard/_base.scss
@@ -1,10 +1,10 @@
 @use "../core" as *;
 
-.#{$prefix}-billboard {
+.rvt-billboard {
 	background-color: var(--rvt-color-theme-background-strong);
 	position: relative;
 
-	.#{$prefix}-theme-light & {
+	.rvt-theme-light & {
 		background-color: var(--rvt-color-theme-accent-inverse);
 	}
 
@@ -61,7 +61,7 @@
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-billboard {
+	.rvt-billboard {
 		display: flex;
 		flex-direction: row-reverse;
 

--- a/src/sass/billboard/_base.scss
+++ b/src/sass/billboard/_base.scss
@@ -26,7 +26,7 @@
 		color: var(--rvt-color-theme-text-accent);
 		font-family: $font-family-condensed;
 		font-size: var(--rvt-ts-26);
-		font-weight: $font-weight-black;
+		font-weight: var(--rvt-font-weight-black);
 		letter-spacing: 0.04rem;
 		line-height: 1.2;
 		text-transform: uppercase;

--- a/src/sass/billboard/_base.scss
+++ b/src/sass/billboard/_base.scss
@@ -25,7 +25,7 @@
 	&__title {
 		color: var(--rvt-color-theme-text-accent);
 		font-family: $font-family-condensed;
-		font-size: $ts-26;
+		font-size: var(--rvt-ts-26);
 		font-weight: $font-weight-black;
 		letter-spacing: 0.04rem;
 		line-height: 1.2;
@@ -70,7 +70,7 @@
 		}
 
 		&__title {
-			font-size: $ts-29;
+			font-size: var(--rvt-ts-29);
 		}
 
 		&__image {
@@ -115,7 +115,7 @@
 		}
 
 		&--compact &__title {
-			font-size: $ts-26;
+			font-size: var(--rvt-ts-26);
 		}
 	}
 }

--- a/src/sass/billboard/_base.scss
+++ b/src/sass/billboard/_base.scss
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 @use "../core" as *;
 
 .rvt-billboard {

--- a/src/sass/breadcrumb/_base.scss
+++ b/src/sass/breadcrumb/_base.scss
@@ -6,7 +6,7 @@
 .rvt-breadcrumbs {
 	display: inline-flex;
 	flex-wrap: wrap;
-	gap: $spacing-xxs * 0.75;
+	gap: calc(var(--rvt-spacing-xxs) * 0.75);
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -16,7 +16,7 @@
 		display: inline-flex;
 		font-family: $font-family-mono;
 		font-size: $ts-12;
-		gap: $spacing-xxs;
+		gap: var(--rvt-spacing-xxs);
 		line-height: 1.25rem;
 		margin-top: 0;
 
@@ -25,15 +25,15 @@
 			clip-path: path(var(--rvt-icon-chevron-right));
 			content: "";
 			display: block;
-			height: $spacing-sm;
-			width: $spacing-sm;
+			height: var(--rvt-spacing-sm);
+			width: var(--rvt-spacing-sm);
 		}
 
 		a {
 			align-items: center;
 			display: inline-flex;
 			color: var(--rvt-color-theme-text);
-			gap: $spacing-xxs;
+			gap: var(--rvt-spacing-xxs);
 			text-decoration: none;
 
 			&:hover {
@@ -51,8 +51,8 @@
 			clip-path: path(var(--rvt-icon-home));
 			content: "";
 			display: block;
-			height: $spacing-sm;
-			width: $spacing-sm;
+			height: var(--rvt-spacing-sm);
+			width: var(--rvt-spacing-sm);
 		}
 	}
 
@@ -60,6 +60,6 @@
 		color: var(--rvt-color-theme-accent);
 		font-weight: $font-weight-medium;
 		text-decoration: underline;
-		text-underline-offset: $spacing-xxs;
+		text-underline-offset: var(--rvt-spacing-xxs);
 	}
 }

--- a/src/sass/breadcrumb/_base.scss
+++ b/src/sass/breadcrumb/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-breadcrumbs {
 	display: inline-flex;
 	flex-wrap: wrap;

--- a/src/sass/breadcrumb/_base.scss
+++ b/src/sass/breadcrumb/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-breadcrumbs {
+.rvt-breadcrumbs {
 	display: inline-flex;
 	flex-wrap: wrap;
 	gap: $spacing-xxs * 0.75;

--- a/src/sass/breadcrumb/_base.scss
+++ b/src/sass/breadcrumb/_base.scss
@@ -58,7 +58,7 @@
 
 	li[aria-current="page"] {
 		color: var(--rvt-color-theme-accent);
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 		text-decoration: underline;
 		text-underline-offset: var(--rvt-spacing-xxs);
 	}

--- a/src/sass/breadcrumb/_base.scss
+++ b/src/sass/breadcrumb/_base.scss
@@ -15,7 +15,7 @@
 		align-items: center;
 		display: inline-flex;
 		font-family: $font-family-mono;
-		font-size: $ts-12;
+		font-size: var(--rvt-ts-12);
 		gap: var(--rvt-spacing-xxs);
 		line-height: 1.25rem;
 		margin-top: 0;

--- a/src/sass/breadcrumb/_base.scss
+++ b/src/sass/breadcrumb/_base.scss
@@ -14,7 +14,7 @@
 	li {
 		align-items: center;
 		display: inline-flex;
-		font-family: $font-family-mono;
+		font-family: var(--rvt-font-family-mono);
 		font-size: var(--rvt-ts-12);
 		gap: var(--rvt-spacing-xxs);
 		line-height: 1.25rem;

--- a/src/sass/buttons-segmented/_base.scss
+++ b/src/sass/buttons-segmented/_base.scss
@@ -3,20 +3,20 @@
 
 @use "../core" as *;
 
-.#{$prefix}-button-segmented {
+.rvt-button-segmented {
 	display: inline-flex;
 
 	&--fitted {
 		display: flex;
 		width: 100%;
 
-		.#{$prefix}-button {
+		.rvt-button {
 			flex-grow: 1;
 			justify-content: center;
 		}
 	}
 
-	.#{$prefix}-button {
+	.rvt-button {
 		position: relative;
 
 		&:focus {
@@ -24,22 +24,22 @@
 		}
 	}
 
-	a.#{$prefix}-button {
+	a.rvt-button {
 		text-align: center;
 	}
 
-	.#{$prefix}-button:first-child {
+	.rvt-button:first-child {
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
 	}
 
-	.#{$prefix}-button:last-child {
+	.rvt-button:last-child {
 		border-top-left-radius: 0;
 		border-bottom-left-radius: 0;
 		margin-left: -2px;
 	}
 
-	.#{$prefix}-button:not(:first-child):not(:last-child) {
+	.rvt-button:not(:first-child):not(:last-child) {
 		border-radius: 0;
 		margin-left: -2px;
 	}
@@ -49,42 +49,42 @@
    * segmented button.
    */
 
-	.dropdown:first-child > .#{$prefix}-button:only-of-type,
-	.#{$prefix}-dropdown:first-child > .#{$prefix}-button:only-of-type {
+	.dropdown:first-child > .rvt-button:only-of-type,
+	.rvt-dropdown:first-child > .rvt-button:only-of-type {
 		border-top-right-radius: 0;
 		border-bottom-right-radius: 0;
 		margin-left: -2px;
 	}
 
-	.dropdown:first-child > .#{$prefix}-button:first-of-type,
-	.#{$prefix}-dropdown:first-child > .#{$prefix}-button:first-of-type {
+	.dropdown:first-child > .rvt-button:first-of-type,
+	.rvt-dropdown:first-child > .rvt-button:first-of-type {
 		border-top-left-radius: $spacing-xxs;
 		border-bottom-left-radius: $spacing-xxs;
 	}
 
-	.dropdown:last-child > .#{$prefix}-button:only-of-type,
-	.#{$prefix}-dropdown:last-child > .#{$prefix}-button:only-of-type {
+	.dropdown:last-child > .rvt-button:only-of-type,
+	.rvt-dropdown:last-child > .rvt-button:only-of-type {
 		border-top-left-radius: 0;
 		border-bottom-left-radius: 0;
 		margin-left: -2px;
 	}
 
-	.dropdown:last-child > .#{$prefix}-button:last-of-type,
-	.#{$prefix}-dropdown:last-child > .#{$prefix}-button:last-of-type {
+	.dropdown:last-child > .rvt-button:last-of-type,
+	.rvt-dropdown:last-child > .rvt-button:last-of-type {
 		border-top-right-radius: $spacing-xxs;
 		border-bottom-right-radius: $spacing-xxs;
 	}
 
 	.dropdown:not(:first-child):not(:last-child)
-		> .#{$prefix}-button:only-of-type,
-	.#{$prefix}-dropdown:not(:first-child):not(:last-child)
-		> .#{$prefix}-button:only-of-type {
+		> .rvt-button:only-of-type,
+	.rvt-dropdown:not(:first-child):not(:last-child)
+		> .rvt-button:only-of-type {
 		border-radius: 0;
 		margin-left: -2px;
 	}
 
-	.#{$prefix}-dropdown:last-child
-		> .#{$prefix}-button:not(.#{$prefix}-button--secondary) {
+	.rvt-dropdown:last-child
+		> .rvt-button:not(.rvt-button--secondary) {
 		margin-left: 2px;
 	}
 }

--- a/src/sass/buttons-segmented/_base.scss
+++ b/src/sass/buttons-segmented/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-button-segmented {
 	display: inline-flex;
 

--- a/src/sass/buttons-segmented/_base.scss
+++ b/src/sass/buttons-segmented/_base.scss
@@ -58,8 +58,8 @@
 
 	.dropdown:first-child > .rvt-button:first-of-type,
 	.rvt-dropdown:first-child > .rvt-button:first-of-type {
-		border-top-left-radius: $spacing-xxs;
-		border-bottom-left-radius: $spacing-xxs;
+		border-top-left-radius: var(--rvt-spacing-xxs);
+		border-bottom-left-radius: var(--rvt-spacing-xxs);
 	}
 
 	.dropdown:last-child > .rvt-button:only-of-type,
@@ -71,8 +71,8 @@
 
 	.dropdown:last-child > .rvt-button:last-of-type,
 	.rvt-dropdown:last-child > .rvt-button:last-of-type {
-		border-top-right-radius: $spacing-xxs;
-		border-bottom-right-radius: $spacing-xxs;
+		border-top-right-radius: var(--rvt-spacing-xxs);
+		border-bottom-right-radius: var(--rvt-spacing-xxs);
 	}
 
 	.dropdown:not(:first-child):not(:last-child)

--- a/src/sass/calendar-tile/_base.scss
+++ b/src/sass/calendar-tile/_base.scss
@@ -28,7 +28,7 @@
 	}
 
 	&__day {
-		font-size: $ts-36;
+		font-size: var(--rvt-ts-36);
 		font-weight: $font-weight-medium;
 		letter-spacing: 0.075rem;
 		margin-top: var(--rvt-spacing-xxs);

--- a/src/sass/calendar-tile/_base.scss
+++ b/src/sass/calendar-tile/_base.scss
@@ -8,7 +8,7 @@
 	background-color: var(--rvt-color-brand-extralight);
 	display: inline-flex;
 	flex-direction: column;
-	font-family: $font-family-mono;
+	font-family: var(--rvt-font-family-mono);
 	line-height: 1.1;
 	padding: var(--rvt-spacing-sm);
 	position: relative;

--- a/src/sass/calendar-tile/_base.scss
+++ b/src/sass/calendar-tile/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-cal {
+.rvt-cal {
 	color: var(--rvt-color-brand-main);
 	background-color: var(--rvt-color-brand-extralight);
 	display: inline-flex;

--- a/src/sass/calendar-tile/_base.scss
+++ b/src/sass/calendar-tile/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-cal {
 	color: var(--rvt-color-brand-main);
 	background-color: var(--rvt-color-brand-extralight);

--- a/src/sass/calendar-tile/_base.scss
+++ b/src/sass/calendar-tile/_base.scss
@@ -10,7 +10,7 @@
 	flex-direction: column;
 	font-family: $font-family-mono;
 	line-height: 1.1;
-	padding: $spacing-sm;
+	padding: var(--rvt-spacing-sm);
 	position: relative;
 
 	&__month,
@@ -18,7 +18,7 @@
 	&__year {
 		margin-left: auto;
 		margin-right: auto;
-		padding: 0 $spacing-sm;
+		padding: 0 var(--rvt-spacing-sm);
 		text-transform: uppercase;
 	}
 
@@ -31,10 +31,10 @@
 		font-size: $ts-36;
 		font-weight: $font-weight-medium;
 		letter-spacing: 0.075rem;
-		margin-top: $spacing-xxs;
+		margin-top: var(--rvt-spacing-xxs);
 	}
 
 	&__year {
-		margin-top: $spacing-xxs;
+		margin-top: var(--rvt-spacing-xxs);
 	}
 }

--- a/src/sass/calendar-tile/_base.scss
+++ b/src/sass/calendar-tile/_base.scss
@@ -29,7 +29,7 @@
 
 	&__day {
 		font-size: var(--rvt-ts-36);
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 		letter-spacing: 0.075rem;
 		margin-top: var(--rvt-spacing-xxs);
 	}

--- a/src/sass/callout/_base.scss
+++ b/src/sass/callout/_base.scss
@@ -18,7 +18,7 @@
 	}
 
 	&__inner {
-		padding: $spacing-md;
+		padding: var(--rvt-spacing-md);
 	}
 
 	&__eyebrow {
@@ -38,25 +38,25 @@
 	}
 
 	&__eyebrow + &__title {
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 	}
 
 	&__content {
-		margin-top: $spacing-md;
+		margin-top: var(--rvt-spacing-md);
 	}
 
 	&__actions {
 		display: flex;
 		flex-direction: column;
-		gap: $spacing-md;
-		margin-top: $spacing-md;
+		gap: var(--rvt-spacing-md);
+		margin-top: var(--rvt-spacing-md);
 	}
 }
 
 @container callout (min-width: 640px) {
 	.rvt-callout {
 		&__inner {
-			padding: $spacing-xxl;
+			padding: var(--rvt-spacing-xxl);
 		}
 
 		&__actions {
@@ -70,10 +70,10 @@
 	.rvt-callout {
 		&__inner {
 			display: flex;
-			gap: $spacing-lg;
+			gap: var(--rvt-spacing-lg);
 			margin-inline: auto;
 			max-width: 75%;
-			padding: $spacing-xxl;
+			padding: var(--rvt-spacing-xxl);
 		}
 
 		&__title {

--- a/src/sass/callout/_base.scss
+++ b/src/sass/callout/_base.scss
@@ -29,7 +29,7 @@
 
 	&__title {
 		color: var(--rvt-color-theme-text-accent);
-		font-family: $font-family-condensed;
+		font-family: var(--rvt-font-family-condensed);
 		font-size: var(--rvt-ts-26);
 		font-weight: var(--rvt-font-weight-black);
 		letter-spacing: 0.04rem;

--- a/src/sass/callout/_base.scss
+++ b/src/sass/callout/_base.scss
@@ -30,7 +30,7 @@
 	&__title {
 		color: var(--rvt-color-theme-text-accent);
 		font-family: $font-family-condensed;
-		font-size: $ts-26;
+		font-size: var(--rvt-ts-26);
 		font-weight: $font-weight-black;
 		letter-spacing: 0.04rem;
 		line-height: 1.2;
@@ -77,7 +77,7 @@
 		}
 
 		&__title {
-			font-size: $ts-29;
+			font-size: var(--rvt-ts-29);
 		}
 	}
 }

--- a/src/sass/callout/_base.scss
+++ b/src/sass/callout/_base.scss
@@ -31,7 +31,7 @@
 		color: var(--rvt-color-theme-text-accent);
 		font-family: $font-family-condensed;
 		font-size: var(--rvt-ts-26);
-		font-weight: $font-weight-black;
+		font-weight: var(--rvt-font-weight-black);
 		letter-spacing: 0.04rem;
 		line-height: 1.2;
 		text-transform: uppercase;

--- a/src/sass/callout/_base.scss
+++ b/src/sass/callout/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 
 // Temp Callout component
-.#{$prefix}-callout {
+.rvt-callout {
 	border: 1px solid var(--rvt-color-theme-accent-inverse);
 	background-color: var(--rvt-color-theme-accent-inverse);
 	color: var(--rvt-color-theme-text-accent);
@@ -54,7 +54,7 @@
 }
 
 @container callout (min-width: 640px) {
-	.#{$prefix}-callout {
+	.rvt-callout {
 		&__inner {
 			padding: $spacing-xxl;
 		}
@@ -67,7 +67,7 @@
 }
 
 @container callout (min-width: 1024px) {
-	.#{$prefix}-callout {
+	.rvt-callout {
 		&__inner {
 			display: flex;
 			gap: $spacing-lg;

--- a/src/sass/card/_base.scss
+++ b/src/sass/card/_base.scss
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 @use "../core" as *;
 
 .rvt-card {

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:math";
 
-.#{$prefix}-checkbox {
+.rvt-checkbox {
 	display: inline-block;
 	padding-left: $spacing-lg;
 	position: relative;

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -106,6 +106,6 @@
 
 	&__description {
 		display: block;
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 	}
 }

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -6,26 +6,26 @@
 
 .rvt-checkbox {
 	display: inline-block;
-	padding-left: $spacing-lg;
+	padding-left: var(--rvt-spacing-lg);
 	position: relative;
 
 	input[type="checkbox"] {
 		cursor: pointer;
-		height: $spacing-md;
+		height: var(--rvt-spacing-md);
 		left: 0;
 		margin: 0;
 		opacity: 0;
 		position: absolute;
 		top: 0;
-		width: $spacing-lg;
+		width: var(--rvt-spacing-lg);
 	}
 
 	&--sr-only-label {
-		padding-left: $spacing-md;
+		padding-left: var(--rvt-spacing-md);
 	}
 
 	&--sr-only-label input[type="checkbox"] {
-		width: $spacing-md;
+		width: var(--rvt-spacing-md);
 	}
 
 	&--sr-only-label input[type="checkbox"] ~ label {
@@ -48,14 +48,14 @@
 
 	input[type="checkbox"] ~ label::before {
 		background-color: var(--color-background);
-		border: math.div($spacing-xxs, 4) solid var(--color-border);
+		border: math.div(var(--rvt-spacing-xxs), 4) solid var(--color-border);
 		content: "";
 		display: inline-block;
-		height: $spacing-sm;
+		height: var(--rvt-spacing-sm);
 		left: math.div(3rem, 16);
 		position: absolute;
 		top: math.div(3rem, 16);
-		width: $spacing-sm;
+		width: var(--rvt-spacing-sm);
 	}
 
 	input[type="checkbox"] ~ label::after {
@@ -63,11 +63,11 @@
 		clip-path: path(var(--icon));
 		content: "";
 		display: var(--display-icon);
-		height: $spacing-sm;
+		height: var(--rvt-spacing-sm);
 		left: calc(4rem / 16);
 		position: absolute;
 		top: calc(4rem / 16);
-		width: $spacing-sm;
+		width: var(--rvt-spacing-sm);
 	}
 
 	input[type="checkbox"]:checked ~ label {

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -1,9 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:math";
-
 .rvt-checkbox {
 	display: inline-block;
 	padding-left: var(--rvt-spacing-lg);
@@ -48,13 +45,13 @@
 
 	input[type="checkbox"] ~ label::before {
 		background-color: var(--color-background);
-		border: math.div(var(--rvt-spacing-xxs), 4) solid var(--color-border);
+		border: calc(var(--rvt-spacing-xxs) / 4) solid var(--color-border);
 		content: "";
 		display: inline-block;
 		height: var(--rvt-spacing-sm);
-		left: math.div(3rem, 16);
+		left: calc(3rem / 16);
 		position: absolute;
-		top: math.div(3rem, 16);
+		top: calc(3rem / 16);
 		width: var(--rvt-spacing-sm);
 	}
 
@@ -93,8 +90,8 @@
 	}
 
 	input[type="checkbox"]:focus ~ label::before {
-		outline: math.div(2rem, 16) solid var(--rvt-color-theme-accent-strong);
-		outline-offset: math.div(2rem, 16);
+		outline: calc(2rem / 16) solid var(--rvt-color-theme-accent-strong);
+		outline-offset: calc(2rem / 16);
 	}
 
 	input[type="checkbox"]:indeterminate ~ label {

--- a/src/sass/checkboxes/_base.scss
+++ b/src/sass/checkboxes/_base.scss
@@ -43,7 +43,7 @@
 		--display-icon: none;
 		cursor: pointer;
 		display: inline-block;
-		line-height: $line-height-base;
+		line-height: var(--rvt-line-height-base);
 	}
 
 	input[type="checkbox"] ~ label::before {

--- a/src/sass/contact-info/_base.scss
+++ b/src/sass/contact-info/_base.scss
@@ -15,7 +15,7 @@
 
 	&__address-eyebrow {
 		color: var(--rvt-color-theme-text-accent);
-		font-family: $font-family-mono;
+		font-family: var(--rvt-font-family-mono);
 		font-size: var(--rvt-ts-12);
 	}
 

--- a/src/sass/contact-info/_base.scss
+++ b/src/sass/contact-info/_base.scss
@@ -16,11 +16,11 @@
 	&__address-eyebrow {
 		color: var(--rvt-color-theme-text-accent);
 		font-family: $font-family-mono;
-		font-size: $ts-12;
+		font-size: var(--rvt-ts-12);
 	}
 
 	&__address-title {
-		font-size: $ts-20;
+		font-size: var(--rvt-ts-20);
 		font-weight: $font-weight-medium;
 	}
 

--- a/src/sass/contact-info/_base.scss
+++ b/src/sass/contact-info/_base.scss
@@ -10,7 +10,7 @@
 	&__address {
 		display: flex;
 		flex-direction: column;
-		gap: $spacing-md;
+		gap: var(--rvt-spacing-md);
 	}
 
 	&__address-eyebrow {
@@ -25,17 +25,17 @@
 	}
 
 	&__address-eyebrow + &__address-title {
-		margin-top: $spacing-xxs;
+		margin-top: var(--rvt-spacing-xxs);
 	}
 
 	&__address-text {
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 	}
 
 	&__icon-list {
 		display: flex;
 		flex-direction: column;
-		gap: $spacing-sm;
+		gap: var(--rvt-spacing-sm);
 		list-style: "";
 		margin-bottom: 0;
 		margin-top: 0;
@@ -45,7 +45,7 @@
 	&__icon-list-item {
 		align-items: center;
 		display: flex;
-		gap: $spacing-xs;
+		gap: var(--rvt-spacing-xs);
 		line-height: 1.1;
 	}
 
@@ -58,7 +58,7 @@
 			border: none;
 			color: var(--rvt-color-theme-accent);
 			display: inline-flex;
-			gap: $spacing-xs;
+			gap: var(--rvt-spacing-xs);
 			font-weight: $font-weight-medium;
 			padding: 0;
 		}
@@ -68,8 +68,8 @@
 			clip-path: path(var(--rvt-icon-chevron-down));
 			content: "";
 			display: block;
-			height: $spacing-sm;
-			width: $spacing-sm;
+			height: var(--rvt-spacing-sm);
+			width: var(--rvt-spacing-sm);
 		}
 
 		button:hover {
@@ -84,11 +84,11 @@
 	}
 
 	&__intro + &__address {
-		margin-top: $spacing-xl;
+		margin-top: var(--rvt-spacing-xl);
 	}
 
 	&__address + &__icon-list {
-		margin-top: $spacing-md;
+		margin-top: var(--rvt-spacing-md);
 	}
 }
 
@@ -113,7 +113,7 @@
 
 		&__icon-list {
 			border-left: 1px solid var(--rvt-color-theme-ui);
-			padding-left: $spacing-lg;
+			padding-left: var(--rvt-spacing-lg);
 		}
 	}
 }

--- a/src/sass/contact-info/_base.scss
+++ b/src/sass/contact-info/_base.scss
@@ -50,7 +50,7 @@
 	}
 
 	&__disclosure {
-		width: $width-md;
+		width: var(--rvt-width-md);
 
 		button {
 			align-items: center;

--- a/src/sass/contact-info/_base.scss
+++ b/src/sass/contact-info/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-contact-info {
+.rvt-contact-info {
 	container-name: contact;
 	container-type: inline-size;
 
@@ -93,7 +93,7 @@
 }
 
 @container contact (min-width: #{$breakpoint-md}) {
-	.#{$prefix}-contact-info {
+	.rvt-contact-info {
 		&__inner {
 			display: flex;
 

--- a/src/sass/contact-info/_base.scss
+++ b/src/sass/contact-info/_base.scss
@@ -21,7 +21,7 @@
 
 	&__address-title {
 		font-size: var(--rvt-ts-20);
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 	}
 
 	&__address-eyebrow + &__address-title {
@@ -59,7 +59,7 @@
 			color: var(--rvt-color-theme-accent);
 			display: inline-flex;
 			gap: var(--rvt-spacing-xs);
-			font-weight: $font-weight-medium;
+			font-weight: var(--rvt-font-weight-medium);
 			padding: 0;
 		}
 

--- a/src/sass/core/mixins/_container.scss
+++ b/src/sass/core/mixins/_container.scss
@@ -6,7 +6,7 @@
 @mixin container($max-width: $breakpoint-xxl) {
 	margin-inline: auto;
 	max-width: var(--rvt-container-max-width, #{$max-width});
-	padding-inline: var(--rvt-container-padding-inline, #{$spacing-sm});
+	padding-inline: var(--rvt-container-padding-inline, #{var(--rvt-spacing-sm)});
 
 	@media (min-width: $breakpoint-lg) {
 		--rvt-container-padding-inline: 4vw;

--- a/src/sass/core/mixins/_container.scss
+++ b/src/sass/core/mixins/_container.scss
@@ -6,7 +6,7 @@
 @mixin container($max-width: $breakpoint-xxl) {
 	margin-inline: auto;
 	max-width: var(--rvt-container-max-width, #{$max-width});
-	padding-inline: var(--rvt-container-padding-inline, #{var(--rvt-spacing-sm)});
+	padding-inline: var(--rvt-container-padding-inline, var(--rvt-spacing-sm));
 
 	@media (min-width: $breakpoint-lg) {
 		--rvt-container-padding-inline: 4vw;

--- a/src/sass/defaults/_fonts.scss
+++ b/src/sass/defaults/_fonts.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 @font-face {
 	font-family: BentonSansCond;
 	src: url("https://fonts.iu.edu/fonts/benton-sans-cond-regular.eot");

--- a/src/sass/defaults/_fonts.scss
+++ b/src/sass/defaults/_fonts.scss
@@ -16,7 +16,7 @@
 		url("https://fonts.iu.edu/fonts/benton-sans-cond-regular.svg#BentonSansCondRegular")
 			format("svg");
 	font-style: normal;
-	font-weight: $font-weight-regular;
+	font-weight: var(--rvt-font-weight-regular);
 	font-display: swap;
 }
 
@@ -32,7 +32,7 @@
 		url("https://fonts.iu.edu/fonts/benton-sans-cond-black.svg#BentonSansCondBlack")
 			format("svg");
 	font-style: normal;
-	font-weight: $font-weight-black;
+	font-weight: var(--rvt-font-weight-black);
 	font-display: swap;
 }
 
@@ -48,14 +48,14 @@
 		url("https://fonts.iu.edu/fonts/benton-sans-cond-bold.svg#BentonSansCondBold")
 			format("svg");
 	font-style: normal;
-	font-weight: $font-weight-bold;
+	font-weight: var(--rvt-font-weight-bold);
 	font-display: swap;
 }
 
 @font-face {
 	font-family: BentonSans;
 	font-style: normal;
-	font-weight: $font-weight-regular;
+	font-weight: var(--rvt-font-weight-regular);
 	src: url("https://fonts.iu.edu/fonts/benton-sans-regular.eot");
 	src:
 		url("https://fonts.iu.edu/fonts/benton-sans-regular.eot?#iefix")
@@ -70,7 +70,7 @@
 @font-face {
 	font-family: BentonSans;
 	font-style: italic;
-	font-weight: $font-weight-regular;
+	font-weight: var(--rvt-font-weight-regular);
 	src: url("https://fonts.iu.edu/fonts/benton-sans-italic.eot");
 	src:
 		url("https://fonts.iu.edu/fonts/benton-sans-italic.eot?#iefix")
@@ -85,7 +85,7 @@
 @font-face {
 	font-family: BentonSans;
 	font-style: normal;
-	font-weight: $font-weight-medium;
+	font-weight: var(--rvt-font-weight-medium);
 	src: url("https://fonts.iu.edu/fonts/benton-sans-medium.eot");
 	src:
 		url("https://fonts.iu.edu/fonts/benton-sans-medium.eot?#iefix")
@@ -100,7 +100,7 @@
 @font-face {
 	font-family: BentonSans;
 	font-style: normal;
-	font-weight: $font-weight-bold;
+	font-weight: var(--rvt-font-weight-bold);
 	src: url("https://fonts.iu.edu/fonts/benton-sans-bold.eot");
 	src:
 		url("https://fonts.iu.edu/fonts/benton-sans-bold.eot?#iefix")
@@ -115,7 +115,7 @@
 @font-face {
 	font-family: GeorgiaPro;
 	font-style: normal;
-	font-weight: $font-weight-regular;
+	font-weight: var(--rvt-font-weight-regular);
 	src: url("https://fonts.iu.edu/fonts/georgia-pro-regular.eot");
 	src:
 		url("https://fonts.iu.edu/fonts/georgia-pro-regular.eot?#iefix")
@@ -130,7 +130,7 @@
 @font-face {
 	font-family: GeorgiaPro;
 	font-style: italic;
-	font-weight: $font-weight-regular;
+	font-weight: var(--rvt-font-weight-regular);
 	src: url("https://fonts.iu.edu/fonts/georgia-pro-italic.eot");
 	src:
 		url("https://fonts.iu.edu/fonts/georgia-pro-italic.eot?#iefix")
@@ -145,7 +145,7 @@
 @font-face {
 	font-family: GeorgiaPro;
 	font-style: normal;
-	font-weight: $font-weight-bold;
+	font-weight: var(--rvt-font-weight-bold);
 	src: url("https://fonts.iu.edu/fonts/georgia-pro-bold.eot");
 	src:
 		url("https://fonts.iu.edu/fonts/georgia-pro-bold.eot?#iefix")
@@ -160,7 +160,7 @@
 @font-face {
 	font-family: GeorgiaPro;
 	font-style: italic;
-	font-weight: $font-weight-bold;
+	font-weight: var(--rvt-font-weight-bold);
 	src: url("https://fonts.iu.edu/fonts/georgia-pro-bold-italic.eot");
 	src:
 		url("https://fonts.iu.edu/fonts/georgia-pro-bold-italic.eot?#iefix")

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -66,7 +66,7 @@ figure {
 
 figcaption {
 	font-family: $font-family-mono;
-	font-size: $ts-14;
+	font-size: var(--rvt-ts-14);
 	padding-top: var(--rvt-spacing-sm);
 }
 

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -26,7 +26,7 @@ body {
 	font-variation-settings: "wdth" 110;
 	font-weight: var(--rvt-font-weight-regular);
 	height: 100%;
-	line-height: $line-height-base;
+	line-height: var(--rvt-line-height-base);
 	margin: 0;
 	padding: 0;
 }

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -22,7 +22,7 @@ html * {
 
 body {
 	color: var(--rvt-color-theme-text);
-	font-family: $font-family-base;
+	font-family: var(--rvt-font-family-base);
 	font-variation-settings: "wdth" 110;
 	font-weight: var(--rvt-font-weight-regular);
 	height: 100%;
@@ -65,7 +65,7 @@ figure {
 }
 
 figcaption {
-	font-family: $font-family-mono;
+	font-family: var(--rvt-font-family-mono);
 	font-size: var(--rvt-ts-14);
 	padding-top: var(--rvt-spacing-sm);
 }

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -24,7 +24,7 @@ body {
 	color: var(--rvt-color-theme-text);
 	font-family: $font-family-base;
 	font-variation-settings: "wdth" 110;
-	font-weight: $font-weight-regular;
+	font-weight: var(--rvt-font-weight-regular);
 	height: 100%;
 	line-height: $line-height-base;
 	margin: 0;
@@ -44,7 +44,7 @@ h4,
 h5,
 h6 {
 	font-size: 1.125rem;
-	font-weight: $font-weight-regular;
+	font-weight: var(--rvt-font-weight-regular);
 	margin: 0;
 }
 
@@ -75,7 +75,7 @@ em {
 }
 
 strong {
-	font-weight: $font-weight-bold;
+	font-weight: var(--rvt-font-weight-bold);
 }
 
 sub,

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 html {
 	font-size: 100%;
 	height: 100%;

--- a/src/sass/defaults/_reset.scss
+++ b/src/sass/defaults/_reset.scss
@@ -67,7 +67,7 @@ figure {
 figcaption {
 	font-family: $font-family-mono;
 	font-size: $ts-14;
-	padding-top: $spacing-sm;
+	padding-top: var(--rvt-spacing-sm);
 }
 
 em {

--- a/src/sass/defaults/_themes.scss
+++ b/src/sass/defaults/_themes.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2024 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 :root,
 .rvt-theme-light {
 	--rvt-color-theme-accent: var(--rvt-color-brand-main);

--- a/src/sass/defaults/_themes.scss
+++ b/src/sass/defaults/_themes.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 
 :root,
-.#{$prefix}-theme-light {
+.rvt-theme-light {
 	--rvt-color-theme-accent: var(--rvt-color-brand-main);
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-dark);
 	--rvt-color-theme-accent-inverse: var(--rvt-color-brand-extralight);
@@ -20,7 +20,7 @@
 	--rvt-color-theme-text-inverse: var(--rvt-color-base-ultralight);
 }
 
-.#{$prefix}-theme-dark {
+.rvt-theme-dark {
 	--rvt-color-theme-accent: var(--rvt-color-brand-extralight);
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-light);
 	--rvt-color-theme-accent-inverse: var(--rvt-color-brand-main);
@@ -36,7 +36,7 @@
 	--rvt-color-theme-text-inverse: var(--rvt-color-base-main);
 }
 
-.#{$prefix}-theme-crimson {
+.rvt-theme-crimson {
 	--rvt-color-theme-accent: var(--rvt-color-brand-extralight);
 	--rvt-color-theme-accent-strong: var(--rvt-color-brand-light);
 	--rvt-color-theme-accent-inverse: var(--rvt-color-brand-main);
@@ -52,9 +52,9 @@
 	--rvt-color-theme-text-inverse: var(--rvt-color-base-main);
 }
 
-.#{$prefix}-theme-light,
-.#{$prefix}-theme-dark,
-.#{$prefix}-theme-crimson {
+.rvt-theme-light,
+.rvt-theme-dark,
+.rvt-theme-crimson {
 	background-color: var(--rvt-color-theme-background);
 	color: var(--rvt-color-theme-text);
 }

--- a/src/sass/dialog/_base.scss
+++ b/src/sass/dialog/_base.scss
@@ -92,7 +92,7 @@
 
 	&__title {
 		font-size: var(--rvt-ts-20);
-		font-weight: $font-weight-bold;
+		font-weight: var(--rvt-font-weight-bold);
 		line-height: 1;
 	}
 

--- a/src/sass/dialog/_base.scss
+++ b/src/sass/dialog/_base.scss
@@ -29,7 +29,7 @@
 	top: 40%;
 	transform: translateY(-40%);
 	width: 90%;
-	z-index: map.get($z-index, "1000");
+	z-index: var(--rvt-z-index-1000);
 
 	&[data-rvt-dialog-darken-page] {
 		box-shadow: 0 0 0 9999px var(--rvt-color-shadow-dark);

--- a/src/sass/dialog/_base.scss
+++ b/src/sass/dialog/_base.scss
@@ -11,11 +11,11 @@
  * It's removed when the dialog is closed making the body scrollable again.
  */
 
-.#{$prefix}-dialog-prevent-scroll {
+.rvt-dialog-prevent-scroll {
 	overflow: hidden;
 }
 
-.#{$prefix}-dialog {
+.rvt-dialog {
 	background-color: var(--rvt-color-theme-background);
 	border-radius: $spacing-xs;
 	box-shadow: $shadow-heavy;
@@ -31,11 +31,11 @@
 	width: 90%;
 	z-index: map.get($z-index, "1000");
 
-	&[data-#{$prefix}-dialog-darken-page] {
+	&[data-rvt-dialog-darken-page] {
 		box-shadow: 0 0 0 9999px var(--rvt-color-shadow-dark);
 	}
 
-	&[data-#{$prefix}-dialog-top-left] {
+	&[data-rvt-dialog-top-left] {
 		bottom: auto;
 		left: $spacing-xl;
 		right: auto;
@@ -43,7 +43,7 @@
 		transform: none;
 	}
 
-	&[data-#{$prefix}-dialog-top-right] {
+	&[data-rvt-dialog-top-right] {
 		bottom: auto;
 		left: auto;
 		right: $spacing-xl;
@@ -51,7 +51,7 @@
 		transform: none;
 	}
 
-	&[data-#{$prefix}-dialog-bottom-left] {
+	&[data-rvt-dialog-bottom-left] {
 		bottom: $spacing-xl;
 		left: $spacing-xl;
 		right: auto;
@@ -59,7 +59,7 @@
 		transform: none;
 	}
 
-	&[data-#{$prefix}-dialog-bottom-right] {
+	&[data-rvt-dialog-bottom-right] {
 		bottom: $spacing-xl;
 		left: auto;
 		right: $spacing-xl;
@@ -108,7 +108,7 @@
 		gap: $spacing-sm;
 		padding: $spacing-sm;
 
-		.#{$prefix}-button {
+		.rvt-button {
 			justify-content: center;
 			text-align: center;
 			width: 100%;
@@ -117,21 +117,21 @@
 		@include mq($breakpoint-sm) {
 			justify-content: flex-end;
 
-			.#{$prefix}-button {
+			.rvt-button {
 				width: auto;
 			}
 		}
 	}
 
-	.#{$prefix}-button[data-#{$prefix}-dialog-close] > * {
+	.rvt-button[data-rvt-dialog-close] > * {
 		pointer-events: none;
 	}
 }
 
-.#{$prefix}-dialog[hidden] {
+.rvt-dialog[hidden] {
 	display: none;
 }
 
-.#{$prefix}-dialog:not([hidden]) {
+.rvt-dialog:not([hidden]) {
 	display: block;
 }

--- a/src/sass/dialog/_base.scss
+++ b/src/sass/dialog/_base.scss
@@ -18,7 +18,7 @@
 .rvt-dialog {
 	background-color: var(--rvt-color-theme-background);
 	border-radius: var(--rvt-spacing-xs);
-	box-shadow: $shadow-heavy;
+	box-shadow: var(--rvt-shadow-heavy);
 	left: 0;
 	margin: auto;
 	max-height: 100%;

--- a/src/sass/dialog/_base.scss
+++ b/src/sass/dialog/_base.scss
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 @use "../core" as *;
-@use "sass:map";
-@use "sass:math";
 
 /**
  * This class gets applied to the body of the document when a modal dialog

--- a/src/sass/dialog/_base.scss
+++ b/src/sass/dialog/_base.scss
@@ -17,7 +17,7 @@
 
 .rvt-dialog {
 	background-color: var(--rvt-color-theme-background);
-	border-radius: $spacing-xs;
+	border-radius: var(--rvt-spacing-xs);
 	box-shadow: $shadow-heavy;
 	left: 0;
 	margin: auto;
@@ -37,32 +37,32 @@
 
 	&[data-rvt-dialog-top-left] {
 		bottom: auto;
-		left: $spacing-xl;
+		left: var(--rvt-spacing-xl);
 		right: auto;
-		top: $spacing-xl;
+		top: var(--rvt-spacing-xl);
 		transform: none;
 	}
 
 	&[data-rvt-dialog-top-right] {
 		bottom: auto;
 		left: auto;
-		right: $spacing-xl;
-		top: $spacing-xl;
+		right: var(--rvt-spacing-xl);
+		top: var(--rvt-spacing-xl);
 		transform: none;
 	}
 
 	&[data-rvt-dialog-bottom-left] {
-		bottom: $spacing-xl;
-		left: $spacing-xl;
+		bottom: var(--rvt-spacing-xl);
+		left: var(--rvt-spacing-xl);
 		right: auto;
 		top: auto;
 		transform: none;
 	}
 
 	&[data-rvt-dialog-bottom-right] {
-		bottom: $spacing-xl;
+		bottom: var(--rvt-spacing-xl);
 		left: auto;
-		right: $spacing-xl;
+		right: var(--rvt-spacing-xl);
 		top: auto;
 		transform: none;
 	}
@@ -70,14 +70,14 @@
 	&__close {
 		background-color: transparent;
 		border: none;
-		border-radius: $spacing-xxs;
+		border-radius: var(--rvt-spacing-xxs);
 		color: var(--rvt-color-theme-text-strong);
 		display: inline-block;
 		height: auto;
 		line-height: 0.5;
-		padding: $spacing-xs;
+		padding: var(--rvt-spacing-xs);
 		position: absolute;
-		right: $spacing-sm;
+		right: var(--rvt-spacing-sm);
 		top: 1.1rem;
 
 		&:hover {
@@ -87,7 +87,7 @@
 
 	&__header {
 		border-bottom: 1px solid var(--rvt-color-theme-ui);
-		padding: $spacing-md $spacing-sm;
+		padding: var(--rvt-spacing-md) var(--rvt-spacing-sm);
 	}
 
 	&__title {
@@ -97,7 +97,7 @@
 	}
 
 	&__body {
-		padding: $spacing-sm;
+		padding: var(--rvt-spacing-sm);
 	}
 
 	&__controls {
@@ -105,8 +105,8 @@
 		border-top: 1px solid var(--rvt-color-theme-ui);
 		display: flex;
 		flex-wrap: wrap;
-		gap: $spacing-sm;
-		padding: $spacing-sm;
+		gap: var(--rvt-spacing-sm);
+		padding: var(--rvt-spacing-sm);
 
 		.rvt-button {
 			justify-content: center;

--- a/src/sass/dialog/_base.scss
+++ b/src/sass/dialog/_base.scss
@@ -91,7 +91,7 @@
 	}
 
 	&__title {
-		font-size: $ts-20;
+		font-size: var(--rvt-ts-20);
 		font-weight: $font-weight-bold;
 		line-height: 1;
 	}

--- a/src/sass/disclosure/_base.scss
+++ b/src/sass/disclosure/_base.scss
@@ -11,7 +11,7 @@
 		color: var(--rvt-color-theme-accent);
 		display: flex;
 		font: inherit;
-		gap: $spacing-xs;
+		gap: var(--rvt-spacing-xs);
 		padding: 0;
 	}
 
@@ -19,8 +19,8 @@
 		background-color: currentColor;
 		clip-path: path(var(--rvt-icon-chevron-right));
 		content: "";
-		height: $spacing-sm;
-		width: $spacing-sm;
+		height: var(--rvt-spacing-sm);
+		width: var(--rvt-spacing-sm);
 	}
 
 	&__toggle[aria-expanded="true"]::before {
@@ -35,8 +35,8 @@
 
 	&__content {
 		box-shadow: calc(2rem / 16) 0 0 var(--rvt-color-theme-ui) inset;
-		margin-left: $spacing-xs;
-		margin-top: $spacing-xs;
-		padding-left: $spacing-sm;
+		margin-left: var(--rvt-spacing-xs);
+		margin-top: var(--rvt-spacing-xs);
+		padding-left: var(--rvt-spacing-sm);
 	}
 }

--- a/src/sass/disclosure/_base.scss
+++ b/src/sass/disclosure/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2021 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-disclosure {
 	&__toggle {
 		align-items: center;

--- a/src/sass/disclosure/_base.scss
+++ b/src/sass/disclosure/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-disclosure {
+.rvt-disclosure {
 	&__toggle {
 		align-items: center;
 		background-color: transparent;

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -9,7 +9,7 @@
 	position: relative;
 
 	.button__text {
-		margin-right: $spacing-xs;
+		margin-right: var(--rvt-spacing-xs);
 	}
 
 	&__menu[aria-hidden="true"] {
@@ -20,8 +20,8 @@
 		background-color: var(--rvt-color-theme-background);
 		box-shadow: $shadow-standard;
 		min-width: 12.5rem;
-		padding-bottom: $spacing-xs;
-		padding-top: $spacing-xs;
+		padding-bottom: var(--rvt-spacing-xs);
+		padding-top: var(--rvt-spacing-xs);
 		position: absolute;
 		// Aligning this right by default so that dropdowns do not
 		// go offscreen when close to the edge of the viewport.
@@ -55,7 +55,7 @@
 			/**
        * This padding-top and bottom value is a magic number.
        */
-			padding: 0.375rem $spacing-sm;
+			padding: 0.375rem var(--rvt-spacing-sm);
 			text-align: left;
 			text-decoration: none;
 			width: 100%;
@@ -86,7 +86,7 @@
 
 	&__menu-heading {
 		color: var(--rvt-color-theme-text-strong);
-		padding: $spacing-sm $spacing-sm $spacing-xxs;
+		padding: var(--rvt-spacing-sm) var(--rvt-spacing-sm) var(--rvt-spacing-xxs);
 		font-weight: $font-weight-bold;
 		font-size: $ts-14;
 
@@ -98,14 +98,14 @@
 	&__menu-divider,
 	&__menu-separator {
 		border-top: 1px solid var(--rvt-color-theme-ui);
-		margin-bottom: $spacing-xs;
-		margin-top: $spacing-xs;
+		margin-bottom: var(--rvt-spacing-xs);
+		margin-top: var(--rvt-spacing-xs);
 	}
 
 	[role="group"] {
 		border-top: 1px solid var(--rvt-color-theme-ui);
-		margin-top: $spacing-xs;
-		padding-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
+		padding-top: var(--rvt-spacing-xs);
 
 		&:first-child {
 			margin-top: 0;

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -1,9 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:map";
-
 .rvt-dropdown {
 	display: inline-block;
 	position: relative;

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -51,7 +51,7 @@
 			border: none;
 			display: block;
 			color: var(--rvt-color-theme-text-strong);
-			font-size: $ts-14;
+			font-size: var(--rvt-ts-14);
 			/**
        * This padding-top and bottom value is a magic number.
        */
@@ -88,7 +88,7 @@
 		color: var(--rvt-color-theme-text-strong);
 		padding: var(--rvt-spacing-sm) var(--rvt-spacing-sm) var(--rvt-spacing-xxs);
 		font-weight: $font-weight-bold;
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 
 		&:first-child {
 			padding-top: 0;

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -71,7 +71,7 @@
 			&[aria-checked="true"] {
 				background-color: var(--rvt-color-theme-background-strong);
 				color: var(--rvt-color-theme-accent);
-				font-weight: $font-weight-medium;
+				font-weight: var(--rvt-font-weight-medium);
 
 				&:hover {
 					color: var(--rvt-color-theme-accent);
@@ -87,7 +87,7 @@
 	&__menu-heading {
 		color: var(--rvt-color-theme-text-strong);
 		padding: var(--rvt-spacing-sm) var(--rvt-spacing-sm) var(--rvt-spacing-xxs);
-		font-weight: $font-weight-bold;
+		font-weight: var(--rvt-font-weight-bold);
 		font-size: var(--rvt-ts-14);
 
 		&:first-child {

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -18,7 +18,7 @@
 
 	&__menu {
 		background-color: var(--rvt-color-theme-background);
-		box-shadow: $shadow-standard;
+		box-shadow: var(--rvt-shadow-standard);
 		min-width: 12.5rem;
 		padding-bottom: var(--rvt-spacing-xs);
 		padding-top: var(--rvt-spacing-xs);

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -27,7 +27,7 @@
 		// go offscreen when close to the edge of the viewport.
 		right: 0;
 		top: 115%;
-		z-index: map.get($z-index, "1000");
+		z-index: var(--rvt-z-index-1000);
 
 		//In some cases, you may need to align the dropdown menu
 		//to the left edge of the button.

--- a/src/sass/dropdown/_base.scss
+++ b/src/sass/dropdown/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:map";
 
-.#{$prefix}-dropdown {
+.rvt-dropdown {
 	display: inline-block;
 	position: relative;
 
@@ -66,7 +66,7 @@
 				text-decoration: none;
 			}
 
-			&.#{$prefix}-is-selected,
+			&.rvt-is-selected,
 			&[aria-current]:not([aria-current="false"]),
 			&[aria-checked="true"] {
 				background-color: var(--rvt-color-theme-background-strong);
@@ -117,6 +117,6 @@
 // NOTE: Context specific styles
 // We need some context-specific styles when dropdowns are used in the
 // header nav.
-.#{$prefix}-header-menu__item .#{$prefix}-dropdown__menu {
+.rvt-header-menu__item .rvt-dropdown__menu {
 	top: 165%;
 }

--- a/src/sass/empty-state/_base.scss
+++ b/src/sass/empty-state/_base.scss
@@ -1,6 +1,6 @@
 @use "../core" as *;
 
-.#{$prefix}-empty-state {
+.rvt-empty-state {
 	background-color: var(--rvt-color-theme-background-strong);
 	border: $spacing-xxs dashed var(--rvt-color-theme-ui);
 	border-radius: $spacing-xs;
@@ -27,7 +27,7 @@
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-empty-state {
+	.rvt-empty-state {
 		&__actions {
 			display: flex;
 			justify-content: center;

--- a/src/sass/empty-state/_base.scss
+++ b/src/sass/empty-state/_base.scss
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 @use "../core" as *;
 
 .rvt-empty-state {

--- a/src/sass/empty-state/_base.scss
+++ b/src/sass/empty-state/_base.scss
@@ -2,18 +2,18 @@
 
 .rvt-empty-state {
 	background-color: var(--rvt-color-theme-background-strong);
-	border: $spacing-xxs dashed var(--rvt-color-theme-ui);
-	border-radius: $spacing-xs;
+	border: var(--rvt-spacing-xxs) dashed var(--rvt-color-theme-ui);
+	border-radius: var(--rvt-spacing-xs);
 	display: flex;
 	flex-direction: column;
-	padding: $spacing-xxl $spacing-md;
+	padding: var(--rvt-spacing-xxl) var(--rvt-spacing-md);
 	text-align: center;
 
 	&__content {
 	}
 
 	&__actions {
-		margin-top: $spacing-md;
+		margin-top: var(--rvt-spacing-md);
 	}
 
 	&__actions > * {
@@ -22,7 +22,7 @@
 	}
 
 	&__actions > *:not(:first-child) {
-		margin-top: $spacing-sm;
+		margin-top: var(--rvt-spacing-sm);
 	}
 }
 
@@ -38,7 +38,7 @@
 		}
 
 		&__actions > *:not(:first-child) {
-			margin-left: $spacing-sm;
+			margin-left: var(--rvt-spacing-sm);
 			margin-top: 0;
 		}
 	}

--- a/src/sass/factoid/_base.scss
+++ b/src/sass/factoid/_base.scss
@@ -14,7 +14,7 @@
 	}
 
 	&__content {
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 	}
 }
 

--- a/src/sass/factoid/_base.scss
+++ b/src/sass/factoid/_base.scss
@@ -10,7 +10,7 @@
 
 	&__label {
 		font-family: $font-family-mono;
-		font-size: $ts-12;
+		font-size: var(--rvt-ts-12);
 	}
 
 	&__content {

--- a/src/sass/factoid/_base.scss
+++ b/src/sass/factoid/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-factoid {
+.rvt-factoid {
 	&__item {
 		padding: $spacing-sm;
 	}
@@ -19,7 +19,7 @@
 }
 
 @media (min-width: $breakpoint-md) {
-	.#{$prefix}-factoid {
+	.rvt-factoid {
 		display: flex;
 		flex-wrap: wrap;
 

--- a/src/sass/factoid/_base.scss
+++ b/src/sass/factoid/_base.scss
@@ -5,7 +5,7 @@
 
 .rvt-factoid {
 	&__item {
-		padding: $spacing-sm;
+		padding: var(--rvt-spacing-sm);
 	}
 
 	&__label {

--- a/src/sass/factoid/_base.scss
+++ b/src/sass/factoid/_base.scss
@@ -9,7 +9,7 @@
 	}
 
 	&__label {
-		font-family: $font-family-mono;
+		font-family: var(--rvt-font-family-mono);
 		font-size: var(--rvt-ts-12);
 	}
 

--- a/src/sass/file-input/_base.scss
+++ b/src/sass/file-input/_base.scss
@@ -45,7 +45,7 @@
 		span {
 			display: inline-block;
 			font-weight: var(--rvt-font-weight-bold);
-			line-height: $line-height-base;
+			line-height: var(--rvt-line-height-base);
 		}
 	}
 }

--- a/src/sass/file-input/_base.scss
+++ b/src/sass/file-input/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:math";
 
-.#{$prefix}-file {
+.rvt-file {
 	align-items: center;
 	display: flex;
 	flex-wrap: wrap;

--- a/src/sass/file-input/_base.scss
+++ b/src/sass/file-input/_base.scss
@@ -20,7 +20,7 @@
 		cursor: pointer;
 		display: flex;
 		flex-grow: 0;
-		font-size: $ts-base;
+		font-size: var(--rvt-ts-base);
 		font-weight: $font-weight-bold;
 		margin-bottom: 0;
 		margin-top: 0;

--- a/src/sass/file-input/_base.scss
+++ b/src/sass/file-input/_base.scss
@@ -21,7 +21,7 @@
 		display: flex;
 		flex-grow: 0;
 		font-size: var(--rvt-ts-base);
-		font-weight: $font-weight-bold;
+		font-weight: var(--rvt-font-weight-bold);
 		margin-bottom: 0;
 		margin-top: 0;
 		width: inherit;
@@ -44,7 +44,7 @@
 
 		span {
 			display: inline-block;
-			font-weight: $font-weight-bold;
+			font-weight: var(--rvt-font-weight-bold);
 			line-height: $line-height-base;
 		}
 	}

--- a/src/sass/file-input/_base.scss
+++ b/src/sass/file-input/_base.scss
@@ -40,7 +40,7 @@
 	}
 
 	&__preview {
-		margin-left: $spacing-sm;
+		margin-left: var(--rvt-spacing-sm);
 
 		span {
 			display: inline-block;

--- a/src/sass/file-input/_base.scss
+++ b/src/sass/file-input/_base.scss
@@ -1,9 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:math";
-
 .rvt-file {
 	align-items: center;
 	display: flex;

--- a/src/sass/footer-system/_footer-base.scss
+++ b/src/sass/footer-system/_footer-base.scss
@@ -24,7 +24,7 @@
 	}
 
 	&__item {
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		margin-top: var(--rvt-spacing-xs);
 	}
 

--- a/src/sass/footer-system/_footer-base.scss
+++ b/src/sass/footer-system/_footer-base.scss
@@ -1,4 +1,5 @@
-// Brand section (copyright)
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
 
 @use "../core" as *;
 

--- a/src/sass/footer-system/_footer-base.scss
+++ b/src/sass/footer-system/_footer-base.scss
@@ -8,8 +8,8 @@
 		display: flex;
 		flex-direction: column;
 		margin-left: auto;
-		padding-bottom: $spacing-sm;
-		padding-top: $spacing-sm;
+		padding-bottom: var(--rvt-spacing-sm);
+		padding-top: var(--rvt-spacing-sm);
 	}
 
 	&__logo {
@@ -25,7 +25,7 @@
 
 	&__item {
 		font-size: $ts-14;
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 	}
 
 	&__link {
@@ -57,7 +57,7 @@
 		&__list {
 			display: flex;
 			margin-bottom: 0;
-			margin-left: $spacing-sm;
+			margin-left: var(--rvt-spacing-sm);
 			margin-top: 0;
 		}
 
@@ -66,7 +66,7 @@
 		}
 
 		&__item:not(:first-child) {
-			margin-left: $spacing-sm;
+			margin-left: var(--rvt-spacing-sm);
 		}
 	}
 }

--- a/src/sass/footer-system/_footer-base.scss
+++ b/src/sass/footer-system/_footer-base.scss
@@ -2,7 +2,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-footer-base {
+.rvt-footer-base {
 	&__inner {
 		border-top: 1px solid var(--rvt-color-theme-ui);
 		display: flex;
@@ -40,7 +40,7 @@
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-footer-base {
+	.rvt-footer-base {
 		&__inner {
 			align-items: center;
 			flex-direction: row;

--- a/src/sass/footer-system/_footer-resources.scss
+++ b/src/sass/footer-system/_footer-resources.scss
@@ -3,27 +3,27 @@
 @use "../core" as *;
 
 .rvt-footer-resources {
-	padding-bottom: $spacing-sm;
+	padding-bottom: var(--rvt-spacing-sm);
 
 	&__heading {
 		font-size: $ts-18;
 		font-weight: $font-weight-medium;
-		margin-top: $spacing-md;
+		margin-top: var(--rvt-spacing-md);
 	}
 
 	&__text-block {
 		font-size: $ts-14;
-		margin-top: $spacing-sm;
+		margin-top: var(--rvt-spacing-sm);
 	}
 
 	&__list {
 		list-style: none;
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 		padding-left: 0;
 	}
 
 	&__list-item {
-		margin-top: $spacing-xxs;
+		margin-top: var(--rvt-spacing-xxs);
 	}
 
 	&__list-item a {
@@ -45,22 +45,22 @@
 		border-color: transparent;
 		color: var(--rvt-color-theme-accent);
 		justify-content: center;
-		margin-bottom: $spacing-sm;
+		margin-bottom: var(--rvt-spacing-sm);
 		width: 100%;
 	}
 }
 
 @include mq($breakpoint-md) {
 	.rvt-footer-resources {
-		padding-bottom: $spacing-lg;
-		padding-top: $spacing-lg;
+		padding-bottom: var(--rvt-spacing-lg);
+		padding-top: var(--rvt-spacing-lg);
 
 		&__heading {
 			margin-top: 0;
 		}
 
 		&__list {
-			margin-top: $spacing-sm;
+			margin-top: var(--rvt-spacing-sm);
 		}
 	}
 
@@ -68,6 +68,6 @@
 	// visually when used together with social component.
 
 	.rvt-footer-social + .rvt-footer-resources {
-		padding-top: $spacing-xs;
+		padding-top: var(--rvt-spacing-xs);
 	}
 }

--- a/src/sass/footer-system/_footer-resources.scss
+++ b/src/sass/footer-system/_footer-resources.scss
@@ -2,7 +2,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-footer-resources {
+.rvt-footer-resources {
 	padding-bottom: $spacing-sm;
 
 	&__heading {
@@ -51,7 +51,7 @@
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-footer-resources {
+	.rvt-footer-resources {
 		padding-bottom: $spacing-lg;
 		padding-top: $spacing-lg;
 
@@ -67,7 +67,7 @@
 	// Adjust the padding of the resources component to make spacing work better
 	// visually when used together with social component.
 
-	.#{$prefix}-footer-social + .#{$prefix}-footer-resources {
+	.rvt-footer-social + .rvt-footer-resources {
 		padding-top: $spacing-xs;
 	}
 }

--- a/src/sass/footer-system/_footer-resources.scss
+++ b/src/sass/footer-system/_footer-resources.scss
@@ -1,4 +1,5 @@
-// Related section
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
 
 @use "../core" as *;
 

--- a/src/sass/footer-system/_footer-resources.scss
+++ b/src/sass/footer-system/_footer-resources.scss
@@ -7,7 +7,7 @@
 
 	&__heading {
 		font-size: var(--rvt-ts-18);
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 		margin-top: var(--rvt-spacing-md);
 	}
 

--- a/src/sass/footer-system/_footer-resources.scss
+++ b/src/sass/footer-system/_footer-resources.scss
@@ -6,13 +6,13 @@
 	padding-bottom: var(--rvt-spacing-sm);
 
 	&__heading {
-		font-size: $ts-18;
+		font-size: var(--rvt-ts-18);
 		font-weight: $font-weight-medium;
 		margin-top: var(--rvt-spacing-md);
 	}
 
 	&__text-block {
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		margin-top: var(--rvt-spacing-sm);
 	}
 
@@ -28,7 +28,7 @@
 
 	&__list-item a {
 		color: var(--rvt-color-theme-text-strong);
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		text-decoration: none;
 
 		&:hover {

--- a/src/sass/footer-system/_footer-social.scss
+++ b/src/sass/footer-system/_footer-social.scss
@@ -4,8 +4,8 @@
 
 .rvt-footer-social {
 	background-color: var(--rvt-color-theme-background);
-	padding-bottom: $spacing-md;
-	padding-top: $spacing-md;
+	padding-bottom: var(--rvt-spacing-md);
+	padding-top: var(--rvt-spacing-md);
 }
 
 .rvt-social-link {
@@ -13,9 +13,9 @@
 	border: 1px solid var(--rvt-color-theme-ui);
 	border-radius: $border-radius-circle;
 	display: flex;
-	height: $spacing-sm * 2.25;
+	height: calc(var(--rvt-spacing-sm) * 2.25);
 	justify-content: center;
-	width: $spacing-sm * 2.25;
+	width: calc(var(--rvt-spacing-sm) * 2.25);
 
 	&:hover {
 		background-color: var(--rvt-color-theme-accent);

--- a/src/sass/footer-system/_footer-social.scss
+++ b/src/sass/footer-system/_footer-social.scss
@@ -1,6 +1,5 @@
-// Social section
-
-@use "../core" as *;
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
 
 .rvt-footer-social {
 	background-color: var(--rvt-color-theme-background);

--- a/src/sass/footer-system/_footer-social.scss
+++ b/src/sass/footer-system/_footer-social.scss
@@ -2,13 +2,13 @@
 
 @use "../core" as *;
 
-.#{$prefix}-footer-social {
+.rvt-footer-social {
 	background-color: var(--rvt-color-theme-background);
 	padding-bottom: $spacing-md;
 	padding-top: $spacing-md;
 }
 
-.#{$prefix}-social-link {
+.rvt-social-link {
 	align-items: center;
 	border: 1px solid var(--rvt-color-theme-ui);
 	border-radius: $border-radius-circle;

--- a/src/sass/footer-system/_footer-social.scss
+++ b/src/sass/footer-system/_footer-social.scss
@@ -11,7 +11,7 @@
 .rvt-social-link {
 	align-items: center;
 	border: 1px solid var(--rvt-color-theme-ui);
-	border-radius: $border-radius-circle;
+	border-radius: var(--rvt-border-radius-circle);
 	display: flex;
 	height: calc(var(--rvt-spacing-sm) * 2.25);
 	justify-content: center;

--- a/src/sass/grid/_base.scss
+++ b/src/sass/grid/_base.scss
@@ -69,7 +69,7 @@ $gutter: math.div($spacing-md, 2);
  */
 
 @each $key, $value in $row-widths {
-	.#{$prefix}-container-#{$key} {
+	.rvt-container-#{$key} {
 		@include container($value);
 	}
 }
@@ -90,14 +90,14 @@ $gutter: math.div($spacing-md, 2);
 	position: relative;
 }
 
-.#{$prefix}-row {
+.rvt-row {
 	@include row;
 
-	.#{$prefix}-cols {
+	.rvt-cols {
 		@include cols;
 	}
 
-	.#{$prefix}-cols--last {
+	.rvt-cols--last {
 		margin-left: auto;
 	}
 
@@ -106,7 +106,7 @@ $gutter: math.div($spacing-md, 2);
 		margin-right: $gutter * -2;
 	}
 
-	&--loose > [class^="#{$prefix}-cols"] {
+	&--loose > [class^="rvt-cols"] {
 		padding-left: $gutter * 2;
 		padding-right: $gutter * 2;
 	}
@@ -116,15 +116,15 @@ $gutter: math.div($spacing-md, 2);
 		margin-right: $gutter * -0.75;
 	}
 
-	&--tight > [class^="#{$prefix}-cols"] {
+	&--tight > [class^="rvt-cols"] {
 		padding-left: $gutter * 0.75;
 		padding-right: $gutter * 0.75;
 	}
 
-	[class^="#{$prefix}-cols"] {
+	[class^="rvt-cols"] {
 		/**
      * This keeps the row from collapsing when cols inside are too
-     * big for their parent .#{$prefix}-row__cols.
+     * big for their parent .rvt-row__cols.
      */
 		min-width: 0;
 		display: block;
@@ -136,7 +136,7 @@ $gutter: math.div($spacing-md, 2);
  * than 12 columns in total.
  */
 
-.#{$prefix}-cols--right {
+.rvt-cols--right {
 	justify-content: flex-end;
 }
 
@@ -147,14 +147,14 @@ $gutter: math.div($spacing-md, 2);
 }
 
 @each $variable, $size in $breakpoints {
-	.#{$prefix}-cols-#{$variable} {
+	.rvt-cols-#{$variable} {
 		@extend %auto-row-props;
 	}
 }
 
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
-		.#{$prefix}-cols-#{$variable} {
+		.rvt-cols-#{$variable} {
 			flex-basis: 0;
 			flex-grow: 1;
 			max-width: 100%;
@@ -182,7 +182,7 @@ $gutter: math.div($spacing-md, 2);
 }
 
 @each $columns, $width in $row-columns {
-	.#{$prefix}-cols-#{$columns} {
+	.rvt-cols-#{$columns} {
 		flex-basis: $width * 1%;
 		max-width: $width * 1%;
 
@@ -197,7 +197,7 @@ $gutter: math.div($spacing-md, 2);
 /* stylelint-disable */
 @each $variable, $size in $breakpoints {
 	@each $columns, $width in $row-columns {
-		.#{$prefix}-cols-#{$columns}-#{$variable} {
+		.rvt-cols-#{$columns}-#{$variable} {
 			@extend %cols-properties;
 		}
 	}
@@ -206,7 +206,7 @@ $gutter: math.div($spacing-md, 2);
 @each $variable, $size in $breakpoints {
 	@if $variable == "sm" {
 		@each $columns, $width in $row-columns {
-			.#{$prefix}-cols-#{$columns}-sm {
+			.rvt-cols-#{$columns}-sm {
 				flex-basis: $width * 1%;
 				max-width: $width * 1%;
 			}
@@ -214,7 +214,7 @@ $gutter: math.div($spacing-md, 2);
 	} @else {
 		@include mq($size) {
 			@each $columns, $width in $row-columns {
-				.#{$prefix}-cols-#{$columns}-#{$variable} {
+				.rvt-cols-#{$columns}-#{$variable} {
 					flex-basis: $width * 1%;
 					max-width: $width * 1%;
 				}
@@ -226,13 +226,13 @@ $gutter: math.div($spacing-md, 2);
 // Push and pull utilities
 
 @each $columns, $width in $row-columns {
-	.#{$prefix}-cols-push-#{$columns} {
+	.rvt-cols-push-#{$columns} {
 		left: $width * 1%;
 	}
 }
 
 @each $columns, $width in $row-columns {
-	.#{$prefix}-cols-pull-#{$columns} {
+	.rvt-cols-pull-#{$columns} {
 		right: $width * 1%;
 	}
 }
@@ -245,26 +245,26 @@ $gutter: math.div($spacing-md, 2);
 @each $variable, $size in $breakpoints {
 	@if $size == "sm" {
 		@each $columns, $width in $row-columns {
-			.#{$prefix}-cols-push-#{$columns}-#{$variable} {
+			.rvt-cols-push-#{$columns}-#{$variable} {
 				left: $width * 1%;
 			}
 		}
 
 		@each $columns, $width in $row-columns {
-			.#{$prefix}-cols-pull-#{$columns}-#{$variable} {
+			.rvt-cols-pull-#{$columns}-#{$variable} {
 				right: $width * 1%;
 			}
 		}
 	} @else {
 		@include mq($size) {
 			@each $columns, $width in $row-columns {
-				.#{$prefix}-cols-push-#{$columns}-#{$variable} {
+				.rvt-cols-push-#{$columns}-#{$variable} {
 					left: $width * 1%;
 				}
 			}
 
 			@each $columns, $width in $row-columns {
-				.#{$prefix}-cols-pull-#{$columns}-#{$variable} {
+				.rvt-cols-pull-#{$columns}-#{$variable} {
 					right: $width * 1%;
 				}
 			}

--- a/src/sass/header-system/_base.scss
+++ b/src/sass/header-system/_base.scss
@@ -235,7 +235,7 @@
 	}
 
 	&__body {
-		font-family: $font-family-condensed;
+		font-family: var(--rvt-font-family-condensed);
 		text-transform: uppercase;
 	}
 

--- a/src/sass/header-system/_base.scss
+++ b/src/sass/header-system/_base.scss
@@ -114,7 +114,7 @@
 
 	&-menu__link {
 		color: var(--rvt-color-theme-text-strong);
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		font-weight: $font-weight-medium;
 		padding-block: var(--rvt-spacing-xs);
 		text-decoration: none;
@@ -129,7 +129,7 @@
 			color: var(--rvt-color-theme-text-strong);
 			cursor: pointer;
 			display: flex;
-			font-size: $ts-14;
+			font-size: var(--rvt-ts-14);
 			font-weight: $font-weight-medium;
 			gap: var(--rvt-spacing-xs);
 			margin-top: calc(var(--rvt-spacing-xxs) * 0.75);
@@ -241,7 +241,7 @@
 
 	&__title {
 		color: var(--rvt-color-theme-text-strong);
-		font-size: $ts-20;
+		font-size: var(--rvt-ts-20);
 		font-weight: $font-weight-black;
 		letter-spacing: 0.025rem;
 	}

--- a/src/sass/header-system/_base.scss
+++ b/src/sass/header-system/_base.scss
@@ -3,7 +3,7 @@
 
 .rvt-skip-link {
 	background-color: var(--rvt-color-theme-background);
-	padding: $spacing-xs;
+	padding: var(--rvt-spacing-xs);
 	position: fixed;
 	top: -6rem;
 	z-index: 999;
@@ -15,12 +15,12 @@
 
 .rvt-header {
 	background-color: var(--rvt-color-theme-background);
-	padding-block: $spacing-sm;
+	padding-block: var(--rvt-spacing-sm);
 
 	&__inner {
 		align-items: center;
 		display: flex;
-		gap: $spacing-sm;
+		gap: var(--rvt-spacing-sm);
 		@include container;
 	}
 
@@ -37,21 +37,21 @@
 		color: var(--rvt-color-theme-text-strong);
 		cursor: pointer;
 		display: flex;
-		height: $spacing-xl;
+		height: var(--rvt-spacing-xl);
 		justify-content: center;
-		width: $spacing-xl;
+		width: var(--rvt-spacing-xl);
 	}
 
 	&-menu {
 		display: flex;
-		gap: $spacing-sm;
+		gap: var(--rvt-spacing-sm);
 		justify-content: flex-end;
 	}
 
 	&-menu__list {
 		display: flex;
 		flex-grow: 1;
-		gap: $spacing-sm;
+		gap: var(--rvt-spacing-sm);
 		justify-content: flex-end;
 		list-style: "";
 		margin: 0;
@@ -71,7 +71,7 @@
 			color: var(--rvt-color-theme-text-strong);
 			display: flex;
 			justify-content: center;
-			padding-inline: math.div($spacing-xxs, 1.5);
+			padding-inline: math.div(var(--rvt-spacing-xxs), 1.5);
 		}
 
 		button[aria-expanded="true"] > svg {
@@ -80,10 +80,10 @@
 
 		&:has([aria-current="page"])::after {
 			background-color: var(--rvt-color-theme-accent);
-			bottom: $spacing-xxs * -0.125;
+			bottom: calc(var(--rvt-spacing-xxs) * -0.125);
 			content: "";
 			display: block;
-			height: $spacing-xxs;
+			height: var(--rvt-spacing-xxs);
 			opacity: 1;
 			position: absolute;
 		}
@@ -91,10 +91,10 @@
 
 	&-menu__item::after {
 		background-color: var(--rvt-color-theme-accent);
-		bottom: $spacing-xxs * -1;
+		bottom: calc(var(--rvt-spacing-xxs) * -1);
 		content: "";
 		display: block;
-		height: $spacing-xxs * 0.5;
+		height: calc(var(--rvt-spacing-xxs) * 0.5);
 		opacity: 0;
 		position: absolute;
 		transition: all 0.2s ease;
@@ -102,7 +102,7 @@
 	}
 
 	&-menu__item:hover::after {
-		bottom: $spacing-xxs * -0.25;
+		bottom: calc(var(--rvt-spacing-xxs) * -0.25);
 		opacity: 1;
 		transition: 0.2s;
 	}
@@ -116,7 +116,7 @@
 		color: var(--rvt-color-theme-text-strong);
 		font-size: $ts-14;
 		font-weight: $font-weight-medium;
-		padding-block: $spacing-xs;
+		padding-block: var(--rvt-spacing-xs);
 		text-decoration: none;
 	}
 
@@ -131,10 +131,10 @@
 			display: flex;
 			font-size: $ts-14;
 			font-weight: $font-weight-medium;
-			gap: $spacing-xs;
-			margin-top: $spacing-xxs * 0.75;
-			padding-block: $spacing-xxs;
-			padding-inline: $spacing-sm;
+			gap: var(--rvt-spacing-xs);
+			margin-top: calc(var(--rvt-spacing-xxs) * 0.75);
+			padding-block: var(--rvt-spacing-xxs);
+			padding-inline: var(--rvt-spacing-sm);
 		}
 
 		> button[hidden] {
@@ -153,7 +153,7 @@
 	&__buttons {
 		align-items: center;
 		display: flex;
-		gap: $spacing-sm;
+		gap: var(--rvt-spacing-sm);
 		margin-left: auto;
 	}
 
@@ -169,7 +169,7 @@
 
 	&__search-bar-inner {
 		background-color: var(--rvt-color-theme-background);
-		padding-block: $spacing-xs;
+		padding-block: var(--rvt-spacing-xs);
 	}
 
 	&__search-bar input[type="text"]:focus {
@@ -191,7 +191,7 @@
 		box-shadow: 0 0 0 9999px var(--rvt-color-shadow-dark);
 		height: 100vh;
 		overflow-y: auto;
-		padding-top: $spacing-lg;
+		padding-top: var(--rvt-spacing-lg);
 		position: absolute;
 		right: 0;
 		top: 0;
@@ -221,7 +221,7 @@
 .rvt-lockup {
 	align-items: center;
 	display: inline-flex;
-	gap: $spacing-sm;
+	gap: var(--rvt-spacing-sm);
 	text-decoration: none;
 
 	&__tab {

--- a/src/sass/header-system/_base.scss
+++ b/src/sass/header-system/_base.scss
@@ -1,5 +1,7 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 @use "../core" as *;
-@use "sass:math";
 
 .rvt-skip-link {
 	background-color: var(--rvt-color-theme-background);
@@ -71,7 +73,7 @@
 			color: var(--rvt-color-theme-text-strong);
 			display: flex;
 			justify-content: center;
-			padding-inline: math.div(var(--rvt-spacing-xxs), 1.5);
+			padding-inline: calc(var(--rvt-spacing-xxs) / 1.5);
 		}
 
 		button[aria-expanded="true"] > svg {

--- a/src/sass/header-system/_base.scss
+++ b/src/sass/header-system/_base.scss
@@ -115,7 +115,7 @@
 	&-menu__link {
 		color: var(--rvt-color-theme-text-strong);
 		font-size: var(--rvt-ts-14);
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 		padding-block: var(--rvt-spacing-xs);
 		text-decoration: none;
 	}
@@ -130,7 +130,7 @@
 			cursor: pointer;
 			display: flex;
 			font-size: var(--rvt-ts-14);
-			font-weight: $font-weight-medium;
+			font-weight: var(--rvt-font-weight-medium);
 			gap: var(--rvt-spacing-xs);
 			margin-top: calc(var(--rvt-spacing-xxs) * 0.75);
 			padding-block: var(--rvt-spacing-xxs);
@@ -142,7 +142,7 @@
 		}
 
 		ul li a {
-			font-weight: $font-weight-regular;
+			font-weight: var(--rvt-font-weight-regular);
 		}
 
 		.rvt-header-menu__item .rvt-dropdown {
@@ -242,7 +242,7 @@
 	&__title {
 		color: var(--rvt-color-theme-text-strong);
 		font-size: var(--rvt-ts-20);
-		font-weight: $font-weight-black;
+		font-weight: var(--rvt-font-weight-black);
 		letter-spacing: 0.025rem;
 	}
 

--- a/src/sass/hero-area/_base.scss
+++ b/src/sass/hero-area/_base.scss
@@ -15,7 +15,7 @@
 		color: var(--rvt-color-theme-accent);
 		display: block;
 		font-family: $font-family-mono;
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		letter-spacing: 0.125rem;
 		text-transform: uppercase;
 	}
@@ -29,7 +29,7 @@
 	&__title {
 		color: var(--rvt-color-theme-accent);
 		font-family: $font-family-condensed;
-		font-size: $ts-32;
+		font-size: var(--rvt-ts-32);
 		font-variation-settings: "wdth" 140;
 		font-weight: 850;
 		line-height: 1.1;
@@ -86,7 +86,7 @@
 	&--profile &__subtitle {
 		color: var(--rvt-color-theme-accent);
 		font-family: $font-family-condensed;
-		font-size: $ts-20;
+		font-size: var(--rvt-ts-20);
 		font-weight: $font-weight-black;
 		margin: 0;
 		text-transform: uppercase;
@@ -109,7 +109,7 @@
 		}
 
 		&__title {
-			font-size: $ts-46;
+			font-size: var(--rvt-ts-46);
 		}
 
 		&__actions > * {
@@ -150,7 +150,7 @@
 		}
 
 		&--profile &__subtitle {
-			font-size: $ts-26;
+			font-size: var(--rvt-ts-26);
 		}
 
 		&--split &__media img {
@@ -177,7 +177,7 @@
 		}
 
 		&__teaser {
-			font-size: $ts-20;
+			font-size: var(--rvt-ts-20);
 			margin-top: var(--rvt-spacing-lg);
 		}
 
@@ -201,12 +201,12 @@
 		}
 
 		&--profile &__subtitle {
-			font-size: $ts-29;
+			font-size: var(--rvt-ts-29);
 		}
 
 		&--statement &__title,
 		&--feature &__title {
-			font-size: $ts-52;
+			font-size: var(--rvt-ts-52);
 		}
 
 		&--feature &__banner {
@@ -235,7 +235,7 @@
 		}
 
 		&--split &__title {
-			font-size: $ts-52;
+			font-size: var(--rvt-ts-52);
 		}
 
 		&--split &__inner {

--- a/src/sass/hero-area/_base.scss
+++ b/src/sass/hero-area/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-hero {
+.rvt-hero {
 	&__inner {
 		display: flex;
 		flex-direction: column;
@@ -94,7 +94,7 @@
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-hero {
+	.rvt-hero {
 		&__body {
 			flex-grow: 1;
 			max-width: 90ch;
@@ -167,7 +167,7 @@
 }
 
 @include mq($breakpoint-lg) {
-	.#{$prefix}-hero {
+	.rvt-hero {
 		&__inner {
 			flex-direction: row;
 		}
@@ -250,8 +250,8 @@
 }
 
 // Non-global theme specifics
-.#{$prefix}-hero,
-.#{$prefix}-hero {
+.rvt-hero,
+.rvt-hero {
 	&__quick-links {
 		padding: $spacing-lg;
 	}

--- a/src/sass/hero-area/_base.scss
+++ b/src/sass/hero-area/_base.scss
@@ -7,7 +7,7 @@
 	&__inner {
 		display: flex;
 		flex-direction: column;
-		gap: $spacing-lg;
+		gap: var(--rvt-spacing-lg);
 		@include container;
 	}
 
@@ -37,7 +37,7 @@
 	}
 
 	&__eyebrow + &__title {
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 	}
 
 	&__teaser > * {
@@ -46,13 +46,13 @@
 
 	&__title + &__actions,
 	&__teaser + &__actions {
-		margin-top: $spacing-md;
+		margin-top: var(--rvt-spacing-md);
 	}
 
 	&__actions {
 		display: flex;
 		flex-wrap: wrap;
-		gap: $spacing-sm;
+		gap: var(--rvt-spacing-sm);
 	}
 
 	&__actions > * {
@@ -69,17 +69,17 @@
 	}
 
 	&--statement &__banner {
-		margin-top: $spacing-lg;
+		margin-top: var(--rvt-spacing-lg);
 	}
 
 	&--feature &__banner {
-		margin-top: $spacing-xxl;
+		margin-top: var(--rvt-spacing-xxl);
 	}
 
 	&--feature &__banner {
 		display: flex;
 		flex-direction: column;
-		gap: $spacing-lg;
+		gap: var(--rvt-spacing-lg);
 		@include container();
 	}
 
@@ -101,7 +101,7 @@
 		}
 
 		&__actions {
-			gap: $spacing-md;
+			gap: var(--rvt-spacing-md);
 		}
 
 		&__callout {
@@ -173,17 +173,17 @@
 		}
 
 		&__eyebrow + &__title {
-			margin-top: $spacing-sm;
+			margin-top: var(--rvt-spacing-sm);
 		}
 
 		&__teaser {
 			font-size: $ts-20;
-			margin-top: $spacing-lg;
+			margin-top: var(--rvt-spacing-lg);
 		}
 
 		&__title + &__actions,
 		&__teaser + &__actions {
-			margin-top: $spacing-xl;
+			margin-top: var(--rvt-spacing-xl);
 		}
 
 		&__teaser > * {
@@ -191,7 +191,7 @@
 		}
 
 		&__teaser > * + * {
-			margin-top: $spacing-sm;
+			margin-top: var(--rvt-spacing-sm);
 		}
 
 		&__callout {
@@ -239,7 +239,7 @@
 		}
 
 		&--split &__inner {
-			gap: $spacing-xxl;
+			gap: var(--rvt-spacing-xxl);
 		}
 
 		&--split &__body,
@@ -253,6 +253,6 @@
 .rvt-hero,
 .rvt-hero {
 	&__quick-links {
-		padding: $spacing-lg;
+		padding: var(--rvt-spacing-lg);
 	}
 }

--- a/src/sass/hero-area/_base.scss
+++ b/src/sass/hero-area/_base.scss
@@ -14,21 +14,21 @@
 	&__eyebrow {
 		color: var(--rvt-color-theme-accent);
 		display: block;
-		font-family: $font-family-mono;
+		font-family: var(--rvt-font-family-mono);
 		font-size: var(--rvt-ts-14);
 		letter-spacing: 0.125rem;
 		text-transform: uppercase;
 	}
 
 	&__eyebrow > :not(.rvt-breadcrumbs) {
-		font-family: $font-family-sans;
+		font-family: var(--rvt-font-family-sans);
 		letter-spacing: normal;
 		text-transform: none;
 	}
 
 	&__title {
 		color: var(--rvt-color-theme-accent);
-		font-family: $font-family-condensed;
+		font-family: var(--rvt-font-family-condensed);
 		font-size: var(--rvt-ts-32);
 		font-variation-settings: "wdth" 140;
 		font-weight: 850;
@@ -85,7 +85,7 @@
 
 	&--profile &__subtitle {
 		color: var(--rvt-color-theme-accent);
-		font-family: $font-family-condensed;
+		font-family: var(--rvt-font-family-condensed);
 		font-size: var(--rvt-ts-20);
 		font-weight: var(--rvt-font-weight-black);
 		margin: 0;

--- a/src/sass/hero-area/_base.scss
+++ b/src/sass/hero-area/_base.scss
@@ -87,7 +87,7 @@
 		color: var(--rvt-color-theme-accent);
 		font-family: $font-family-condensed;
 		font-size: var(--rvt-ts-20);
-		font-weight: $font-weight-black;
+		font-weight: var(--rvt-font-weight-black);
 		margin: 0;
 		text-transform: uppercase;
 	}

--- a/src/sass/input-group/_base.scss
+++ b/src/sass/input-group/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:map";
 
-.#{$prefix}-input-group {
+.rvt-input-group {
 	display: flex;
 	flex-wrap: nowrap;
 	position: relative;
@@ -30,7 +30,7 @@
 		flex-grow: 1;
 		margin-left: -1px;
 
-		.#{$prefix}-button {
+		.rvt-button {
 			border-top-left-radius: 0;
 			border-bottom-left-radius: 0;
 			display: flex;
@@ -64,7 +64,7 @@
 	&__prepend {
 		margin-right: -1px;
 
-		.#{$prefix}-button {
+		.rvt-button {
 			border-bottom-right-radius: 0;
 			border-top-right-radius: 0;
 			display: flex;

--- a/src/sass/input-group/_base.scss
+++ b/src/sass/input-group/_base.scss
@@ -1,9 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:map";
-
 .rvt-input-group {
 	display: flex;
 	flex-wrap: nowrap;

--- a/src/sass/input-group/_base.scss
+++ b/src/sass/input-group/_base.scss
@@ -47,18 +47,18 @@
 		border: 1px solid var(--rvt-color-theme-text-strong);
 		display: flex;
 		height: 100%;
-		padding-left: $spacing-sm * 0.75;
-		padding-right: $spacing-sm * 0.75;
+		padding-left: calc(var(--rvt-spacing-sm) * 0.75);
+		padding-right: calc(var(--rvt-spacing-sm) * 0.75);
 	}
 
 	&__append &__text {
-		border-bottom-right-radius: $spacing-xxs;
-		border-top-right-radius: $spacing-xxs;
+		border-bottom-right-radius: var(--rvt-spacing-xxs);
+		border-top-right-radius: var(--rvt-spacing-xxs);
 	}
 
 	&__prepend &__text {
-		border-bottom-left-radius: $spacing-xxs;
-		border-top-left-radius: $spacing-xxs;
+		border-bottom-left-radius: var(--rvt-spacing-xxs);
+		border-top-left-radius: var(--rvt-spacing-xxs);
 	}
 
 	&__prepend {

--- a/src/sass/input-group/_base.scss
+++ b/src/sass/input-group/_base.scss
@@ -12,18 +12,18 @@
 	&__input:not(:first-child) {
 		border-bottom-left-radius: 0;
 		border-top-left-radius: 0;
-		z-index: map.get($z-index, "100");
+		z-index: var(--rvt-z-index-100);
 	}
 
 	&__input:not(:last-child) {
 		border-bottom-right-radius: 0;
 		border-top-right-radius: 0;
-		z-index: map.get($z-index, "100");
+		z-index: var(--rvt-z-index-100);
 	}
 
 	&__input:focus:not(:last-child),
 	&__input:focus:not(:first-child) {
-		z-index: map.get($z-index, "300");
+		z-index: var(--rvt-z-index-300);
 	}
 
 	&__append {
@@ -36,7 +36,7 @@
 			display: flex;
 			flex-grow: 1;
 			white-space: nowrap;
-			z-index: map.get($z-index, "200");
+			z-index: var(--rvt-z-index-200);
 		}
 	}
 
@@ -69,7 +69,7 @@
 			border-top-right-radius: 0;
 			display: flex;
 			white-space: nowrap;
-			z-index: map.get($z-index, "200");
+			z-index: var(--rvt-z-index-200);
 		}
 	}
 }

--- a/src/sass/inputs/_base.scss
+++ b/src/sass/inputs/_base.scss
@@ -1,9 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:math";
-
 .rvt {
 	&-input,
 	&-text-input,

--- a/src/sass/inputs/_base.scss
+++ b/src/sass/inputs/_base.scss
@@ -14,9 +14,9 @@
 		border-radius: 0;
 		color: inherit;
 		display: block;
-		height: $spacing-sm * 3;
+		height: calc(var(--rvt-spacing-sm) * 3);
 		line-height: 1.1;
-		padding: $spacing-xs;
+		padding: var(--rvt-spacing-xs);
 		width: 100%;
 
 		/**
@@ -32,7 +32,7 @@
 	}
 
 	&-textarea {
-		height: $spacing-base * 15;
+		height: calc(var(--rvt-spacing-base) * 15);
 		line-height: $line-height-base;
 		overflow: auto; // Remove scrollbar in IE
 	}
@@ -52,16 +52,16 @@
 		background-color: currentColor;
 		clip-path: path(var(--rvt-icon-chevron-down));
 		content: "";
-		height: $spacing-sm;
+		height: var(--rvt-spacing-sm);
 		pointer-events: none;
 		position: absolute;
-		right: $spacing-sm;
-		top: $spacing-sm;
-		width: $spacing-sm;
+		right: var(--rvt-spacing-sm);
+		top: var(--rvt-spacing-sm);
+		width: var(--rvt-spacing-sm);
 	}
 
 	&-select > select {
-		padding-right: $spacing-xl;
+		padding-right: var(--rvt-spacing-xl);
 	}
 
 	&-select > select::-ms-expand {
@@ -69,8 +69,8 @@
 	}
 
 	&-select > select[multiple] {
-		height: $spacing-xxl * 2;
-		padding-right: $spacing-xs;
+		height: calc(var(--rvt-spacing-xxl) * 2);
+		padding-right: var(--rvt-spacing-xs);
 	}
 
 	&-select:has(> select[multiple])::before {
@@ -94,7 +94,7 @@
 	}
 
 	&-label + * {
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 	}
 
 	&-fieldset {

--- a/src/sass/inputs/_base.scss
+++ b/src/sass/inputs/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:math";
 
-.#{$prefix} {
+.rvt {
 	&-input,
 	&-text-input,
 	&-textarea,

--- a/src/sass/inputs/_base.scss
+++ b/src/sass/inputs/_base.scss
@@ -90,7 +90,7 @@
 	&-label {
 		display: inline-block;
 		font-size: var(--rvt-ts-14);
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 	}
 
 	&-label + * {
@@ -105,7 +105,7 @@
 
 	&-legend {
 		display: block;
-		font-weight: $font-weight-regular;
+		font-weight: var(--rvt-font-weight-regular);
 		margin: 0;
 		width: 100%;
 	}

--- a/src/sass/inputs/_base.scss
+++ b/src/sass/inputs/_base.scss
@@ -89,7 +89,7 @@
 
 	&-label {
 		display: inline-block;
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		font-weight: $font-weight-medium;
 	}
 

--- a/src/sass/inputs/_base.scss
+++ b/src/sass/inputs/_base.scss
@@ -33,7 +33,7 @@
 
 	&-textarea {
 		height: calc(var(--rvt-spacing-base) * 15);
-		line-height: $line-height-base;
+		line-height: var(--rvt-line-height-base);
 		overflow: auto; // Remove scrollbar in IE
 	}
 

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -18,8 +18,8 @@
 	&__content {
 		// This stops some overflow issues if non-breaking content starts to overflow.
 		min-width: 0;
-		padding-bottom: $spacing-lg;
-		padding-top: $spacing-lg;
+		padding-bottom: var(--rvt-spacing-lg);
+		padding-top: var(--rvt-spacing-lg);
 	}
 
 	&__wrapper--single &__content {
@@ -27,8 +27,8 @@
 	}
 
 	&__break-out {
-		margin-left: -$spacing-md;
-		margin-right: -$spacing-md;
+		margin-left: -var(--rvt-spacing-md);
+		margin-right: -var(--rvt-spacing-md);
 
 		img {
 			width: 100%;
@@ -37,8 +37,8 @@
 
 	&__sidebar {
 		border-top: 1px solid var(--rvt-color-theme-ui);
-		padding-bottom: $spacing-lg;
-		padding-top: $spacing-lg;
+		padding-bottom: var(--rvt-spacing-lg);
+		padding-top: var(--rvt-spacing-lg);
 	}
 }
 
@@ -55,18 +55,18 @@
 			flex-grow: 1;
 			flex-shrink: 0;
 			max-width: $width-md;
-			padding-top: $spacing-xxl * 1.5;
+			padding-top: calc(var(--rvt-spacing-xxl) * 1.5);
 		}
 
 		&__content {
 			flex-grow: 1;
-			padding-bottom: $spacing-xxl;
-			padding-left: $spacing-xxl;
-			padding-top: $spacing-xxl * 1.5;
+			padding-bottom: var(--rvt-spacing-xxl);
+			padding-left: var(--rvt-spacing-xxl);
+			padding-top: calc(var(--rvt-spacing-xxl) * 1.5);
 		}
 
 		&__break-out {
-			margin-left: -$spacing-xxl;
+			margin-left: -var(--rvt-spacing-xxl);
 		}
 
 		&__break-out,
@@ -75,7 +75,7 @@
 		}
 
 		&__wrapper--single &__break-out {
-			margin-left: -$spacing-md;
+			margin-left: -var(--rvt-spacing-md);
 		}
 	}
 }
@@ -83,18 +83,18 @@
 @include mq($breakpoint-xl) {
 	.rvt-layout {
 		&__break-out {
-			margin-right: -$spacing-xxl;
+			margin-right: -var(--rvt-spacing-xxl);
 		}
 
 		&__wrapper--single &__break-out {
-			margin-left: -$spacing-xxl;
+			margin-left: -var(--rvt-spacing-xxl);
 		}
 
 		&__feature-slot {
 			float: right;
-			margin-bottom: $spacing-lg;
-			margin-left: $spacing-lg;
-			margin-right: -$spacing-xxl;
+			margin-bottom: var(--rvt-spacing-lg);
+			margin-left: var(--rvt-spacing-lg);
+			margin-right: -var(--rvt-spacing-xxl);
 			width: $width-xl;
 		}
 

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -51,10 +51,10 @@
 		&__sidebar {
 			border-right: 1px solid var(--rvt-color-theme-ui);
 			border-top: none;
-			flex-basis: $width-md;
+			flex-basis: var(--rvt-width-md);
 			flex-grow: 1;
 			flex-shrink: 0;
-			max-width: $width-md;
+			max-width: var(--rvt-width-md);
 			padding-top: calc(var(--rvt-spacing-xxl) * 1.5);
 		}
 
@@ -95,7 +95,7 @@
 			margin-bottom: var(--rvt-spacing-lg);
 			margin-left: var(--rvt-spacing-lg);
 			margin-right: -var(--rvt-spacing-xxl);
-			width: $width-xl;
+			width: var(--rvt-width-xl);
 		}
 
 		&__feature-slot + * {

--- a/src/sass/layout/_base.scss
+++ b/src/sass/layout/_base.scss
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 @use "../core" as *;
 
 .rvt-layout {

--- a/src/sass/layout/_container.scss
+++ b/src/sass/layout/_container.scss
@@ -7,7 +7,7 @@
 	@include container;
 
 	& + & {
-		margin-top: $spacing-md;
+		margin-top: var(--rvt-spacing-md);
 	}
 
 	&--fluid {

--- a/src/sass/layout/_grid.scss
+++ b/src/sass/layout/_grid.scss
@@ -5,10 +5,10 @@
 
 .rvt-grid {
 	display: grid;
-	gap: #{$spacing-md};
+	gap: #{var(--rvt-spacing-md)};
 
 	& + & {
-		margin-top: #{$spacing-md};
+		margin-top: #{var(--rvt-spacing-md)};
 	}
 }
 
@@ -48,7 +48,7 @@
 
 @include mq($breakpoint-lg) {
 	.rvt-grid {
-		gap: $spacing-lg;
+		gap: var(--rvt-spacing-lg);
 	}
 
 	// Make the sidebar layout variant kick in once

--- a/src/sass/layout/_grid.scss
+++ b/src/sass/layout/_grid.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-grid {
+.rvt-grid {
 	display: grid;
 	gap: #{$spacing-md};
 

--- a/src/sass/layout/_grid.scss
+++ b/src/sass/layout/_grid.scss
@@ -5,10 +5,10 @@
 
 .rvt-grid {
 	display: grid;
-	gap: #{var(--rvt-spacing-md)};
+	gap: var(--rvt-spacing-md);
 
 	& + & {
-		margin-top: #{var(--rvt-spacing-md)};
+		margin-top: var(--rvt-spacing-md);
 	}
 }
 

--- a/src/sass/layout/_layout-base.scss
+++ b/src/sass/layout/_layout-base.scss
@@ -16,16 +16,16 @@
 
 .rvt-layout-base {
 	display: grid;
-	gap: $spacing-md;
+	gap: var(--rvt-spacing-md);
 	@include container;
 
 	&__sidebar {
-		padding-block-start: $spacing-lg;
+		padding-block-start: var(--rvt-spacing-lg);
 	}
 
 	&__main {
-		padding-block-start: $spacing-md;
-		padding-block-end: $spacing-md;
+		padding-block-start: var(--rvt-spacing-md);
+		padding-block-end: var(--rvt-spacing-md);
 	}
 
 	&--single-column &__main {
@@ -36,7 +36,7 @@
 
 	&__breakout {
 		margin-left: calc(50% - 50vw);
-		padding-block: $spacing-xl;
+		padding-block: var(--rvt-spacing-xl);
 		width: 100vw;
 	}
 
@@ -52,19 +52,19 @@
 
 @include mq($breakpoint-lg) {
 	.rvt-layout-base {
-		grid-template-columns: ($spacing-sm * 18) 1fr;
-		gap: $spacing-xxl;
+		grid-template-columns: calc(var(--rvt-spacing-sm) * 18) 1fr;
+		gap: var(--rvt-spacing-xxl);
 
 		&__sidebar {
 			border-right: 1px solid var(--rvt-color-theme-ui);
 		}
 
 		&__sidebar {
-			padding-block: $spacing-xxl * 1.25;
+			padding-block: calc(var(--rvt-spacing-xxl) * 1.25);
 		}
 
 		&__main {
-			padding-block-end: $spacing-xxl;
+			padding-block-end: var(--rvt-spacing-xxl);
 		}
 
 		&__breakout {

--- a/src/sass/layout/_layout-base.scss
+++ b/src/sass/layout/_layout-base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-page {
+.rvt-page {
 	display: flex;
 	flex-direction: column;
 	height: 100vh;
@@ -14,7 +14,7 @@
 	}
 }
 
-.#{$prefix}-layout-base {
+.rvt-layout-base {
 	display: grid;
 	gap: $spacing-md;
 	@include container;
@@ -51,7 +51,7 @@
 }
 
 @include mq($breakpoint-lg) {
-	.#{$prefix}-layout-base {
+	.rvt-layout-base {
 		grid-template-columns: ($spacing-sm * 18) 1fr;
 		gap: $spacing-xxl;
 

--- a/src/sass/layout/_section.scss
+++ b/src/sass/layout/_section.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2024 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-section {
 	/* @link https://utopia.fyi/clamp/calculator?a=330,1260,24—88 */
 	--rvt-padding-section-fluid: clamp(1.5rem, 0.0806rem + 6.8817vw, 5.5rem);

--- a/src/sass/layout/_section.scss
+++ b/src/sass/layout/_section.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-section {
+.rvt-section {
 	/* @link https://utopia.fyi/clamp/calculator?a=330,1260,24—88 */
 	--rvt-padding-section-fluid: clamp(1.5rem, 0.0806rem + 6.8817vw, 5.5rem);
 	padding-block: var(--rvt-padding-section-fluid);
@@ -14,8 +14,8 @@
 	}
 }
 
-.#{$prefix}-section.rvt-theme-light + .#{$prefix}-section.rvt-theme-light,
-.#{$prefix}-section.rvt-theme-crimson + .#{$prefix}-section.rvt-theme-crimson,
-.#{$prefix}-section.rvt-theme-dark + .#{$prefix}-section.rvt-theme-dark {
+.rvt-section.rvt-theme-light + .rvt-section.rvt-theme-light,
+.rvt-section.rvt-theme-crimson + .rvt-section.rvt-theme-crimson,
+.rvt-section.rvt-theme-dark + .rvt-section.rvt-theme-dark {
 	padding-block-start: 0;
 }

--- a/src/sass/link-hub/_base.scss
+++ b/src/sass/link-hub/_base.scss
@@ -46,14 +46,14 @@
 	}
 
 	&__text {
-		font-size: $ts-20;
+		font-size: var(--rvt-ts-20);
 		font-weight: $font-weight-regular;
 		line-height: 1.25;
 	}
 
 	&__description {
 		color: var(--rvt-color-theme-text);
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		margin-top: var(--rvt-spacing-xs);
 	}
 

--- a/src/sass/link-hub/_base.scss
+++ b/src/sass/link-hub/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-link-hub {
+.rvt-link-hub {
 	display: grid;
 	grid-gap: 0 $spacing-md * 2;
 	grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));

--- a/src/sass/link-hub/_base.scss
+++ b/src/sass/link-hub/_base.scss
@@ -47,7 +47,7 @@
 
 	&__text {
 		font-size: var(--rvt-ts-20);
-		font-weight: $font-weight-regular;
+		font-weight: var(--rvt-font-weight-regular);
 		line-height: 1.25;
 	}
 

--- a/src/sass/link-hub/_base.scss
+++ b/src/sass/link-hub/_base.scss
@@ -5,7 +5,7 @@
 
 .rvt-link-hub {
 	display: grid;
-	grid-gap: 0 $spacing-md * 2;
+	grid-gap: 0 calc(var(--rvt-spacing-md) * 2);
 	grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
 	list-style: none;
 	padding: 0;
@@ -17,9 +17,9 @@
 
 	&__link {
 		display: block;
-		padding-bottom: $spacing-sm;
-		padding-right: $spacing-xl;
-		padding-top: $spacing-sm;
+		padding-bottom: var(--rvt-spacing-sm);
+		padding-right: var(--rvt-spacing-xl);
+		padding-top: var(--rvt-spacing-sm);
 		position: relative;
 		text-decoration: none;
 	}
@@ -29,11 +29,11 @@
 		content: "";
 		clip-path: path(var(--rvt-icon-arrow-right));
 		display: inline-block;
-		height: $spacing-sm;
+		height: var(--rvt-spacing-sm);
 		position: absolute;
-		right: $spacing-sm;
-		top: $spacing-sm * 1.25;
-		width: $spacing-sm;
+		right: var(--rvt-spacing-sm);
+		top: calc(var(--rvt-spacing-sm) * 1.25);
+		width: var(--rvt-spacing-sm);
 	}
 
 	&__text,
@@ -54,7 +54,7 @@
 	&__description {
 		color: var(--rvt-color-theme-text);
 		font-size: $ts-14;
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 	}
 
 	&--stacked {

--- a/src/sass/link-hub/_base.scss
+++ b/src/sass/link-hub/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2022 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-link-hub {
 	display: grid;
 	grid-gap: 0 calc(var(--rvt-spacing-md) * 2);

--- a/src/sass/links/_base.scss
+++ b/src/sass/links/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 
 a,
-.#{$prefix}-link {
+.rvt-link {
 	color: var(--rvt-color-theme-accent);
 
 	&:hover,
@@ -13,14 +13,14 @@ a,
 	}
 }
 
-.#{$prefix}-link--bold,
-.#{$prefix}-link-bold {
+.rvt-link--bold,
+.rvt-link-bold {
 	font-weight: $font-weight-bold;
 }
 
-.#{$prefix}-link--bold,
-.#{$prefix}-link-bold,
-.#{$prefix}-link-plain {
+.rvt-link--bold,
+.rvt-link-bold,
+.rvt-link-plain {
 	text-decoration: none;
 
 	&:hover {
@@ -28,8 +28,8 @@ a,
 	}
 }
 
-.#{$prefix}-link-cta,
-.#{$prefix}-link--cta {
+.rvt-link-cta,
+.rvt-link--cta {
 	display: inline-block;
 	font-weight: $font-weight-medium;
 	text-decoration: none;

--- a/src/sass/links/_base.scss
+++ b/src/sass/links/_base.scss
@@ -39,15 +39,15 @@ a,
 		clip-path: path(var(--rvt-icon-arrow-right));
 		content: "";
 		display: inline-block;
-		height: $spacing-sm;
-		margin-left: $spacing-xs;
+		height: var(--rvt-spacing-sm);
+		margin-left: var(--rvt-spacing-xs);
 		position: relative;
-		top: $spacing-xxs * 0.8;
+		top: calc(var(--rvt-spacing-xxs) * 0.8);
 		transition: all 0.2s ease;
-		width: $spacing-sm;
+		width: var(--rvt-spacing-sm);
 	}
 
 	&:hover::after {
-		transform: translateX($spacing-xxs);
+		transform: translateX(var(--rvt-spacing-xxs));
 	}
 }

--- a/src/sass/links/_base.scss
+++ b/src/sass/links/_base.scss
@@ -15,7 +15,7 @@ a,
 
 .rvt-link--bold,
 .rvt-link-bold {
-	font-weight: $font-weight-bold;
+	font-weight: var(--rvt-font-weight-bold);
 }
 
 .rvt-link--bold,
@@ -31,7 +31,7 @@ a,
 .rvt-link-cta,
 .rvt-link--cta {
 	display: inline-block;
-	font-weight: $font-weight-medium;
+	font-weight: var(--rvt-font-weight-medium);
 	text-decoration: none;
 
 	&::after {

--- a/src/sass/links/_base.scss
+++ b/src/sass/links/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 a,
 .rvt-link {
 	color: var(--rvt-color-theme-accent);

--- a/src/sass/list-hub/_base.scss
+++ b/src/sass/list-hub/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:math";
 
-.#{$prefix}-list-hub {
+.rvt-list-hub {
 	background-color: transparent;
 
 	&__title {

--- a/src/sass/list-hub/_base.scss
+++ b/src/sass/list-hub/_base.scss
@@ -9,7 +9,7 @@
 
 	&__title {
 		color: var(--rvt-color-theme-accent);
-		font-family: $font-family-mono;
+		font-family: var(--rvt-font-family-mono);
 		font-size: var(--rvt-ts-12);
 		letter-spacing: math.div(var(--rvt-spacing-xxs), 2);
 		text-transform: uppercase;

--- a/src/sass/list-hub/_base.scss
+++ b/src/sass/list-hub/_base.scss
@@ -10,7 +10,7 @@
 	&__title {
 		color: var(--rvt-color-theme-accent);
 		font-family: $font-family-mono;
-		font-size: $ts-12;
+		font-size: var(--rvt-ts-12);
 		letter-spacing: math.div(var(--rvt-spacing-xxs), 2);
 		text-transform: uppercase;
 	}
@@ -46,7 +46,7 @@
 		align-items: center;
 		color: var(--rvt-color-theme-text-strong);
 		display: flex;
-		font-size: $ts-18;
+		font-size: var(--rvt-ts-18);
 		font-variation-settings:
 			"wdth" 135,
 			"YTLC" 540;
@@ -115,7 +115,7 @@
 		> ul li,
 		> ol li,
 		> p {
-			font-size: $ts-16;
+			font-size: var(--rvt-ts-16);
 		}
 	}
 

--- a/src/sass/list-hub/_base.scss
+++ b/src/sass/list-hub/_base.scss
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 @use "../core" as *;
-@use "sass:math";
 
 .rvt-list-hub {
 	background-color: transparent;
@@ -11,7 +10,7 @@
 		color: var(--rvt-color-theme-accent);
 		font-family: var(--rvt-font-family-mono);
 		font-size: var(--rvt-ts-12);
-		letter-spacing: math.div(var(--rvt-spacing-xxs), 2);
+		letter-spacing: calc(var(--rvt-spacing-xxs) / 2);
 		text-transform: uppercase;
 	}
 

--- a/src/sass/list-hub/_base.scss
+++ b/src/sass/list-hub/_base.scss
@@ -50,7 +50,7 @@
 		font-variation-settings:
 			"wdth" 135,
 			"YTLC" 540;
-		font-weight: $font-weight-bold;
+		font-weight: var(--rvt-font-weight-bold);
 		gap: var(--rvt-spacing-xs);
 		line-height: 1.3;
 		position: relative;

--- a/src/sass/list-hub/_base.scss
+++ b/src/sass/list-hub/_base.scss
@@ -11,7 +11,7 @@
 		color: var(--rvt-color-theme-accent);
 		font-family: $font-family-mono;
 		font-size: $ts-12;
-		letter-spacing: math.div($spacing-xxs, 2);
+		letter-spacing: math.div(var(--rvt-spacing-xxs), 2);
 		text-transform: uppercase;
 	}
 
@@ -20,14 +20,14 @@
 		margin-bottom: 0;
 		// Magic number to help with visual alignment when
 		// list hub is first element in a layout with a sidebar
-		margin-top: $spacing-xs * 1.5;
+		margin-top: calc(var(--rvt-spacing-xs) * 1.5);
 		padding-left: 0;
 	}
 
 	&__item {
 		border-top: 1px solid var(--rvt-color-theme-ui);
-		padding-block: $spacing-sm;
-		padding-inline: $spacing-sm;
+		padding-block: var(--rvt-spacing-sm);
+		padding-inline: var(--rvt-spacing-sm);
 	}
 
 	// If the item is not a link remove eyebrow padding for proper alignment.
@@ -38,7 +38,7 @@
 	&__eyebrow {
 		@include eyebrow;
 		color: var(--rvt-color-theme-accent);
-		padding-inline-start: $spacing-md;
+		padding-inline-start: var(--rvt-spacing-md);
 	}
 
 	&__link,
@@ -51,7 +51,7 @@
 			"wdth" 135,
 			"YTLC" 540;
 		font-weight: $font-weight-bold;
-		gap: $spacing-xs;
+		gap: var(--rvt-spacing-xs);
 		line-height: 1.3;
 		position: relative;
 		text-decoration: none;
@@ -88,15 +88,15 @@
 		clip-path: path(var(--icon));
 		content: "";
 		flex-shrink: 0;
-		height: $spacing-sm;
+		height: var(--rvt-spacing-sm);
 		position: relative;
 		transform: rotate(var(--rotate));
 		transition: all 0.2s ease;
-		width: $spacing-sm;
+		width: var(--rvt-spacing-sm);
 	}
 
 	&__link:hover::before {
-		transform: rotate(var(--rotate)) translateY($spacing-xxs);
+		transform: rotate(var(--rotate)) translateY(var(--rvt-spacing-xxs));
 	}
 
 	&__item-title + &__content {
@@ -105,8 +105,8 @@
 
 	&__content {
 		color: var(--rvt-color-theme-text);
-		margin-block-start: $spacing-xs;
-		padding-inline-start: $spacing-md;
+		margin-block-start: var(--rvt-spacing-xs);
+		padding-inline-start: var(--rvt-spacing-md);
 
 		> ul:not([class]) {
 			list-style-type: disc;
@@ -124,6 +124,6 @@
 	}
 
 	&__content > * + * {
-		margin-top: $spacing-sm;
+		margin-top: var(--rvt-spacing-sm);
 	}
 }

--- a/src/sass/lists/_base.scss
+++ b/src/sass/lists/_base.scss
@@ -3,44 +3,44 @@
 
 @use "../core" as *;
 
-.#{$prefix}-list,
-.#{$prefix}-list-inline,
-.#{$prefix}-list-plain {
+.rvt-list,
+.rvt-list-inline,
+.rvt-list-plain {
 	display: flex;
 	gap: $spacing-xs $spacing-sm;
 	margin: $spacing-xs 0 0 0;
 }
 
-.#{$prefix}-list,
-.#{$prefix}-list-plain {
+.rvt-list,
+.rvt-list-plain {
 	flex-direction: column;
 }
 
-.#{$prefix}-list-inline,
-.#{$prefix}-list-plain {
+.rvt-list-inline,
+.rvt-list-plain {
 	// Equivalent to `list-style: none`, but retains list semantics in VoiceOver.
 	list-style: "";
 	padding-left: 0;
 }
 
-.#{$prefix}-list,
-.#{$prefix}-list-plain .#{$prefix}-list-plain {
+.rvt-list,
+.rvt-list-plain .rvt-list-plain {
 	padding-left: $spacing-lg;
 }
 
-.#{$prefix}-list-inline {
+.rvt-list-inline {
 	flex-direction: row;
 	flex-wrap: wrap;
 }
 
-.#{$prefix}-list-reset {
+.rvt-list-reset {
 	list-style: "";
 	margin-top: 0;
 	margin-bottom: 0;
 	padding-left: 0;
 }
 
-.#{$prefix}-list-description {
+.rvt-list-description {
 	margin: 0;
 
 	:where(dt) {

--- a/src/sass/lists/_base.scss
+++ b/src/sass/lists/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-list,
 .rvt-list-inline,
 .rvt-list-plain {

--- a/src/sass/lists/_base.scss
+++ b/src/sass/lists/_base.scss
@@ -7,8 +7,8 @@
 .rvt-list-inline,
 .rvt-list-plain {
 	display: flex;
-	gap: $spacing-xs $spacing-sm;
-	margin: $spacing-xs 0 0 0;
+	gap: var(--rvt-spacing-xs) var(--rvt-spacing-sm);
+	margin: var(--rvt-spacing-xs) 0 0 0;
 }
 
 .rvt-list,
@@ -25,7 +25,7 @@
 
 .rvt-list,
 .rvt-list-plain .rvt-list-plain {
-	padding-left: $spacing-lg;
+	padding-left: var(--rvt-spacing-lg);
 }
 
 .rvt-list-inline {
@@ -45,7 +45,7 @@
 
 	:where(dt) {
 		font-weight: $font-weight-medium;
-		margin-top: $spacing-sm;
+		margin-top: var(--rvt-spacing-sm);
 	}
 
 	:where(dt + dt) {

--- a/src/sass/lists/_base.scss
+++ b/src/sass/lists/_base.scss
@@ -44,7 +44,7 @@
 	margin: 0;
 
 	:where(dt) {
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 		margin-top: var(--rvt-spacing-sm);
 	}
 

--- a/src/sass/loading-indicator/_base.scss
+++ b/src/sass/loading-indicator/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-loader {
+.rvt-loader {
 	animation: 0.8s linear infinite loader;
 	display: inline-block;
 	border: 0.2rem solid transparent;

--- a/src/sass/loading-indicator/_base.scss
+++ b/src/sass/loading-indicator/_base.scss
@@ -11,9 +11,9 @@
 	border-right-color: var(--rvt-color-theme-accent);
 	border-top-color: var(--rvt-color-theme-accent);
 	border-radius: 50%;
-	height: $spacing-sm * 1.25;
+	height: calc(var(--rvt-spacing-sm) * 1.25);
 	position: relative;
-	width: $spacing-sm * 1.25;
+	width: calc(var(--rvt-spacing-sm) * 1.25);
 
 	&--reverse {
 		border-bottom-color: var(--rvt-color-theme-background);
@@ -22,45 +22,45 @@
 	}
 
 	&--xxs {
-		border-width: $spacing-sm * 0.125;
-		height: $spacing-sm;
-		width: $spacing-sm;
+		border-width: calc(var(--rvt-spacing-sm) * 0.125);
+		height: var(--rvt-spacing-sm);
+		width: var(--rvt-spacing-sm);
 	}
 
 	&--xs {
-		border-width: $spacing-sm * (0.125 * 1.25);
-		height: $spacing-sm * 1.25;
-		width: $spacing-sm * 1.25;
+		border-width: calc(var(--rvt-spacing-sm) * 0.125 * 1.25);
+		height: calc(var(--rvt-spacing-sm) * 1.25);
+		width: calc(var(--rvt-spacing-sm) * 1.25);
 	}
 
 	&--sm {
-		border-width: $spacing-sm * (0.125 * 1.75);
-		height: $spacing-sm * 1.75;
-		width: $spacing-sm * 1.75;
+		border-width: calc(var(--rvt-spacing-sm) * 0.125 * 1.75);
+		height: calc(var(--rvt-spacing-sm) * 1.75);
+		width: calc(var(--rvt-spacing-sm) * 1.75);
 	}
 
 	&--md {
-		border-width: $spacing-sm * (0.125 * 2);
-		height: $spacing-sm * 2;
-		width: $spacing-sm * 2;
+		border-width: calc(var(--rvt-spacing-sm) * 0.125 * 2);
+		height: calc(var(--rvt-spacing-sm) * 2);
+		width: calc(var(--rvt-spacing-sm) * 2);
 	}
 
 	&--lg {
-		border-width: $spacing-sm * (0.125 * 2.75);
-		height: $spacing-sm * 2.75;
-		width: $spacing-sm * 2.75;
+		border-width: calc(var(--rvt-spacing-sm) * 0.125 * 2.75);
+		height: calc(var(--rvt-spacing-sm) * 2.75);
+		width: calc(var(--rvt-spacing-sm) * 2.75);
 	}
 
 	&--xl {
-		border-width: $spacing-sm * (0.125 * 3.25);
-		height: $spacing-sm * 3.25;
-		width: $spacing-sm * 3.25;
+		border-width: calc(var(--rvt-spacing-sm) * 0.125 * 3.25);
+		height: calc(var(--rvt-spacing-sm) * 3.25);
+		width: calc(var(--rvt-spacing-sm) * 3.25);
 	}
 
 	&--xxl {
-		border-width: $spacing-sm * (0.125 * 4);
-		height: $spacing-sm * 4;
-		width: $spacing-sm * 4;
+		border-width: calc(var(--rvt-spacing-sm) * 0.125 * 4);
+		height: calc(var(--rvt-spacing-sm) * 4);
+		width: calc(var(--rvt-spacing-sm) * 4);
 	}
 }
 

--- a/src/sass/loading-indicator/_base.scss
+++ b/src/sass/loading-indicator/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-loader {
 	animation: 0.8s linear infinite loader;
 	display: inline-block;

--- a/src/sass/media-hub/_base.scss
+++ b/src/sass/media-hub/_base.scss
@@ -16,24 +16,24 @@
 		-moz-osx-font-smoothing: grayscale;
 
 		a {
-			text-decoration-thickness: $spacing-xs;
-			text-underline-offset: $spacing-xs;
+			text-decoration-thickness: var(--rvt-spacing-xs);
+			text-underline-offset: var(--rvt-spacing-xs);
 		}
 
 		a:hover {
-			text-decoration-thickness: $spacing-xs;
-			text-underline-offset: $spacing-xs;
+			text-decoration-thickness: var(--rvt-spacing-xs);
+			text-underline-offset: var(--rvt-spacing-xs);
 			transition: 0.2s all ease-in-out;
 		}
 	}
 
 	&__teaser + &__media {
-		margin-top: $spacing-xxl;
+		margin-top: var(--rvt-spacing-xxl);
 	}
 
 	&__media {
 		display: grid;
-		gap: $spacing-xs;
+		gap: var(--rvt-spacing-xs);
 		grid-template-columns: repeat(6, 1fr);
 		grid-template-rows: auto auto;
 		position: relative;

--- a/src/sass/media-hub/_base.scss
+++ b/src/sass/media-hub/_base.scss
@@ -7,7 +7,7 @@
 	&__teaser {
 		color: var(--rvt-color-theme-text-accent);
 		font-family: $font-family-serif;
-		font-size: $ts-46;
+		font-size: var(--rvt-ts-46);
 		letter-spacing: 0.01rem;
 		line-height: $line-height-tight;
 		margin: 0;

--- a/src/sass/media-hub/_base.scss
+++ b/src/sass/media-hub/_base.scss
@@ -9,7 +9,7 @@
 		font-family: var(--rvt-font-family-serif);
 		font-size: var(--rvt-ts-46);
 		letter-spacing: 0.01rem;
-		line-height: $line-height-tight;
+		line-height: var(--rvt-line-height-tight);
 		margin: 0;
 		max-width: 40ch;
 		-webkit-font-smoothing: antialiased;

--- a/src/sass/media-hub/_base.scss
+++ b/src/sass/media-hub/_base.scss
@@ -6,7 +6,7 @@
 .rvt-media-hub {
 	&__teaser {
 		color: var(--rvt-color-theme-text-accent);
-		font-family: $font-family-serif;
+		font-family: var(--rvt-font-family-serif);
 		font-size: var(--rvt-ts-46);
 		letter-spacing: 0.01rem;
 		line-height: $line-height-tight;

--- a/src/sass/media-hub/_base.scss
+++ b/src/sass/media-hub/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-media-hub {
+.rvt-media-hub {
 	&__teaser {
 		color: var(--rvt-color-theme-text-accent);
 		font-family: $font-family-serif;

--- a/src/sass/media-hub/_base.scss
+++ b/src/sass/media-hub/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2025 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-media-hub {
 	&__teaser {
 		color: var(--rvt-color-theme-text-accent);

--- a/src/sass/pagination/_base.scss
+++ b/src/sass/pagination/_base.scss
@@ -5,7 +5,7 @@
 @use "sass:map";
 @use "sass:math";
 
-.#{$prefix}-pagination {
+.rvt-pagination {
 	display: flex;
 	gap: $spacing-xs;
 	list-style: none;

--- a/src/sass/pagination/_base.scss
+++ b/src/sass/pagination/_base.scss
@@ -51,7 +51,7 @@
 			min-width: var(--rvt-spacing-xl);
 			padding: var(--rvt-spacing-xs);
 			text-decoration: none;
-			z-index: map.get($z-index, "100");
+			z-index: var(--rvt-z-index-100);
 		}
 
 		a:hover {
@@ -63,7 +63,7 @@
 		a:focus,
 		a[aria-current="page"]:focus {
 			border-radius: inherit;
-			z-index: map.get($z-index, "1000");
+			z-index: var(--rvt-z-index-1000);
 		}
 
 		a[aria-current="page"] {

--- a/src/sass/pagination/_base.scss
+++ b/src/sass/pagination/_base.scss
@@ -1,10 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:map";
-@use "sass:math";
-
 .rvt-pagination {
 	display: flex;
 	gap: var(--rvt-spacing-xs);

--- a/src/sass/pagination/_base.scss
+++ b/src/sass/pagination/_base.scss
@@ -7,7 +7,7 @@
 
 .rvt-pagination {
 	display: flex;
-	gap: $spacing-xs;
+	gap: var(--rvt-spacing-xs);
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -37,26 +37,26 @@
 
 		> *:not(a) {
 			color: var(--rvt-color-theme-text);
-			min-height: $spacing-xl;
-			min-width: $spacing-xl;
-			padding: $spacing-xs $spacing-sm;
+			min-height: var(--rvt-spacing-xl);
+			min-width: var(--rvt-spacing-xl);
+			padding: var(--rvt-spacing-xs) var(--rvt-spacing-sm);
 		}
 
 		a {
 			color: var(--rvt-color-theme-text);
 			display: flex;
 			flex-grow: 1;
-			gap: $spacing-xxs;
-			min-height: $spacing-xl;
-			min-width: $spacing-xl;
-			padding: $spacing-xs;
+			gap: var(--rvt-spacing-xxs);
+			min-height: var(--rvt-spacing-xl);
+			min-width: var(--rvt-spacing-xl);
+			padding: var(--rvt-spacing-xs);
 			text-decoration: none;
 			z-index: map.get($z-index, "100");
 		}
 
 		a:hover {
 			background-color: var(--rvt-color-theme-background-strong);
-			box-shadow: inset 0 ($spacing-xxs * -0.5) 0 var(--rvt-color-theme-accent);
+			box-shadow: inset 0 calc(var(--rvt-spacing-xxs) * -0.5) 0 var(--rvt-color-theme-accent);
 			color: var(--rvt-color-theme-accent);
 		}
 

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -44,7 +44,7 @@
 	}
 
 	&__title {
-		font-weight: $font-weight-bold;
+		font-weight: var(--rvt-font-weight-bold);
 	}
 }
 

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -52,7 +52,7 @@
 	.rvt-quote {
 		&__text {
 			font-size: var(--rvt-ts-52);
-			line-height: $line-height-tight;
+			line-height: var(--rvt-line-height-tight);
 		}
 	}
 }

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -21,7 +21,7 @@
 
 	&__text {
 		color: var(--rvt-color-theme-accent);
-		font-family: $font-family-condensed;
+		font-family: var(--rvt-font-family-condensed);
 		font-weight: 850;
 		font-variation-settings: "wdth" 140;
 		font-size: var(--rvt-ts-26);

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -24,7 +24,7 @@
 		font-family: $font-family-condensed;
 		font-weight: 850;
 		font-variation-settings: "wdth" 140;
-		font-size: $ts-26;
+		font-size: var(--rvt-ts-26);
 		margin: 0;
 		text-transform: uppercase;
 
@@ -51,7 +51,7 @@
 @include mq($breakpoint-md) {
 	.rvt-quote {
 		&__text {
-			font-size: $ts-52;
+			font-size: var(--rvt-ts-52);
 			line-height: $line-height-tight;
 		}
 	}

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -1,7 +1,7 @@
 @use "../core" as *;
 @use "sass:math";
 
-.#{$prefix}-quote {
+.rvt-quote {
 	display: flex;
 	flex-direction: column;
 	gap: 1rem;
@@ -49,7 +49,7 @@
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-quote {
+	.rvt-quote {
 		&__text {
 			font-size: $ts-52;
 			line-height: $line-height-tight;

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -1,5 +1,7 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 @use "../core" as *;
-@use "sass:math";
 
 .rvt-quote {
 	display: flex;

--- a/src/sass/quote/_base.scss
+++ b/src/sass/quote/_base.scss
@@ -11,8 +11,8 @@
 		clip-path: path(var(--rvt-icon-quote-open));
 		display: block;
 		content: "";
-		height: math.div(50, 16) * $spacing-sm;
-		width: math.div(65, 16) * $spacing-sm;
+		height: calc(50/16 * var(--rvt-spacing-sm));
+		width: calc(65/16 * var(--rvt-spacing-sm));
 	}
 
 	&--image::before {

--- a/src/sass/radios/_base.scss
+++ b/src/sass/radios/_base.scss
@@ -87,6 +87,6 @@ $padding: math.div(3rem, 16);
 
 	&__description {
 		display: block;
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 	}
 }

--- a/src/sass/radios/_base.scss
+++ b/src/sass/radios/_base.scss
@@ -1,12 +1,8 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:math";
-
-$padding: math.div(3rem, 16);
-
 .rvt-radio {
+	--padding: calc(3rem / 16);
 	display: inline-block;
 	padding-left: var(--rvt-spacing-lg);
 	position: relative;
@@ -45,15 +41,15 @@ $padding: math.div(3rem, 16);
 
 	input[type="radio"] ~ label::before {
 		background-color: var(--rvt-color-theme-background);
-		border: math.div(var(--rvt-spacing-xxs), 4) solid var(--rvt-color-theme-text-strong);
+		border: calc(var(--rvt-spacing-xxs) / 4) solid var(--rvt-color-theme-text-strong);
 		border-radius: var(--rvt-spacing-sm);
-		box-shadow: inset 0 0 0 $padding var(--rvt-color-theme-background);
+		box-shadow: inset 0 0 0 var(--padding) var(--rvt-color-theme-background);
 		content: "";
 		display: inline-block;
 		height: var(--rvt-spacing-sm);
-		left: math.div(3rem, 16);
+		left: calc(3rem / 16);
 		position: absolute;
-		top: math.div(3rem, 16);
+		top: calc(3rem / 16);
 		width: var(--rvt-spacing-sm);
 	}
 
@@ -63,8 +59,8 @@ $padding: math.div(3rem, 16);
 	}
 
 	input[type="radio"]:focus ~ label::before {
-		outline: math.div(2rem, 16) solid var(--rvt-color-theme-accent-strong);
-		outline-offset: math.div(2rem, 16);
+		outline: calc(2rem / 16) solid var(--rvt-color-theme-accent-strong);
+		outline-offset: calc(2rem / 16);
 	}
 
 	input[type="radio"]:disabled {
@@ -78,7 +74,7 @@ $padding: math.div(3rem, 16);
 	input[type="radio"]:disabled ~ label::before {
 		background-color: var(--rvt-color-theme-background-strong);
 		border-color: var(--rvt-color-theme-ui-strong);
-		box-shadow: inset 0 0 0 $padding var(--rvt-color-theme-background-strong);
+		box-shadow: inset 0 0 0 var(--padding) var(--rvt-color-theme-background-strong);
 	}
 
 	input[type="radio"]:disabled:checked ~ label::before {

--- a/src/sass/radios/_base.scss
+++ b/src/sass/radios/_base.scss
@@ -6,7 +6,7 @@
 
 $padding: math.div(3rem, 16);
 
-.#{$prefix}-radio {
+.rvt-radio {
 	display: inline-block;
 	padding-left: $spacing-lg;
 	position: relative;

--- a/src/sass/radios/_base.scss
+++ b/src/sass/radios/_base.scss
@@ -40,7 +40,7 @@ $padding: math.div(3rem, 16);
 	input[type="radio"] ~ label {
 		cursor: pointer;
 		display: inline-block;
-		line-height: $line-height-base;
+		line-height: var(--rvt-line-height-base);
 	}
 
 	input[type="radio"] ~ label::before {

--- a/src/sass/radios/_base.scss
+++ b/src/sass/radios/_base.scss
@@ -8,26 +8,26 @@ $padding: math.div(3rem, 16);
 
 .rvt-radio {
 	display: inline-block;
-	padding-left: $spacing-lg;
+	padding-left: var(--rvt-spacing-lg);
 	position: relative;
 
 	input[type="radio"] {
 		cursor: pointer;
-		height: $spacing-md;
+		height: var(--rvt-spacing-md);
 		left: 0;
 		margin: 0;
 		opacity: 0;
 		position: absolute;
 		top: 0;
-		width: $spacing-lg;
+		width: var(--rvt-spacing-lg);
 	}
 
 	&--sr-only-label {
-		padding-left: $spacing-md;
+		padding-left: var(--rvt-spacing-md);
 	}
 
 	&--sr-only-label input[type="radio"] {
-		width: $spacing-md;
+		width: var(--rvt-spacing-md);
 	}
 
 	&--sr-only-label input[type="radio"] ~ label {
@@ -45,16 +45,16 @@ $padding: math.div(3rem, 16);
 
 	input[type="radio"] ~ label::before {
 		background-color: var(--rvt-color-theme-background);
-		border: math.div($spacing-xxs, 4) solid var(--rvt-color-theme-text-strong);
-		border-radius: $spacing-sm;
+		border: math.div(var(--rvt-spacing-xxs), 4) solid var(--rvt-color-theme-text-strong);
+		border-radius: var(--rvt-spacing-sm);
 		box-shadow: inset 0 0 0 $padding var(--rvt-color-theme-background);
 		content: "";
 		display: inline-block;
-		height: $spacing-sm;
+		height: var(--rvt-spacing-sm);
 		left: math.div(3rem, 16);
 		position: absolute;
 		top: math.div(3rem, 16);
-		width: $spacing-sm;
+		width: var(--rvt-spacing-sm);
 	}
 
 	input[type="radio"]:checked ~ label::before {

--- a/src/sass/section-intro/_base.scss
+++ b/src/sass/section-intro/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-section-intro {
+.rvt-section-intro {
 	margin-inline: auto;
 	max-width: $breakpoint-md;
 	text-align: center;
@@ -82,7 +82,7 @@
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-section-intro {
+	.rvt-section-intro {
 		&__title {
 			font-size: $ts-41;
 		}
@@ -94,7 +94,7 @@
 }
 
 @include mq($breakpoint-lg) {
-	.#{$prefix}-section-intro {
+	.rvt-section-intro {
 		&--teaser {
 			display: flex;
 			flex-wrap: wrap;

--- a/src/sass/section-intro/_base.scss
+++ b/src/sass/section-intro/_base.scss
@@ -11,7 +11,7 @@
 	&__title {
 		color: var(--rvt-color-theme-accent);
 		font-family: $font-family-condensed;
-		font-size: $ts-36;
+		font-size: var(--rvt-ts-36);
 		font-weight: $font-weight-black;
 		line-height: $line-height-tight;
 		margin-top: var(--rvt-spacing-sm);
@@ -27,7 +27,7 @@
 
 	&__teaser {
 		color: var(--rvt-color-theme-text);
-		font-size: $ts-16;
+		font-size: var(--rvt-ts-16);
 		margin-top: var(--rvt-spacing-sm);
 
 		> * {
@@ -84,11 +84,11 @@
 @include mq($breakpoint-md) {
 	.rvt-section-intro {
 		&__title {
-			font-size: $ts-41;
+			font-size: var(--rvt-ts-41);
 		}
 
 		&__teaser {
-			font-size: $ts-20;
+			font-size: var(--rvt-ts-20);
 		}
 	}
 }

--- a/src/sass/section-intro/_base.scss
+++ b/src/sass/section-intro/_base.scss
@@ -12,7 +12,7 @@
 		color: var(--rvt-color-theme-accent);
 		font-family: $font-family-condensed;
 		font-size: var(--rvt-ts-36);
-		font-weight: $font-weight-black;
+		font-weight: var(--rvt-font-weight-black);
 		line-height: $line-height-tight;
 		margin-top: var(--rvt-spacing-sm);
 		text-transform: uppercase;

--- a/src/sass/section-intro/_base.scss
+++ b/src/sass/section-intro/_base.scss
@@ -10,7 +10,7 @@
 
 	&__title {
 		color: var(--rvt-color-theme-accent);
-		font-family: $font-family-condensed;
+		font-family: var(--rvt-font-family-condensed);
 		font-size: var(--rvt-ts-36);
 		font-weight: var(--rvt-font-weight-black);
 		line-height: $line-height-tight;

--- a/src/sass/section-intro/_base.scss
+++ b/src/sass/section-intro/_base.scss
@@ -13,7 +13,7 @@
 		font-family: var(--rvt-font-family-condensed);
 		font-size: var(--rvt-ts-36);
 		font-weight: var(--rvt-font-weight-black);
-		line-height: $line-height-tight;
+		line-height: var(--rvt-line-height-tight);
 		margin-top: var(--rvt-spacing-sm);
 		text-transform: uppercase;
 		-webkit-font-smoothing: antialiased;

--- a/src/sass/section-intro/_base.scss
+++ b/src/sass/section-intro/_base.scss
@@ -14,7 +14,7 @@
 		font-size: $ts-36;
 		font-weight: $font-weight-black;
 		line-height: $line-height-tight;
-		margin-top: $spacing-sm;
+		margin-top: var(--rvt-spacing-sm);
 		text-transform: uppercase;
 		-webkit-font-smoothing: antialiased;
 		-moz-osx-font-smoothing: grayscale;
@@ -28,22 +28,22 @@
 	&__teaser {
 		color: var(--rvt-color-theme-text);
 		font-size: $ts-16;
-		margin-top: $spacing-sm;
+		margin-top: var(--rvt-spacing-sm);
 
 		> * {
 			margin: 0;
 		}
 
 		> * + * {
-			margin-top: $spacing-md;
+			margin-top: var(--rvt-spacing-md);
 		}
 	}
 
 	&__actions {
 		display: flex;
-		gap: $spacing-sm;
+		gap: var(--rvt-spacing-sm);
 		justify-content: center;
-		margin-top: $spacing-xl;
+		margin-top: var(--rvt-spacing-xl);
 	}
 
 	&--feature::before {
@@ -58,13 +58,13 @@
 
 	&--feature &__eyebrow {
 		display: block;
-		padding-top: $spacing-sm;
+		padding-top: var(--rvt-spacing-sm);
 		position: relative;
 	}
 
 	&--feature &__teaser {
 		color: var(--rvt-color-theme-accent);
-		padding-top: $spacing-xl;
+		padding-top: var(--rvt-spacing-xl);
 		position: relative;
 		text-align: left;
 	}
@@ -73,11 +73,11 @@
 		background-color: var(--rvt-color-theme-accent);
 		content: "";
 		display: block;
-		height: $spacing-lg;
+		height: var(--rvt-spacing-lg);
 		left: 50%;
 		position: absolute;
-		top: -$spacing-xxs;
-		width: $spacing-xxs;
+		top: -var(--rvt-spacing-xxs);
+		width: var(--rvt-spacing-xxs);
 	}
 }
 
@@ -98,12 +98,12 @@
 		&--teaser {
 			display: flex;
 			flex-wrap: wrap;
-			gap: $spacing-lg;
+			gap: var(--rvt-spacing-lg);
 			max-width: 100%;
 		}
 
 		&--teaser &__title {
-			margin-top: $spacing-xs;
+			margin-top: var(--rvt-spacing-xs);
 		}
 
 		&--teaser {

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -56,7 +56,7 @@
 		border-left: 0.25rem solid transparent;
 		color: var(--rvt-color-theme-text-strong);
 		flex-grow: 1;
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 		padding: var(--rvt-spacing-sm);
 		position: relative;
 		text-decoration: none;
@@ -73,7 +73,7 @@
 	}
 
 	&__item &__item &__link {
-		font-weight: $font-weight-regular;
+		font-weight: var(--rvt-font-weight-regular);
 	}
 
 	&__link[aria-current="page"] + &__toggle {
@@ -143,7 +143,7 @@
 		background-color: var(--rvt-color-theme-background);
 		border: 2px solid var(--rvt-color-theme-ui);
 		display: flex;
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 		gap: var(--rvt-spacing-sm);
 		height: calc(var(--rvt-spacing-sm) * 3);
 		justify-content: space-between;

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -134,7 +134,7 @@
 	&__link,
 	&__toggle {
 		&:focus {
-			z-index: $z-index-100;
+			z-index: var(--rvt-z-index-100);
 		}
 	}
 

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -10,7 +10,7 @@
 	&__label {
 		color: var(--rvt-color-theme-accent);
 		display: block;
-		font-family: $font-family-mono;
+		font-family: var(--rvt-font-family-mono);
 		font-size: var(--rvt-ts-12);
 		letter-spacing: calc(var(--rvt-spacing-sm) * 0.125);
 		text-transform: uppercase;

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -5,14 +5,14 @@
 @use "sass:math";
 
 .rvt-sidenav {
-	margin-top: $spacing-lg;
+	margin-top: var(--rvt-spacing-lg);
 
 	&__label {
 		color: var(--rvt-color-theme-accent);
 		display: block;
 		font-family: $font-family-mono;
 		font-size: $ts-12;
-		letter-spacing: $spacing-sm * 0.125;
+		letter-spacing: calc(var(--rvt-spacing-sm) * 0.125);
 		text-transform: uppercase;
 	}
 
@@ -23,7 +23,7 @@
 	}
 
 	&__label + &__list {
-		margin-top: $spacing-sm;
+		margin-top: var(--rvt-spacing-sm);
 	}
 
 	&__list[hidden],
@@ -44,7 +44,7 @@
 	}
 
 	&__item &__list {
-		margin-left: $spacing-sm;
+		margin-left: var(--rvt-spacing-sm);
 	}
 
 	&__item-wrapper {
@@ -57,7 +57,7 @@
 		color: var(--rvt-color-theme-text-strong);
 		flex-grow: 1;
 		font-weight: $font-weight-medium;
-		padding: $spacing-sm;
+		padding: var(--rvt-spacing-sm);
 		position: relative;
 		text-decoration: none;
 
@@ -102,15 +102,15 @@
 		cursor: pointer;
 		display: none; // Hide by default if JS doesn't load
 		justify-content: center;
-		padding: 0 $spacing-md;
+		padding: 0 var(--rvt-spacing-md);
 
 		&::after {
 			background-color: currentColor;
 			clip-path: path(var(--rvt-icon-chevron-down));
 			content: "";
 			display: block;
-			height: $spacing-sm;
-			width: $spacing-sm;
+			height: var(--rvt-spacing-sm);
+			width: var(--rvt-spacing-sm);
 		}
 
 		svg {
@@ -144,15 +144,15 @@
 		border: 2px solid var(--rvt-color-theme-ui);
 		display: flex;
 		font-weight: $font-weight-medium;
-		gap: $spacing-sm;
-		height: $spacing-sm * 3;
+		gap: var(--rvt-spacing-sm);
+		height: calc(var(--rvt-spacing-sm) * 3);
 		justify-content: space-between;
-		padding-inline: $spacing-sm;
+		padding-inline: var(--rvt-spacing-sm);
 		width: 100%;
 	}
 
 	&--compact &__label + &__list {
-		margin-top: $spacing-xs;
+		margin-top: var(--rvt-spacing-xs);
 	}
 
 	&--compact &__item {
@@ -161,7 +161,7 @@
 
 	&--compact &__link {
 		font-weight: var(--rvt-font-weight-normal);
-		padding: $spacing-xxs $spacing-sm;
+		padding: var(--rvt-spacing-xxs) var(--rvt-spacing-sm);
 
 		&:hover {
 			background-color: var(--rvt-color-theme-background-strong);
@@ -179,10 +179,10 @@
 	&--compact &__item &__list &__link {
 		font-size: var(--rvt-ts-14);
 		line-height: calc(20rem / 16);
-		padding-left: $spacing-lg;
+		padding-left: var(--rvt-spacing-lg);
 	}
 }
 
 .rvt-layout-base__sidebar .rvt-sidenav {
-	margin-top: $spacing-sm;
+	margin-top: var(--rvt-spacing-sm);
 }

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:math";
 
-.#{$prefix}-sidenav {
+.rvt-sidenav {
 	margin-top: $spacing-lg;
 
 	&__label {
@@ -183,6 +183,6 @@
 	}
 }
 
-.#{$prefix}-layout-base__sidebar .#{$prefix}-sidenav {
+.rvt-layout-base__sidebar .rvt-sidenav {
 	margin-top: $spacing-sm;
 }

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -1,9 +1,6 @@
 // Copyright (C) 2019 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:math";
-
 .rvt-sidenav {
 	margin-top: var(--rvt-spacing-lg);
 

--- a/src/sass/sidenav/_base.scss
+++ b/src/sass/sidenav/_base.scss
@@ -11,7 +11,7 @@
 		color: var(--rvt-color-theme-accent);
 		display: block;
 		font-family: $font-family-mono;
-		font-size: $ts-12;
+		font-size: var(--rvt-ts-12);
 		letter-spacing: calc(var(--rvt-spacing-sm) * 0.125);
 		text-transform: uppercase;
 	}

--- a/src/sass/stat-group/_base.scss
+++ b/src/sass/stat-group/_base.scss
@@ -12,7 +12,7 @@
 	&__note {
 		color: var(--rvt-color-theme-accent);
 		font-family: $font-family-mono;
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		margin-block-end: 0;
 		margin-block-start: var(--rvt-spacing-lg);
 	}

--- a/src/sass/stat-group/_base.scss
+++ b/src/sass/stat-group/_base.scss
@@ -1,4 +1,5 @@
-@use "../core" as *;
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
 
 .rvt-stat-group {
 	container-name: stat-group;

--- a/src/sass/stat-group/_base.scss
+++ b/src/sass/stat-group/_base.scss
@@ -14,7 +14,7 @@
 		font-family: $font-family-mono;
 		font-size: $ts-14;
 		margin-block-end: 0;
-		margin-block-start: $spacing-lg;
+		margin-block-start: var(--rvt-spacing-lg);
 	}
 }
 

--- a/src/sass/stat-group/_base.scss
+++ b/src/sass/stat-group/_base.scss
@@ -11,7 +11,7 @@
 
 	&__note {
 		color: var(--rvt-color-theme-accent);
-		font-family: $font-family-mono;
+		font-family: var(--rvt-font-family-mono);
 		font-size: var(--rvt-ts-14);
 		margin-block-end: 0;
 		margin-block-start: var(--rvt-spacing-lg);

--- a/src/sass/stat-group/_base.scss
+++ b/src/sass/stat-group/_base.scss
@@ -1,6 +1,6 @@
 @use "../core" as *;
 
-.#{$prefix}-stat-group {
+.rvt-stat-group {
 	container-name: stat-group;
 	container-type: inline-size;
 
@@ -19,7 +19,7 @@
 }
 
 @container stat-group (min-width: 40em) {
-	.#{$prefix}-stat-group {
+	.rvt-stat-group {
 		&__inner {
 			flex-direction: row;
 			flex-wrap: wrap;
@@ -37,7 +37,7 @@
 }
 
 @container stat-group (min-width: 68.75em) {
-	.#{$prefix}-stat-group {
+	.rvt-stat-group {
 		&__inner > * {
 			min-width: auto;
 		}

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -28,14 +28,14 @@
 	&__number {
 		color: var(--rvt-color-theme-accent);
 		font-family: $font-family-mono;
-		font-size: $ts-41;
+		font-size: var(--rvt-ts-41);
 		font-variation-settings: "wdth" 150;
 		font-weight: $font-weight-black;
 	}
 
 	&__description {
 		color: var(--rvt-color-theme-accent);
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		letter-spacing: 0.025rem;
 	}
 }

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -30,7 +30,7 @@
 		font-family: $font-family-mono;
 		font-size: var(--rvt-ts-41);
 		font-variation-settings: "wdth" 150;
-		font-weight: $font-weight-black;
+		font-weight: var(--rvt-font-weight-black);
 	}
 
 	&__description {

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -1,6 +1,6 @@
 @use "../core" as *;
 
-.#{$prefix}-stat {
+.rvt-stat {
 	display: inline-flex;
 	padding: $spacing-xl $spacing-md;
 	text-decoration: none;
@@ -41,7 +41,7 @@
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-stat {
+	.rvt-stat {
 		padding: $spacing-xxl;
 	}
 }

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 @use "../core" as *;
 
 .rvt-stat {

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -8,7 +8,7 @@
 
 	&[href]:hover {
 		border-radius: var(--rvt-spacing-xs);
-		box-shadow: $shadow-heavy;
+		box-shadow: var(--rvt-shadow-heavy);
 		color: var(--rvt-color-theme-accent);
 		transform: scale(1.1);
 	}

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -18,7 +18,7 @@
 	}
 
 	&__content {
-		font-family: $font-family-mono;
+		font-family: var(--rvt-font-family-mono);
 	}
 
 	&__image + * {
@@ -27,7 +27,7 @@
 
 	&__number {
 		color: var(--rvt-color-theme-accent);
-		font-family: $font-family-mono;
+		font-family: var(--rvt-font-family-mono);
 		font-size: var(--rvt-ts-41);
 		font-variation-settings: "wdth" 150;
 		font-weight: var(--rvt-font-weight-black);

--- a/src/sass/stat/_base.scss
+++ b/src/sass/stat/_base.scss
@@ -2,12 +2,12 @@
 
 .rvt-stat {
 	display: inline-flex;
-	padding: $spacing-xl $spacing-md;
+	padding: var(--rvt-spacing-xl) var(--rvt-spacing-md);
 	text-decoration: none;
 	transition: all 0.2s ease;
 
 	&[href]:hover {
-		border-radius: $spacing-xs;
+		border-radius: var(--rvt-spacing-xs);
 		box-shadow: $shadow-heavy;
 		color: var(--rvt-color-theme-accent);
 		transform: scale(1.1);
@@ -22,7 +22,7 @@
 	}
 
 	&__image + * {
-		margin-top: $spacing-md;
+		margin-top: var(--rvt-spacing-md);
 	}
 
 	&__number {
@@ -42,6 +42,6 @@
 
 @include mq($breakpoint-md) {
 	.rvt-stat {
-		padding: $spacing-xxl;
+		padding: var(--rvt-spacing-xxl);
 	}
 }

--- a/src/sass/step-indicator/_base.scss
+++ b/src/sass/step-indicator/_base.scss
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 @use "../core" as *;
-@use "sass:map";
-@use "sass:math";
 
 .rvt-steps {
 	display: flex;
@@ -77,7 +75,7 @@
 	&__indicator {
 		align-items: center;
 		background-color: var(--rvt-color-theme-background);
-		border: math.div(var(--rvt-spacing-xxs), 2) solid var(--rvt-color-theme-ui);
+		border: calc(var(--rvt-spacing-xxs) / 2) solid var(--rvt-color-theme-ui);
 		border-radius: 999rem;
 		box-shadow:
 			0 0 0 calc(1rem / 16) var(--rvt-color-base-ultralight),
@@ -129,7 +127,7 @@
 	}
 
 	&--vertical &__item::before {
-		box-shadow: math.div(var(--rvt-spacing-xxs), -2) 0 0 0 var(--rvt-color-theme-ui);
+		box-shadow: calc(var(--rvt-spacing-xxs) / -2) 0 0 0 var(--rvt-color-theme-ui);
 		height: 100%;
 		left: calc(var(--rvt-spacing-sm) * 1.125);
 		position: absolute;

--- a/src/sass/step-indicator/_base.scss
+++ b/src/sass/step-indicator/_base.scss
@@ -83,7 +83,7 @@
 			0 0 0 calc(1rem / 16) var(--rvt-color-base-ultralight),
 			0 0 0 var(--rvt-spacing-xs) var(--rvt-color-theme-background);
 		display: inline-flex;
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 		height: var(--rvt-spacing-lg);
 		justify-content: center;
 		position: relative;

--- a/src/sass/step-indicator/_base.scss
+++ b/src/sass/step-indicator/_base.scss
@@ -88,7 +88,7 @@
 		justify-content: center;
 		position: relative;
 		width: var(--rvt-spacing-lg);
-		z-index: map.get($z-index, "100");
+		z-index: var(--rvt-z-index-100);
 	}
 
 	&__indicator--success {

--- a/src/sass/step-indicator/_base.scss
+++ b/src/sass/step-indicator/_base.scss
@@ -5,7 +5,7 @@
 @use "sass:map";
 @use "sass:math";
 
-.#{$prefix}-steps {
+.rvt-steps {
 	display: flex;
 	list-style: none;
 	margin: 0;
@@ -153,25 +153,25 @@
  * when user can click through all steps of a multi-page flow.
  */
 
-a.#{$prefix}-steps__item-content {
+a.rvt-steps__item-content {
 	text-decoration: none;
 }
 
-a.#{$prefix}-steps__item-content:hover .#{$prefix}-steps__label {
+a.rvt-steps__item-content:hover .rvt-steps__label {
 	text-decoration: underline;
 }
 
-a.#{$prefix}-steps__item-content:hover .#{$prefix}-steps__indicator,
-a.#{$prefix}-steps__item-content:focus .#{$prefix}-steps__indicator,
-a.#{$prefix}-steps__item-content[aria-current="step"]
-	.#{$prefix}-steps__indicator {
+a.rvt-steps__item-content:hover .rvt-steps__indicator,
+a.rvt-steps__item-content:focus .rvt-steps__indicator,
+a.rvt-steps__item-content[aria-current="step"]
+	.rvt-steps__indicator {
 	background-color: var(--rvt-color-theme-accent);
 	color: var(--rvt-color-theme-text-inverse);
 	border-color: transparent;
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-steps {
+	.rvt-steps {
 		overflow-x: visible;
 	}
 }

--- a/src/sass/step-indicator/_base.scss
+++ b/src/sass/step-indicator/_base.scss
@@ -22,7 +22,7 @@
 		text-align: center;
 
 		&::before {
-			box-shadow: 0 ($spacing-sm * 2.9) 0 1px var(--rvt-color-theme-ui);
+			box-shadow: 0 calc(var(--rvt-spacing-sm) * 2.9) 0 1px var(--rvt-color-theme-ui);
 			content: "";
 			display: block;
 			width: 100%;
@@ -69,25 +69,25 @@
 		display: block;
 		color: var(--rvt-color-theme-text);
 		font-size: $ts-14;
-		margin-bottom: $spacing-xs;
-		padding-left: $spacing-xs;
-		padding-right: $spacing-xs;
+		margin-bottom: var(--rvt-spacing-xs);
+		padding-left: var(--rvt-spacing-xs);
+		padding-right: var(--rvt-spacing-xs);
 	}
 
 	&__indicator {
 		align-items: center;
 		background-color: var(--rvt-color-theme-background);
-		border: math.div($spacing-xxs, 2) solid var(--rvt-color-theme-ui);
+		border: math.div(var(--rvt-spacing-xxs), 2) solid var(--rvt-color-theme-ui);
 		border-radius: 999rem;
 		box-shadow:
 			0 0 0 calc(1rem / 16) var(--rvt-color-base-ultralight),
-			0 0 0 $spacing-xs var(--rvt-color-theme-background);
+			0 0 0 var(--rvt-spacing-xs) var(--rvt-color-theme-background);
 		display: inline-flex;
 		font-weight: $font-weight-medium;
-		height: $spacing-lg;
+		height: var(--rvt-spacing-lg);
 		justify-content: center;
 		position: relative;
-		width: $spacing-lg;
+		width: var(--rvt-spacing-lg);
 		z-index: map.get($z-index, "100");
 	}
 
@@ -119,7 +119,7 @@
 
 	&--vertical &__item {
 		margin-top: 0;
-		padding-top: $spacing-lg;
+		padding-top: var(--rvt-spacing-lg);
 		position: relative;
 		text-align: left;
 	}
@@ -129,9 +129,9 @@
 	}
 
 	&--vertical &__item::before {
-		box-shadow: math.div($spacing-xxs, -2) 0 0 0 var(--rvt-color-theme-ui);
+		box-shadow: math.div(var(--rvt-spacing-xxs), -2) 0 0 0 var(--rvt-color-theme-ui);
 		height: 100%;
-		left: $spacing-sm * 1.125;
+		left: calc(var(--rvt-spacing-sm) * 1.125);
 		position: absolute;
 		top: 0;
 	}
@@ -144,7 +144,7 @@
 
 	&--vertical &__label {
 		margin-bottom: 0;
-		padding-left: $spacing-sm;
+		padding-left: var(--rvt-spacing-sm);
 	}
 }
 

--- a/src/sass/step-indicator/_base.scss
+++ b/src/sass/step-indicator/_base.scss
@@ -68,7 +68,7 @@
 	&__label {
 		display: block;
 		color: var(--rvt-color-theme-text);
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		margin-bottom: var(--rvt-spacing-xs);
 		padding-left: var(--rvt-spacing-xs);
 		padding-right: var(--rvt-spacing-xs);

--- a/src/sass/subnav/_base.scss
+++ b/src/sass/subnav/_base.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-subnav {
 	border-bottom: 1px solid var(--rvt-color-theme-ui);
 	overflow-x: auto;

--- a/src/sass/subnav/_base.scss
+++ b/src/sass/subnav/_base.scss
@@ -29,7 +29,7 @@
 		border: none;
 		color: var(--rvt-color-theme-text-strong);
 		display: flex;
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		padding: var(--rvt-spacing-sm) var(--rvt-spacing-sm);
 		position: relative;
 		text-decoration: none;

--- a/src/sass/subnav/_base.scss
+++ b/src/sass/subnav/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-subnav {
+.rvt-subnav {
 	border-bottom: 1px solid var(--rvt-color-theme-ui);
 	overflow-x: auto;
 	-webkit-overflow-scrolling: auto;

--- a/src/sass/subnav/_base.scss
+++ b/src/sass/subnav/_base.scss
@@ -12,9 +12,9 @@
 		display: flex;
 		list-style: none;
 		margin: 0;
-		padding-left: $spacing-xxs;
-		padding-right: $spacing-xxs;
-		padding-top: $spacing-xxs;
+		padding-left: var(--rvt-spacing-xxs);
+		padding-right: var(--rvt-spacing-xxs);
+		padding-top: var(--rvt-spacing-xxs);
 	}
 
 	&__item {
@@ -30,7 +30,7 @@
 		color: var(--rvt-color-theme-text-strong);
 		display: flex;
 		font-size: $ts-14;
-		padding: $spacing-sm $spacing-sm;
+		padding: var(--rvt-spacing-sm) var(--rvt-spacing-sm);
 		position: relative;
 		text-decoration: none;
 
@@ -49,7 +49,7 @@
 		bottom: 0;
 		content: "";
 		display: block;
-		height: $spacing-xxs;
+		height: var(--rvt-spacing-xxs);
 		left: 0;
 		position: absolute;
 		width: 100%;

--- a/src/sass/switch/_base.scss
+++ b/src/sass/switch/_base.scss
@@ -9,7 +9,7 @@
 	background: none;
 	background-color: var(--rvt-color-theme-text-strong);
 	border: none;
-	border-radius: $border-radius-circle;
+	border-radius: var(--rvt-border-radius-circle);
 	color: var(--rvt-color-theme-background-strong);
 	display: flex;
 	gap: 0.75rem;
@@ -21,7 +21,7 @@
 
 	&::before {
 		background-color: var(--rvt-color-theme-background);
-		border-radius: $border-radius-circle;
+		border-radius: var(--rvt-border-radius-circle);
 		content: "";
 		display: block;
 		height: var(--rvt-spacing-lg);
@@ -33,7 +33,7 @@
 
 	&::after {
 		background-color: var(--rvt-color-theme-text-strong);
-		border-radius: $border-radius-circle;
+		border-radius: var(--rvt-border-radius-circle);
 		clip-path: path(var(--rvt-icon-close));
 		content: "";
 		display: block;

--- a/src/sass/switch/_base.scss
+++ b/src/sass/switch/_base.scss
@@ -1,9 +1,6 @@
 // Copyright (C) 2023 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:math";
-
 .rvt-switch {
 	align-items: center;
 	background: none;

--- a/src/sass/switch/_base.scss
+++ b/src/sass/switch/_base.scss
@@ -93,7 +93,7 @@
 */
 
 	&--small {
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		height: var(--rvt-spacing-md);
 		gap: 0;
 		padding: 0 var(--rvt-spacing-xs);

--- a/src/sass/switch/_base.scss
+++ b/src/sass/switch/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 @use "sass:math";
 
-.#{$prefix}-switch {
+.rvt-switch {
 	align-items: center;
 	background: none;
 	background-color: var(--rvt-color-theme-text-strong);

--- a/src/sass/switch/_base.scss
+++ b/src/sass/switch/_base.scss
@@ -13,7 +13,7 @@
 	color: var(--rvt-color-theme-background-strong);
 	display: flex;
 	gap: 0.75rem;
-	height: $spacing-xl;
+	height: var(--rvt-spacing-xl);
 	line-height: 1;
 	padding: 0 0.75rem;
 	position: relative;
@@ -24,11 +24,11 @@
 		border-radius: $border-radius-circle;
 		content: "";
 		display: block;
-		height: $spacing-lg;
-		left: $spacing-xxs;
+		height: var(--rvt-spacing-lg);
+		left: var(--rvt-spacing-xxs);
 		position: absolute;
 		transition: left 0.2s ease;
-		width: $spacing-lg;
+		width: var(--rvt-spacing-lg);
 	}
 
 	&::after {
@@ -37,11 +37,11 @@
 		clip-path: path(var(--rvt-icon-close));
 		content: "";
 		display: block;
-		height: $spacing-sm;
+		height: var(--rvt-spacing-sm);
 		left: calc(12rem / 16);
 		position: absolute;
 		transition: left 0.2s ease;
-		width: $spacing-sm;
+		width: var(--rvt-spacing-sm);
 	}
 
 	&:hover {
@@ -55,7 +55,7 @@
 	}
 
 	&[aria-checked="true"]::before {
-		left: calc(100% - ($spacing-lg + $spacing-xxs));
+		left: calc(100% - (var(--rvt-spacing-lg) + var(--rvt-spacing-xxs)));
 	}
 
 	&[aria-checked="true"]::after {
@@ -78,25 +78,25 @@
 	// Medium variant is in review.
 	/*
   &--medium {
-    height: $spacing-lg;
+    height: var(--rvt-spacing-lg);
     gap: 0.25rem;
 
     &::after {
-      height: $spacing-md;
-      width: $spacing-md;
+      height: var(--rvt-spacing-md);
+      width: var(--rvt-spacing-md);
     }
 
     &[aria-checked="true"]::after {
-      left: calc(100% - ($spacing-md + $spacing-xxs));
+      left: calc(100% - (var(--rvt-spacing-md) + var(--rvt-spacing-xxs)));
     }
   }
 */
 
 	&--small {
 		font-size: $ts-14;
-		height: $spacing-md;
+		height: var(--rvt-spacing-md);
 		gap: 0;
-		padding: 0 $spacing-xs;
+		padding: 0 var(--rvt-spacing-xs);
 
 		&::before {
 			height: calc(18rem / 16);

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -68,7 +68,7 @@ tbody tr th {
 }
 
 .rvt-table-compact {
-	line-height: $line-height-tight;
+	line-height: var(--rvt-line-height-tight);
 
 	tr th,
 	tr td {

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -5,7 +5,7 @@
 @use "sass:math";
 
 table,
-.#{$prefix}-table {
+.rvt-table {
 	border: 1px solid var(--rvt-color-theme-ui);
 	border-collapse: collapse;
 	border-spacing: 0;
@@ -48,7 +48,7 @@ tbody tr th {
 	padding: $spacing-md;
 }
 
-.#{$prefix}-table-plain {
+.rvt-table-plain {
 	border: none;
 
 	thead {
@@ -61,13 +61,13 @@ tbody tr th {
 	}
 }
 
-.#{$prefix}-table-stripes {
+.rvt-table-stripes {
 	tr:nth-child(even) {
 		background-color: var(--rvt-color-theme-background-strong);
 	}
 }
 
-.#{$prefix}-table-compact {
+.rvt-table-compact {
 	line-height: $line-height-tight;
 
 	tr th,
@@ -76,7 +76,7 @@ tbody tr th {
 	}
 }
 
-.#{$prefix}-table-cells {
+.rvt-table-cells {
 	border-top: 1px solid var(--rvt-color-theme-ui);
 
 	tr td,
@@ -90,8 +90,8 @@ tbody tr th {
 	}
 }
 
-.#{$prefix}-table-crimson,
-.#{$prefix}-table-feature {
+.rvt-table-crimson,
+.rvt-table-feature {
 	thead {
 		background-color: var(--rvt-color-theme-accent);
 		color: var(--rvt-color-theme-background);
@@ -102,7 +102,7 @@ tbody tr th {
  * Adapted from Adrian Roselli's "Under-Engineered Responsive Tables"
  * https://adrianroselli.com/2020/11/under-engineered-responsive-tables.html
  */
-.#{$prefix}-table-responsive[role="region"][tabindex] {
+.rvt-table-responsive[role="region"][tabindex] {
 	/* stylelint-disable */
 	background:
 		linear-gradient(
@@ -147,7 +147,7 @@ tbody tr th {
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-table-responsive[role="region"][tabindex] {
+	.rvt-table-responsive[role="region"][tabindex] {
 		border: none;
 		border-radius: 0;
 	}

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 @use "../core" as *;
-@use "sass:math";
 
 table,
 .rvt-table {

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -13,7 +13,7 @@ table,
 	width: 100%;
 
 	caption {
-		font-size: $ts-32;
+		font-size: var(--rvt-ts-32);
 		font-weight: $font-weight-medium;
 		margin-bottom: var(--rvt-spacing-md);
 		text-align: left;

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -15,7 +15,7 @@ table,
 	caption {
 		font-size: $ts-32;
 		font-weight: $font-weight-medium;
-		margin-bottom: $spacing-md;
+		margin-bottom: var(--rvt-spacing-md);
 		text-align: left;
 	}
 }
@@ -28,8 +28,8 @@ thead {
 	background-color: var(--rvt-color-theme-background-strong);
 
 	tr th {
-		padding-block: $spacing-sm;
-		padding-inline: $spacing-md;
+		padding-block: var(--rvt-spacing-sm);
+		padding-inline: var(--rvt-spacing-md);
 	}
 
 	th,
@@ -45,7 +45,7 @@ tr {
 
 tbody tr td,
 tbody tr th {
-	padding: $spacing-md;
+	padding: var(--rvt-spacing-md);
 }
 
 .rvt-table-plain {
@@ -142,7 +142,7 @@ tbody tr th {
 		14px 100%;
 	/* stylelint-enable */
 	border: 1px solid var(--rvt-color-theme-ui);
-	border-radius: $spacing-xs;
+	border-radius: var(--rvt-spacing-xs);
 	overflow: auto;
 }
 

--- a/src/sass/tables/_base.scss
+++ b/src/sass/tables/_base.scss
@@ -14,14 +14,14 @@ table,
 
 	caption {
 		font-size: var(--rvt-ts-32);
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 		margin-bottom: var(--rvt-spacing-md);
 		text-align: left;
 	}
 }
 
 tr th {
-	font-weight: $font-weight-regular;
+	font-weight: var(--rvt-font-weight-regular);
 }
 
 thead {
@@ -34,7 +34,7 @@ thead {
 
 	th,
 	tr th {
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 		line-height: 1;
 	}
 }

--- a/src/sass/tabs/_base.scss
+++ b/src/sass/tabs/_base.scss
@@ -5,7 +5,7 @@
 @use "sass:map";
 @use "sass:math";
 
-.#{$prefix}-tabs {
+.rvt-tabs {
 	border: 1px solid var(--rvt-color-theme-ui);
 
 	&__tablist {

--- a/src/sass/tabs/_base.scss
+++ b/src/sass/tabs/_base.scss
@@ -1,10 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-@use "sass:map";
-@use "sass:math";
-
 .rvt-tabs {
 	border: 1px solid var(--rvt-color-theme-ui);
 

--- a/src/sass/tabs/_base.scss
+++ b/src/sass/tabs/_base.scss
@@ -21,7 +21,7 @@
 		cursor: pointer;
 		flex-grow: 1;
 		line-height: 1;
-		padding: $spacing-sm $spacing-sm;
+		padding: var(--rvt-spacing-sm) var(--rvt-spacing-sm);
 		position: relative;
 		z-index: map.get($z-index, "100");
 
@@ -50,13 +50,13 @@
 		bottom: 0;
 		content: "";
 		display: block;
-		height: $spacing-xxs;
+		height: var(--rvt-spacing-xxs);
 		left: 0;
 		position: absolute;
 		width: 100%;
 	}
 
 	&__panel {
-		padding: $spacing-sm;
+		padding: var(--rvt-spacing-sm);
 	}
 }

--- a/src/sass/tabs/_base.scss
+++ b/src/sass/tabs/_base.scss
@@ -23,7 +23,7 @@
 		line-height: 1;
 		padding: var(--rvt-spacing-sm) var(--rvt-spacing-sm);
 		position: relative;
-		z-index: map.get($z-index, "100");
+		z-index: var(--rvt-z-index-100);
 
 		&:not(:first-child) {
 			border-left: 1px solid var(--rvt-color-theme-ui);

--- a/src/sass/timeline/_base.scss
+++ b/src/sass/timeline/_base.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-timeline {
+.rvt-timeline {
 	padding: $spacing-lg 0;
 	position: relative;
 
@@ -97,78 +97,78 @@
 }
 
 // TODO: Make a decision on whether we need this variant
-.#{$prefix}-timeline--right {
+.rvt-timeline--right {
 	&::before {
 		left: auto;
 		right: $spacing-xxs;
 	}
 
-	.#{$prefix}-timeline__item::after {
+	.rvt-timeline__item::after {
 		border-left-color: var(--rvt-color-theme-ui);
 		border-right-color: transparent;
 		margin-left: 0;
 		right: 0;
 	}
 
-	.#{$prefix}-timeline__marker {
+	.rvt-timeline__marker {
 		margin-left: 0;
 		right: 0;
 	}
 
-	.#{$prefix}-timeline__content {
+	.rvt-timeline__content {
 		margin-left: 0;
 		margin-right: $spacing-lg;
 	}
 }
 
 @include mq($breakpoint-md) {
-	.#{$prefix}-timeline--center {
+	.rvt-timeline--center {
 		&::before {
 			left: 50%;
 			margin-left: 0;
 		}
 
-		.#{$prefix}-timeline__item {
+		.rvt-timeline__item {
 			flex-basis: 50%;
 			max-width: 50%;
 			padding: 0 $spacing-sm * 0.75;
 			width: 100%;
 		}
 
-		.#{$prefix}-timeline__item--right {
+		.rvt-timeline__item--right {
 			margin-left: auto;
 		}
 
-		.#{$prefix}-timeline__item::after {
+		.rvt-timeline__item::after {
 			border-left-color: var(--rvt-color-theme-ui);
 			border-right-color: transparent;
 			left: 100%;
 			margin-left: -$spacing-md;
 		}
 
-		.#{$prefix}-timeline__item--right::after {
+		.rvt-timeline__item--right::after {
 			border-left-color: transparent;
 			border-right-color: var(--rvt-color-theme-ui);
 			left: auto;
 			margin-left: -$spacing-sm;
 		}
 
-		.#{$prefix}-timeline__marker {
+		.rvt-timeline__marker {
 			left: 100%;
 			margin-left: -$spacing-xxs;
 		}
 
-		.#{$prefix}-timeline__item--right .#{$prefix}-timeline__marker {
+		.rvt-timeline__item--right .rvt-timeline__marker {
 			left: auto;
 			margin-left: -$spacing-sm;
 		}
 
-		.#{$prefix}-timeline__content {
+		.rvt-timeline__content {
 			margin-left: 0;
 			margin-right: $spacing-sm * 0.75;
 		}
 
-		.#{$prefix}-timeline__item--right .#{$prefix}-timeline__content {
+		.rvt-timeline__item--right .rvt-timeline__content {
 			margin-left: $spacing-sm;
 			margin-right: 0;
 		}

--- a/src/sass/timeline/_base.scss
+++ b/src/sass/timeline/_base.scss
@@ -46,7 +46,7 @@
 	&__content {
 		background-color: var(--rvt-color-theme-background);
 		border: none;
-		box-shadow: $shadow-standard;
+		box-shadow: var(--rvt-shadow-standard);
 		margin-inline-start: var(--rvt-spacing-lg);
 	}
 

--- a/src/sass/timeline/_base.scss
+++ b/src/sass/timeline/_base.scss
@@ -83,7 +83,7 @@
 	&__item-dates-icon {
 		align-items: center;
 		background-color: var(--rvt-color-theme-background-strong);
-		border-radius: $border-radius-circle;
+		border-radius: var(--rvt-border-radius-circle);
 		color: var(--rvt-color-theme-accent);
 		display: flex;
 		height: var(--rvt-spacing-xl);

--- a/src/sass/timeline/_base.scss
+++ b/src/sass/timeline/_base.scss
@@ -65,7 +65,7 @@
 
 	&__heading {
 		font-size: var(--rvt-ts-23);
-		font-weight: $font-weight-medium;
+		font-weight: var(--rvt-font-weight-medium);
 	}
 
 	&__content-inner > * {

--- a/src/sass/timeline/_base.scss
+++ b/src/sass/timeline/_base.scss
@@ -58,13 +58,13 @@
 		background-color: var(--rvt-color-theme-accent);
 		color: var(--rvt-color-theme-text-inverse);
 		font-family: $font-family-mono;
-		font-size: $ts-14;
+		font-size: var(--rvt-ts-14);
 		padding-block: var(--rvt-spacing-sm);
 		padding-inline: var(--rvt-spacing-md);
 	}
 
 	&__heading {
-		font-size: $ts-23;
+		font-size: var(--rvt-ts-23);
 		font-weight: $font-weight-medium;
 	}
 

--- a/src/sass/timeline/_base.scss
+++ b/src/sass/timeline/_base.scss
@@ -57,7 +57,7 @@
 	&__label {
 		background-color: var(--rvt-color-theme-accent);
 		color: var(--rvt-color-theme-text-inverse);
-		font-family: $font-family-mono;
+		font-family: var(--rvt-font-family-mono);
 		font-size: var(--rvt-ts-14);
 		padding-block: var(--rvt-spacing-sm);
 		padding-inline: var(--rvt-spacing-md);

--- a/src/sass/timeline/_base.scss
+++ b/src/sass/timeline/_base.scss
@@ -4,7 +4,7 @@
 @use "../core" as *;
 
 .rvt-timeline {
-	padding: $spacing-lg 0;
+	padding: var(--rvt-spacing-lg) 0;
 	position: relative;
 
 	&::before {
@@ -12,14 +12,14 @@
 		content: "";
 		height: 100%;
 		left: 0;
-		margin-left: $spacing-xxs;
+		margin-left: var(--rvt-spacing-xxs);
 		position: absolute;
 		top: 0;
 		width: 1px;
 	}
 
 	&__item {
-		margin-block: $spacing-lg;
+		margin-block: var(--rvt-spacing-lg);
 		position: relative;
 	}
 
@@ -34,24 +34,24 @@
 		background: var(--rvt-color-theme-accent);
 		border-radius: 50%;
 		box-shadow:
-			0 0 0 ($spacing-xs * 0.85) var(--rvt-color-theme-background),
-			0 0 0 $spacing-xs var(--rvt-color-theme-ui);
-		height: $spacing-sm;
-		left: $spacing-xxs * -0.85;
+			0 0 0 calc(var(--rvt-spacing-xs) * 0.85) var(--rvt-color-theme-background),
+			0 0 0 var(--rvt-spacing-xs) var(--rvt-color-theme-ui);
+		height: var(--rvt-spacing-sm);
+		left: calc(var(--rvt-spacing-xxs) * -0.85);
 		position: absolute;
-		top: $spacing-md * 0.85;
-		width: $spacing-sm;
+		top: calc(var(--rvt-spacing-md) * 0.85);
+		width: var(--rvt-spacing-sm);
 	}
 
 	&__content {
 		background-color: var(--rvt-color-theme-background);
 		border: none;
 		box-shadow: $shadow-standard;
-		margin-inline-start: $spacing-lg;
+		margin-inline-start: var(--rvt-spacing-lg);
 	}
 
 	&__content-inner {
-		padding: $spacing-md;
+		padding: var(--rvt-spacing-md);
 	}
 
 	&__label {
@@ -59,8 +59,8 @@
 		color: var(--rvt-color-theme-text-inverse);
 		font-family: $font-family-mono;
 		font-size: $ts-14;
-		padding-block: $spacing-sm;
-		padding-inline: $spacing-md;
+		padding-block: var(--rvt-spacing-sm);
+		padding-inline: var(--rvt-spacing-md);
 	}
 
 	&__heading {
@@ -73,11 +73,11 @@
 	}
 
 	&__content-inner > * + * {
-		margin-block-start: $spacing-md;
+		margin-block-start: var(--rvt-spacing-md);
 	}
 
 	&__item-dates {
-		margin-block-start: $spacing-lg;
+		margin-block-start: var(--rvt-spacing-lg);
 	}
 
 	&__item-dates-icon {
@@ -86,13 +86,13 @@
 		border-radius: $border-radius-circle;
 		color: var(--rvt-color-theme-accent);
 		display: flex;
-		height: $spacing-xl;
+		height: var(--rvt-spacing-xl);
 		justify-content: center;
-		width: $spacing-xl;
+		width: var(--rvt-spacing-xl);
 	}
 
 	&__item-dates + &__item-actions {
-		margin-block-start: $spacing-xl;
+		margin-block-start: var(--rvt-spacing-xl);
 	}
 }
 
@@ -100,7 +100,7 @@
 .rvt-timeline--right {
 	&::before {
 		left: auto;
-		right: $spacing-xxs;
+		right: var(--rvt-spacing-xxs);
 	}
 
 	.rvt-timeline__item::after {
@@ -117,7 +117,7 @@
 
 	.rvt-timeline__content {
 		margin-left: 0;
-		margin-right: $spacing-lg;
+		margin-right: var(--rvt-spacing-lg);
 	}
 }
 
@@ -131,7 +131,7 @@
 		.rvt-timeline__item {
 			flex-basis: 50%;
 			max-width: 50%;
-			padding: 0 $spacing-sm * 0.75;
+			padding: 0 calc(var(--rvt-spacing-sm) * 0.75);
 			width: 100%;
 		}
 
@@ -143,33 +143,33 @@
 			border-left-color: var(--rvt-color-theme-ui);
 			border-right-color: transparent;
 			left: 100%;
-			margin-left: -$spacing-md;
+			margin-left: -var(--rvt-spacing-md);
 		}
 
 		.rvt-timeline__item--right::after {
 			border-left-color: transparent;
 			border-right-color: var(--rvt-color-theme-ui);
 			left: auto;
-			margin-left: -$spacing-sm;
+			margin-left: -var(--rvt-spacing-sm);
 		}
 
 		.rvt-timeline__marker {
 			left: 100%;
-			margin-left: -$spacing-xxs;
+			margin-left: -var(--rvt-spacing-xxs);
 		}
 
 		.rvt-timeline__item--right .rvt-timeline__marker {
 			left: auto;
-			margin-left: -$spacing-sm;
+			margin-left: -var(--rvt-spacing-sm);
 		}
 
 		.rvt-timeline__content {
 			margin-left: 0;
-			margin-right: $spacing-sm * 0.75;
+			margin-right: calc(var(--rvt-spacing-sm) * 0.75);
 		}
 
 		.rvt-timeline__item--right .rvt-timeline__content {
-			margin-left: $spacing-sm;
+			margin-left: var(--rvt-spacing-sm);
 			margin-right: 0;
 		}
 	}

--- a/src/sass/utilities/_border.scss
+++ b/src/sass/utilities/_border.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-border-all {
 	border: 1px solid var(--rvt-color-theme-ui) !important;
 }

--- a/src/sass/utilities/_border.scss
+++ b/src/sass/utilities/_border.scss
@@ -3,59 +3,59 @@
 
 @use "../core" as *;
 
-.#{$prefix}-border-all {
+.rvt-border-all {
 	border: 1px solid var(--rvt-color-theme-ui) !important;
 }
 
-.#{$prefix}-border-all-none {
+.rvt-border-all-none {
 	border: 0 !important;
 }
 
-.#{$prefix}-border-top {
+.rvt-border-top {
 	border-top: 1px solid var(--rvt-color-theme-ui) !important;
 }
 
-.#{$prefix}-border-top-none {
+.rvt-border-top-none {
 	border-top: 0 !important;
 }
 
-.#{$prefix}-border-right {
+.rvt-border-right {
 	border-right: 1px solid var(--rvt-color-theme-ui) !important;
 }
 
-.#{$prefix}-border-right-none {
+.rvt-border-right-none {
 	border-right: 0 !important;
 }
 
-.#{$prefix}-border-bottom {
+.rvt-border-bottom {
 	border-bottom: 1px solid var(--rvt-color-theme-ui) !important;
 }
 
-.#{$prefix}-border-bottom-none {
+.rvt-border-bottom-none {
 	border-bottom: 0 !important;
 }
 
-.#{$prefix}-border-left {
+.rvt-border-left {
 	border-left: 1px solid var(--rvt-color-theme-ui) !important;
 }
 
-.#{$prefix}-border-left-none {
+.rvt-border-left-none {
 	border-left: 0 !important;
 }
 
-.#{$prefix}-border-radius-sm {
+.rvt-border-radius-sm {
 	border-radius: $border-radius-sm !important;
 }
 
-.#{$prefix}-border-radius,
-.#{$prefix}-border-radius-md {
+.rvt-border-radius,
+.rvt-border-radius-md {
 	border-radius: $border-radius-md !important;
 }
 
-.#{$prefix}-border-radius-lg {
+.rvt-border-radius-lg {
 	border-radius: $border-radius-lg !important;
 }
 
-.#{$prefix}-border-radius-circle {
+.rvt-border-radius-circle {
 	border-radius: $border-radius-circle !important;
 }

--- a/src/sass/utilities/_border.scss
+++ b/src/sass/utilities/_border.scss
@@ -44,18 +44,18 @@
 }
 
 .rvt-border-radius-sm {
-	border-radius: $border-radius-sm !important;
+	border-radius: var(--rvt-border-radius-sm) !important;
 }
 
 .rvt-border-radius,
 .rvt-border-radius-md {
-	border-radius: $border-radius-md !important;
+	border-radius: var(--rvt-border-radius-md) !important;
 }
 
 .rvt-border-radius-lg {
-	border-radius: $border-radius-lg !important;
+	border-radius: var(--rvt-border-radius-lg) !important;
 }
 
 .rvt-border-radius-circle {
-	border-radius: $border-radius-circle !important;
+	border-radius: var(--rvt-border-radius-circle) !important;
 }

--- a/src/sass/utilities/_display.scss
+++ b/src/sass/utilities/_display.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 /* Hide only visually, but have it available for
  * screenreaders: h5bp.com/v
  */

--- a/src/sass/utilities/_display.scss
+++ b/src/sass/utilities/_display.scss
@@ -7,7 +7,7 @@
  * screenreaders: h5bp.com/v
  */
 
-.#{$prefix}-sr-only {
+.rvt-sr-only {
 	border: 0;
 	clip: rect(0 0 0 0);
 	height: 1px;
@@ -26,8 +26,8 @@
  * keyboard: h5bp.com/p
  */
 
-.#{$prefix}-sr-only.#{$prefix}-focusable:active,
-.#{$prefix}-sr-only.#{$prefix}-focusable:focus {
+.rvt-sr-only.rvt-focusable:active,
+.rvt-sr-only.rvt-focusable:focus {
 	clip: auto;
 	height: auto;
 	margin: 0;
@@ -36,18 +36,18 @@
 	width: auto;
 }
 
-.#{$prefix}-display-block {
+.rvt-display-block {
 	display: block !important;
 }
 
-.#{$prefix}-display-inline-block {
+.rvt-display-inline-block {
 	display: inline-block !important;
 }
 
-.#{$prefix}-display-inline {
+.rvt-display-inline {
 	display: inline !important;
 }
 
-.#{$prefix}-display-none {
+.rvt-display-none {
 	display: none !important;
 }

--- a/src/sass/utilities/_elements.scss
+++ b/src/sass/utilities/_elements.scss
@@ -13,7 +13,7 @@
 		color: var(--rvt-color-theme-accent);
 		display: inline-block;
 		font-family: monospace;
-		font-size: $ts-16;
+		font-size: var(--rvt-ts-16);
 		padding: 0.125rem 0.25rem;
 	}
 

--- a/src/sass/utilities/_elements.scss
+++ b/src/sass/utilities/_elements.scss
@@ -9,7 +9,7 @@
 
 	&-code {
 		background-color: var(--rvt-color-theme-background-strong);
-		border-radius: $spacing-xxs;
+		border-radius: var(--rvt-spacing-xxs);
 		color: var(--rvt-color-theme-accent);
 		display: inline-block;
 		font-family: monospace;

--- a/src/sass/utilities/_elements.scss
+++ b/src/sass/utilities/_elements.scss
@@ -25,6 +25,6 @@
 	}
 
 	&-strong {
-		font-weight: $font-weight-bold;
+		font-weight: var(--rvt-font-weight-bold);
 	}
 }

--- a/src/sass/utilities/_elements.scss
+++ b/src/sass/utilities/_elements.scss
@@ -1,6 +1,6 @@
 @use "../core" as *;
 
-.#{$prefix} {
+.rvt {
 	&-abbr,
 	&-abbr[title] {
 		border: none;

--- a/src/sass/utilities/_elements.scss
+++ b/src/sass/utilities/_elements.scss
@@ -1,4 +1,5 @@
-@use "../core" as *;
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
 
 .rvt {
 	&-abbr,

--- a/src/sass/utilities/_flex.scss
+++ b/src/sass/utilities/_flex.scss
@@ -5,53 +5,53 @@
 
 // Display flex
 
-.#{$prefix}-flex {
+.rvt-flex {
 	display: flex !important;
 }
 
-.#{$prefix}-inline-flex {
+.rvt-inline-flex {
 	display: inline-flex !important;
 }
 
-.#{$prefix}-flex-row {
+.rvt-flex-row {
 	flex-direction: row !important;
 }
 
-.#{$prefix}-flex-row-reverse {
+.rvt-flex-row-reverse {
 	flex-direction: row-reverse !important;
 }
 
-.#{$prefix}-flex-column {
+.rvt-flex-column {
 	flex-direction: column !important;
 }
 
-.#{$prefix}-flex-column-reverse {
+.rvt-flex-column-reverse {
 	flex-direction: column-reverse !important;
 }
 
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
-		.#{$prefix}-flex-#{$variable}-up {
+		.rvt-flex-#{$variable}-up {
 			display: flex !important;
 		}
 
-		.#{$prefix}-inline-flex-#{$variable}-up {
+		.rvt-inline-flex-#{$variable}-up {
 			display: inline-flex !important;
 		}
 
-		.#{$prefix}-flex-row-#{$variable}-up {
+		.rvt-flex-row-#{$variable}-up {
 			flex-direction: row !important;
 		}
 
-		.#{$prefix}-flex-row-reverse-#{$variable}-up {
+		.rvt-flex-row-reverse-#{$variable}-up {
 			flex-direction: row-reverse !important;
 		}
 
-		.#{$prefix}-flex-column-#{$variable}-up {
+		.rvt-flex-column-#{$variable}-up {
 			flex-direction: column !important;
 		}
 
-		.#{$prefix}-flex-column-reverse-#{$variable}-up {
+		.rvt-flex-column-reverse-#{$variable}-up {
 			flex-direction: column-reverse !important;
 		}
 	}
@@ -59,29 +59,29 @@
 
 // Wrap
 
-.#{$prefix}-wrap {
+.rvt-wrap {
 	flex-wrap: wrap !important;
 }
 
-.#{$prefix}-no-wrap {
+.rvt-no-wrap {
 	flex-wrap: nowrap !important;
 }
 
-.#{$prefix}-wrap-reverse {
+.rvt-wrap-reverse {
 	flex-wrap: wrap-reverse !important;
 }
 
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
-		.#{$prefix}-wrap-#{$variable}-up {
+		.rvt-wrap-#{$variable}-up {
 			flex-wrap: wrap !important;
 		}
 
-		.#{$prefix}-no-wrap-#{$variable}-up {
+		.rvt-no-wrap-#{$variable}-up {
 			flex-wrap: nowrap !important;
 		}
 
-		.#{$prefix}-wrap-reverse-#{$variable}-up {
+		.rvt-wrap-reverse-#{$variable}-up {
 			flex-wrap: wrap-reverse !important;
 		}
 	}
@@ -89,21 +89,21 @@
 
 // Shrink
 
-.#{$prefix}-shrink-1 {
+.rvt-shrink-1 {
 	flex-shrink: 1 !important;
 }
 
-.#{$prefix}-shrink-0 {
+.rvt-shrink-0 {
 	flex-shrink: 0 !important;
 }
 
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
-		.#{$prefix}-shrink-1-#{$variable}-up {
+		.rvt-shrink-1-#{$variable}-up {
 			flex-shrink: 1 !important;
 		}
 
-		.#{$prefix}-shrink-0-#{$variable}-up {
+		.rvt-shrink-0-#{$variable}-up {
 			flex-shrink: 0 !important;
 		}
 	}
@@ -111,21 +111,21 @@
 
 // Grow
 
-.#{$prefix}-grow-1 {
+.rvt-grow-1 {
 	flex-grow: 1 !important;
 }
 
-.#{$prefix}-grow-0 {
+.rvt-grow-0 {
 	flex-grow: 0 !important;
 }
 
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
-		.#{$prefix}-grow-1-#{$variable}-up {
+		.rvt-grow-1-#{$variable}-up {
 			flex-grow: 1 !important;
 		}
 
-		.#{$prefix}-grow-0-#{$variable}-up {
+		.rvt-grow-0-#{$variable}-up {
 			flex-grow: 0 !important;
 		}
 	}
@@ -133,45 +133,45 @@
 
 // Align items
 
-.#{$prefix}-items-start {
+.rvt-items-start {
 	align-items: flex-start !important;
 }
 
-.#{$prefix}-items-end {
+.rvt-items-end {
 	align-items: flex-end !important;
 }
 
-.#{$prefix}-items-center {
+.rvt-items-center {
 	align-items: center !important;
 }
 
-.#{$prefix}-items-baseline {
+.rvt-items-baseline {
 	align-items: baseline !important;
 }
 
-.#{$prefix}-items-stretch {
+.rvt-items-stretch {
 	align-items: stretch !important;
 }
 
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
-		.#{$prefix}-items-start-#{$variable}-up {
+		.rvt-items-start-#{$variable}-up {
 			align-items: flex-start !important;
 		}
 
-		.#{$prefix}-items-end-#{$variable}-up {
+		.rvt-items-end-#{$variable}-up {
 			align-items: flex-end !important;
 		}
 
-		.#{$prefix}-items-center-#{$variable}-up {
+		.rvt-items-center-#{$variable}-up {
 			align-items: center !important;
 		}
 
-		.#{$prefix}-items-baseline-#{$variable}-up {
+		.rvt-items-baseline-#{$variable}-up {
 			align-items: baseline !important;
 		}
 
-		.#{$prefix}-items-stretch-#{$variable}-up {
+		.rvt-items-stretch-#{$variable}-up {
 			align-items: stretch !important;
 		}
 	}
@@ -179,45 +179,45 @@
 
 // Align content
 
-.#{$prefix}-content-start {
+.rvt-content-start {
 	align-content: flex-start !important;
 }
 
-.#{$prefix}-content-end {
+.rvt-content-end {
 	align-content: flex-end !important;
 }
 
-.#{$prefix}-content-center {
+.rvt-content-center {
 	align-content: center !important;
 }
 
-.#{$prefix}-content-stretch {
+.rvt-content-stretch {
 	align-content: stretch !important;
 }
 
-.#{$prefix}-content-baseline {
+.rvt-content-baseline {
 	align-content: baseline !important;
 }
 
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
-		.#{$prefix}-content-start-#{$variable}-up {
+		.rvt-content-start-#{$variable}-up {
 			align-content: flex-start !important;
 		}
 
-		.#{$prefix}-content-end-#{$variable}-up {
+		.rvt-content-end-#{$variable}-up {
 			align-content: flex-end !important;
 		}
 
-		.#{$prefix}-content-center-#{$variable}-up {
+		.rvt-content-center-#{$variable}-up {
 			align-content: center !important;
 		}
 
-		.#{$prefix}-content-stretch-#{$variable}-up {
+		.rvt-content-stretch-#{$variable}-up {
 			align-content: stretch !important;
 		}
 
-		.#{$prefix}-content-baseline-#{$variable}-up {
+		.rvt-content-baseline-#{$variable}-up {
 			align-content: baseline !important;
 		}
 	}
@@ -225,53 +225,53 @@
 
 // Flex justify-content
 
-.#{$prefix}-justify-start {
+.rvt-justify-start {
 	justify-content: flex-start;
 }
 
-.#{$prefix}-justify-end {
+.rvt-justify-end {
 	justify-content: flex-end;
 }
 
-.#{$prefix}-justify-center {
+.rvt-justify-center {
 	justify-content: center;
 }
 
-.#{$prefix}-justify-space-between {
+.rvt-justify-space-between {
 	justify-content: space-between;
 }
 
-.#{$prefix}-justify-space-around {
+.rvt-justify-space-around {
 	justify-content: space-around;
 }
 
-.#{$prefix}-justify-space-evenly {
+.rvt-justify-space-evenly {
 	justify-content: space-evenly;
 }
 
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
-		.#{$prefix}-justify-start-#{$variable}-up {
+		.rvt-justify-start-#{$variable}-up {
 			justify-content: flex-start;
 		}
 
-		.#{$prefix}-justify-end-#{$variable}-up {
+		.rvt-justify-end-#{$variable}-up {
 			justify-content: flex-end;
 		}
 
-		.#{$prefix}-justify-center-#{$variable}-up {
+		.rvt-justify-center-#{$variable}-up {
 			justify-content: center;
 		}
 
-		.#{$prefix}-justify-space-between-#{$variable}-up {
+		.rvt-justify-space-between-#{$variable}-up {
 			justify-content: space-between;
 		}
 
-		.#{$prefix}-justify-space-around-#{$variable}-up {
+		.rvt-justify-space-around-#{$variable}-up {
 			justify-content: space-around;
 		}
 
-		.#{$prefix}-justify-space-evenly-#{$variable}-up {
+		.rvt-justify-space-evenly-#{$variable}-up {
 			justify-content: space-evenly;
 		}
 	}
@@ -279,45 +279,45 @@
 
 // self
 
-.#{$prefix}-self-start {
+.rvt-self-start {
 	align-self: flex-start !important;
 }
 
-.#{$prefix}-self-end {
+.rvt-self-end {
 	align-self: flex-end !important;
 }
 
-.#{$prefix}-self-center {
+.rvt-self-center {
 	align-self: center !important;
 }
 
-.#{$prefix}-self-baseline {
+.rvt-self-baseline {
 	align-self: baseline !important;
 }
 
-.#{$prefix}-self-stretch {
+.rvt-self-stretch {
 	align-self: stretch !important;
 }
 
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
-		.#{$prefix}-self-start-#{$variable}-up {
+		.rvt-self-start-#{$variable}-up {
 			align-self: flex-start;
 		}
 
-		.#{$prefix}-self-end-#{$variable}-up {
+		.rvt-self-end-#{$variable}-up {
 			align-self: flex-end;
 		}
 
-		.#{$prefix}-self-center-#{$variable}-up {
+		.rvt-self-center-#{$variable}-up {
 			align-self: center;
 		}
 
-		.#{$prefix}-self-baseline-#{$variable}-up {
+		.rvt-self-baseline-#{$variable}-up {
 			align-self: baseline;
 		}
 
-		.#{$prefix}-self-stretch-#{$variable}-up {
+		.rvt-self-stretch-#{$variable}-up {
 			align-self: stretch;
 		}
 	}

--- a/src/sass/utilities/_gap.scss
+++ b/src/sass/utilities/_gap.scss
@@ -9,15 +9,15 @@ $modifiers: (
 );
 
 @each $size, $value in map.merge($modifiers, $spacing) {
-	.#{$prefix}-gap-#{$size} {
+	.rvt-gap-#{$size} {
 		gap: $value !important;
 	}
 
-	.#{$prefix}-gap-col-#{$size} {
+	.rvt-gap-col-#{$size} {
 		column-gap: $value !important;
 	}
 
-	.#{$prefix}-gap-row-#{$size} {
+	.rvt-gap-row-#{$size} {
 		row-gap: $value !important;
 	}
 }

--- a/src/sass/utilities/_rich-text.scss
+++ b/src/sass/utilities/_rich-text.scss
@@ -4,7 +4,7 @@
 
 .rvt-prose,
 .rvt-rich-text {
-	--rvt-rich-text-stack-space: #{$spacing-md};
+	--rvt-rich-text-stack-space: #{var(--rvt-spacing-md)};
 	max-width: 80ch;
 
 	> * {
@@ -54,9 +54,9 @@
 	h5,
 	h6 {
 		// Reset the flow space here to put more space before headings.
-		--rvt-rich-text-stack-space: #{$spacing-lg};
+		--rvt-rich-text-stack-space: #{var(--rvt-spacing-lg)};
 		line-height: 1.1;
-		scroll-margin-top: $spacing-md;
+		scroll-margin-top: var(--rvt-spacing-md);
 		// -webkit-font-smoothing: antialiased;
 		// -moz-osx-font-smoothing: grayscale;
 	}
@@ -74,7 +74,7 @@
 
 	:where(li + li),
 	:where(li > ul) {
-		margin-top: $spacing-sm;
+		margin-top: var(--rvt-spacing-sm);
 	}
 
 	:where(li)::marker {
@@ -87,13 +87,13 @@
 	> figure + *,
 	> hr,
 	> hr + * {
-		--rvt-rich-text-stack-space: #{$spacing-xl};
+		--rvt-rich-text-stack-space: #{var(--rvt-spacing-xl)};
 	}
 
 	// Reduce the amount of stack space if a heading is
 	// immediately followed by another heading
 	> :is(h2, h3, h4, h5) + :is(h2, h3, h4, h5) {
-		--rvt-rich-text-stack-space: #{$spacing-md};
+		--rvt-rich-text-stack-space: #{var(--rvt-spacing-md)};
 	}
 
 	> :where(dl) {

--- a/src/sass/utilities/_rich-text.scss
+++ b/src/sass/utilities/_rich-text.scss
@@ -98,13 +98,13 @@
 
 	> :where(dl) {
 		/* stylelint-disable */
-		@extend .#{$prefix}-list-description;
+		@extend .rvt-list-description;
 		/* stylelint-enable */
 	}
 
 	:where(code) {
 		/* stylelint-disable */
-		@extend .#{$prefix}-code;
+		@extend .rvt-code;
 		/* stylelint-enable */
 	}
 

--- a/src/sass/utilities/_rich-text.scss
+++ b/src/sass/utilities/_rich-text.scss
@@ -7,7 +7,7 @@
 
 .rvt-prose,
 .rvt-rich-text {
-	--rvt-rich-text-stack-space: #{var(--rvt-spacing-md)};
+	--rvt-rich-text-stack-space: var(--rvt-spacing-md);
 	max-width: 80ch;
 
 	> * {
@@ -57,7 +57,7 @@
 	h5,
 	h6 {
 		// Reset the flow space here to put more space before headings.
-		--rvt-rich-text-stack-space: #{var(--rvt-spacing-lg)};
+		--rvt-rich-text-stack-space: var(--rvt-spacing-lg);
 		line-height: 1.1;
 		scroll-margin-top: var(--rvt-spacing-md);
 		// -webkit-font-smoothing: antialiased;
@@ -90,13 +90,13 @@
 	> figure + *,
 	> hr,
 	> hr + * {
-		--rvt-rich-text-stack-space: #{var(--rvt-spacing-xl)};
+		--rvt-rich-text-stack-space: var(--rvt-spacing-xl);
 	}
 
 	// Reduce the amount of stack space if a heading is
 	// immediately followed by another heading
 	> :is(h2, h3, h4, h5) + :is(h2, h3, h4, h5) {
-		--rvt-rich-text-stack-space: #{var(--rvt-spacing-md)};
+		--rvt-rich-text-stack-space: var(--rvt-spacing-md);
 	}
 
 	> :where(dl) {

--- a/src/sass/utilities/_rich-text.scss
+++ b/src/sass/utilities/_rich-text.scss
@@ -44,7 +44,7 @@
 		font-variation-settings:
 			"wdth" 135,
 			"YTLC" 540;
-		font-weight: $font-weight-bold;
+		font-weight: var(--rvt-font-weight-bold);
 	}
 
 	h1,

--- a/src/sass/utilities/_rich-text.scss
+++ b/src/sass/utilities/_rich-text.scss
@@ -16,21 +16,21 @@
 	}
 
 	h1 {
-		font-size: $ts-32;
+		font-size: var(--rvt-ts-32);
 	}
 
 	h2 {
-		font-size: $ts-23;
+		font-size: var(--rvt-ts-23);
 	}
 
 	h3 {
-		font-size: $ts-20;
+		font-size: var(--rvt-ts-20);
 	}
 
 	h4,
 	h5,
 	h6 {
-		font-size: $ts-18;
+		font-size: var(--rvt-ts-18);
 	}
 
 	h1,
@@ -120,25 +120,25 @@
 		:where(li),
 		:where(td),
 		:where(dt) {
-			font-size: $ts-18;
+			font-size: var(--rvt-ts-18);
 		}
 
 		h1 {
-			font-size: $ts-41;
+			font-size: var(--rvt-ts-41);
 		}
 
 		h2 {
-			font-size: $ts-32;
+			font-size: var(--rvt-ts-32);
 		}
 
 		h3 {
-			font-size: $ts-26;
+			font-size: var(--rvt-ts-26);
 		}
 
 		h4,
 		h5,
 		h6 {
-			font-size: $ts-23;
+			font-size: var(--rvt-ts-23);
 		}
 	}
 }

--- a/src/sass/utilities/_rich-text.scss
+++ b/src/sass/utilities/_rich-text.scss
@@ -1,3 +1,6 @@
+// Copyright (C) 2018 The Trustees of Indiana University
+// SPDX-License-Identifier: BSD-3-Clause
+
 @use "../core" as *;
 @use "../lists";
 @use "../utilities/elements";

--- a/src/sass/utilities/_shadow.scss
+++ b/src/sass/utilities/_shadow.scss
@@ -7,11 +7,11 @@
 
 @each $key, $value in map.get($tokens, "shadow") {
 	@if string.index($key, "base") {
-		.#{$prefix}-shadow {
+		.rvt-shadow {
 			box-shadow: $value !important;
 		}
 	} @else {
-		.#{$prefix}-shadow-#{$key} {
+		.rvt-shadow-#{$key} {
 			box-shadow: $value !important;
 		}
 	}

--- a/src/sass/utilities/_spacing.scss
+++ b/src/sass/utilities/_spacing.scss
@@ -15,15 +15,15 @@ $spacing-directions: (null, -top, -right, -bottom, -left);
 // NOTE you can reference these sizes in core/_variables.scss
 
 $spacing-sizes: (
-	-xxs: $spacing-xxs,
-	-xs: $spacing-xs,
-	-sm: $spacing-sm,
-	-md: $spacing-md,
-	-lg: $spacing-lg,
-	-xl: $spacing-xl,
-	-xxl: $spacing-xxl,
-	-3-xl: $spacing-3-xl,
-	-4-xl: $spacing-4-xl
+	-xxs: var(--rvt-spacing-xxs),
+	-xs: var(--rvt-spacing-xs),
+	-sm: var(--rvt-spacing-sm),
+	-md: var(--rvt-spacing-md),
+	-lg: var(--rvt-spacing-lg),
+	-xl: var(--rvt-spacing-xl),
+	-xxl: var(--rvt-spacing-xxl),
+	-3-xl: var(--rvt-spacing-3-xl),
+	-4-xl: var(--rvt-spacing-4-xl)
 );
 
 // Super gnarly loop here, but it saves sooo much time

--- a/src/sass/utilities/_spacing.scss
+++ b/src/sass/utilities/_spacing.scss
@@ -38,45 +38,45 @@ $spacing-sizes: (
 
 		// If the direction is "null", add margin to all directions.
 		@if $direction == null {
-			.#{$prefix}-m-all#{$size} {
+			.rvt-m-all#{$size} {
 				margin: $value !important;
 			}
 
-			.#{$prefix}-p-all#{$size} {
+			.rvt-p-all#{$size} {
 				padding: $value !important;
 			}
 
-			.#{$prefix}-m-tb#{$size} {
+			.rvt-m-tb#{$size} {
 				margin-bottom: $value !important;
 				margin-top: $value !important;
 			}
 
-			.#{$prefix}-m-lr#{$size} {
+			.rvt-m-lr#{$size} {
 				margin-left: $value !important;
 				margin-right: $value !important;
 			}
 
-			.#{$prefix}-p-tb#{$size} {
+			.rvt-p-tb#{$size} {
 				padding-bottom: $value !important;
 				padding-top: $value !important;
 			}
 
-			.#{$prefix}-p-lr#{$size} {
+			.rvt-p-lr#{$size} {
 				padding-left: $value !important;
 				padding-right: $value !important;
 			}
 
 			// Otherwise create individual direction utilities.
 		} @else {
-			.#{$prefix}-m#{$direction}#{$size} {
+			.rvt-m#{$direction}#{$size} {
 				margin#{$direction}: $value !important;
 			}
 
-			.-#{$prefix}-m#{$direction}#{$size} {
+			.-rvt-m#{$direction}#{$size} {
 				margin#{$direction}: -$value !important;
 			}
 
-			.#{$prefix}-p#{$direction}#{$size} {
+			.rvt-p#{$direction}#{$size} {
 				padding#{$direction}: $value !important;
 			}
 		}
@@ -96,45 +96,45 @@ $spacing-sizes: (
 
 				// If the direction is "null", add margin to all directions.
 				@if $direction == null {
-					.#{$prefix}-m-all#{$suffix}-#{$variable}-up {
+					.rvt-m-all#{$suffix}-#{$variable}-up {
 						margin: $refs !important;
 					}
 
-					.#{$prefix}-p-all#{$suffix}-#{$variable}-up {
+					.rvt-p-all#{$suffix}-#{$variable}-up {
 						padding: $refs !important;
 					}
 
-					.#{$prefix}-m-tb#{$suffix}-#{$variable}-up {
+					.rvt-m-tb#{$suffix}-#{$variable}-up {
 						margin-bottom: $refs !important;
 						margin-top: $refs !important;
 					}
 
-					.#{$prefix}-m-lr#{$suffix}-#{$variable}-up {
+					.rvt-m-lr#{$suffix}-#{$variable}-up {
 						margin-left: $refs !important;
 						margin-right: $refs !important;
 					}
 
-					.#{$prefix}-p-tb#{$suffix}-#{$variable}-up {
+					.rvt-p-tb#{$suffix}-#{$variable}-up {
 						padding-bottom: $refs !important;
 						padding-top: $refs !important;
 					}
 
-					.#{$prefix}-p-lr#{$suffix}-#{$variable}-up {
+					.rvt-p-lr#{$suffix}-#{$variable}-up {
 						padding-left: $refs !important;
 						padding-right: $refs !important;
 					}
 
 					// Otherwise create individual direction utilities.
 				} @else {
-					.#{$prefix}-m#{$direction}#{$suffix}-#{$variable}-up {
+					.rvt-m#{$direction}#{$suffix}-#{$variable}-up {
 						margin#{$direction}: $refs !important;
 					}
 
-					.-#{$prefix}-m#{$direction}#{$suffix}-#{$variable}-up {
+					.-rvt-m#{$direction}#{$suffix}-#{$variable}-up {
 						margin#{$direction}: -$refs !important;
 					}
 
-					.#{$prefix}-p#{$direction}#{$suffix}-#{$variable}-up {
+					.rvt-p#{$direction}#{$suffix}-#{$variable}-up {
 						padding#{$direction}: $refs !important;
 					}
 				}
@@ -151,47 +151,47 @@ $spacing-sizes: (
 // class with "rvt-" moving forward.
 @each $direction in $spacing-directions {
 	@if $direction == null {
-		.#{$prefix}-m-all-remove,
-		.#{$prefix}-m-all-none {
+		.rvt-m-all-remove,
+		.rvt-m-all-none {
 			margin: 0 !important;
 		}
 
-		.#{$prefix}-m-tb-remove,
-		.#{$prefix}-m-tb-none {
+		.rvt-m-tb-remove,
+		.rvt-m-tb-none {
 			margin-top: 0 !important;
 			margin-bottom: 0 !important;
 		}
 
-		.#{$prefix}-m-lr-remove,
-		.#{$prefix}-m-lr-none {
+		.rvt-m-lr-remove,
+		.rvt-m-lr-none {
 			margin-left: 0 !important;
 			margin-right: 0 !important;
 		}
 
-		.#{$prefix}-p-all-remove,
-		.#{$prefix}-p-all-none {
+		.rvt-p-all-remove,
+		.rvt-p-all-none {
 			padding: 0 !important;
 		}
 
-		.#{$prefix}-p-tb-remove,
-		.#{$prefix}-p-tb-none {
+		.rvt-p-tb-remove,
+		.rvt-p-tb-none {
 			padding-top: 0 !important;
 			padding-bottom: 0 !important;
 		}
 
-		.#{$prefix}-p-lr-remove,
-		.#{$prefix}-p-lr-none {
+		.rvt-p-lr-remove,
+		.rvt-p-lr-none {
 			padding-left: 0 !important;
 			padding-right: 0 !important;
 		}
 	} @else {
-		.#{$prefix}-m#{$direction}-remove,
-		.#{$prefix}-m#{$direction}-none {
+		.rvt-m#{$direction}-remove,
+		.rvt-m#{$direction}-none {
 			margin#{$direction}: 0 !important;
 		}
 
-		.#{$prefix}-p#{$direction}-remove,
-		.#{$prefix}-p#{$direction}-none {
+		.rvt-p#{$direction}-remove,
+		.rvt-p#{$direction}-none {
 			padding#{$direction}: 0 !important;
 		}
 	}
@@ -204,39 +204,39 @@ $spacing-sizes: (
 	@include mq($size) {
 		@each $direction in $spacing-directions {
 			@if $direction == null {
-				.#{$prefix}-m-all-none-#{$variable}-up {
+				.rvt-m-all-none-#{$variable}-up {
 					margin: 0 !important;
 				}
 
-				.#{$prefix}-p-all-none-#{$variable}-up {
+				.rvt-p-all-none-#{$variable}-up {
 					padding: 0 !important;
 				}
 
-				.#{$prefix}-m-tb-none-#{$variable}-up {
+				.rvt-m-tb-none-#{$variable}-up {
 					margin-top: 0 !important;
 					margin-bottom: 0 !important;
 				}
 
-				.#{$prefix}-p-tb-none-#{$variable}-up {
+				.rvt-p-tb-none-#{$variable}-up {
 					padding-top: 0 !important;
 					padding-bottom: 0 !important;
 				}
 
-				.#{$prefix}-m-lr-none-#{$variable}-up {
+				.rvt-m-lr-none-#{$variable}-up {
 					margin-right: 0 !important;
 					margin-left: 0 !important;
 				}
 
-				.#{$prefix}-p-lr-none-#{$variable}-up {
+				.rvt-p-lr-none-#{$variable}-up {
 					padding-right: 0 !important;
 					padding-left: 0 !important;
 				}
 			} @else {
-				.#{$prefix}-m#{$direction}-none-#{$variable}-up {
+				.rvt-m#{$direction}-none-#{$variable}-up {
 					margin#{$direction}: 0 !important;
 				}
 
-				.#{$prefix}-p#{$direction}-none-#{$variable}-up {
+				.rvt-p#{$direction}-none-#{$variable}-up {
 					padding#{$direction}: 0 !important;
 				}
 			}

--- a/src/sass/utilities/_stack.scss
+++ b/src/sass/utilities/_stack.scss
@@ -5,7 +5,7 @@
 
 .rvt-stack,
 .rvt-flow {
-	--rvt-stack-space: #{$spacing-lg};
+	--rvt-stack-space: #{var(--rvt-spacing-lg)};
 }
 
 .rvt-flow > *,
@@ -28,6 +28,6 @@
 @include mq($breakpoint-md) {
 	.rvt-flow,
 	.rvt-stack {
-		--rvt-stack-space: #{$spacing-sm * 5};
+		--rvt-stack-space: calc(var(--rvt-spacing-sm) * 5);
 	}
 }

--- a/src/sass/utilities/_stack.scss
+++ b/src/sass/utilities/_stack.scss
@@ -5,7 +5,7 @@
 
 .rvt-stack,
 .rvt-flow {
-	--rvt-stack-space: #{var(--rvt-spacing-lg)};
+	--rvt-stack-space: var(--rvt-spacing-lg);
 }
 
 .rvt-flow > *,

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -66,17 +66,17 @@
 }
 
 .rvt-font-condensed {
-	font-family: $font-family-condensed !important;
+	font-family: var(--rvt-font-family-condensed) !important;
 }
 
 .rvt-font-sans {
-	font-family: $font-family-sans !important;
+	font-family: var(--rvt-font-family-sans) !important;
 }
 
 .rvt-font-serif {
-	font-family: $font-family-serif !important;
+	font-family: var(--rvt-font-family-serif) !important;
 }
 
 .rvt-font-mono {
-	font-family: $font-family-mono !important;
+	font-family: var(--rvt-font-family-mono) !important;
 }

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -19,22 +19,22 @@
 
 .rvt-text-black,
 .rvt-font-black {
-	font-weight: $font-weight-black !important;
+	font-weight: var(--rvt-font-weight-black) !important;
 }
 
 .rvt-text-bold,
 .rvt-font-bold {
-	font-weight: $font-weight-bold !important;
+	font-weight: var(--rvt-font-weight-bold) !important;
 }
 
 .rvt-text-medium,
 .rvt-font-medium {
-	font-weight: $font-weight-medium !important;
+	font-weight: var(--rvt-font-weight-medium) !important;
 }
 
 .rvt-text-regular,
 .rvt-font-regular {
-	font-weight: $font-weight-regular !important;
+	font-weight: var(--rvt-font-weight-regular) !important;
 }
 
 .rvt-text-left {

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -3,7 +3,7 @@
 
 @use "../core" as *;
 
-.#{$prefix}-text-uppercase {
+.rvt-text-uppercase {
 	text-transform: uppercase !important;
 
 	/**
@@ -13,70 +13,70 @@
 	letter-spacing: 0.04rem !important;
 }
 
-.#{$prefix}-text-lowercase {
+.rvt-text-lowercase {
 	text-transform: lowercase !important;
 }
 
-.#{$prefix}-text-black,
-.#{$prefix}-font-black {
+.rvt-text-black,
+.rvt-font-black {
 	font-weight: $font-weight-black !important;
 }
 
-.#{$prefix}-text-bold,
-.#{$prefix}-font-bold {
+.rvt-text-bold,
+.rvt-font-bold {
 	font-weight: $font-weight-bold !important;
 }
 
-.#{$prefix}-text-medium,
-.#{$prefix}-font-medium {
+.rvt-text-medium,
+.rvt-font-medium {
 	font-weight: $font-weight-medium !important;
 }
 
-.#{$prefix}-text-regular,
-.#{$prefix}-font-regular {
+.rvt-text-regular,
+.rvt-font-regular {
 	font-weight: $font-weight-regular !important;
 }
 
-.#{$prefix}-text-left {
+.rvt-text-left {
 	text-align: left !important;
 }
 
-.#{$prefix}-text-right {
+.rvt-text-right {
 	text-align: right !important;
 }
 
-.#{$prefix}-text-center {
+.rvt-text-center {
 	text-align: center !important;
 }
 
-.#{$prefix}-lh-base {
+.rvt-lh-base {
 	line-height: $line-height-base !important;
 }
 
-.#{$prefix}-lh-tight {
+.rvt-lh-tight {
 	line-height: $line-height-tight !important;
 }
 
-.#{$prefix}-lh-loose {
+.rvt-lh-loose {
 	line-height: $line-height-loose !important;
 }
 
-.#{$prefix}-text-nobr {
+.rvt-text-nobr {
 	white-space: nowrap !important;
 }
 
-.#{$prefix}-font-condensed {
+.rvt-font-condensed {
 	font-family: $font-family-condensed !important;
 }
 
-.#{$prefix}-font-sans {
+.rvt-font-sans {
 	font-family: $font-family-sans !important;
 }
 
-.#{$prefix}-font-serif {
+.rvt-font-serif {
 	font-family: $font-family-serif !important;
 }
 
-.#{$prefix}-font-mono {
+.rvt-font-mono {
 	font-family: $font-family-mono !important;
 }

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -50,15 +50,15 @@
 }
 
 .rvt-lh-base {
-	line-height: $line-height-base !important;
+	line-height: var(--rvt-line-height-base) !important;
 }
 
 .rvt-lh-tight {
-	line-height: $line-height-tight !important;
+	line-height: var(--rvt-line-height-tight) !important;
 }
 
 .rvt-lh-loose {
-	line-height: $line-height-loose !important;
+	line-height: var(--rvt-line-height-loose) !important;
 }
 
 .rvt-text-nobr {

--- a/src/sass/utilities/_text.scss
+++ b/src/sass/utilities/_text.scss
@@ -1,8 +1,6 @@
 // Copyright (C) 2018 The Trustees of Indiana University
 // SPDX-License-Identifier: BSD-3-Clause
 
-@use "../core" as *;
-
 .rvt-text-uppercase {
 	text-transform: uppercase !important;
 

--- a/src/sass/utilities/_type-scale.scss
+++ b/src/sass/utilities/_type-scale.scss
@@ -12,7 +12,7 @@
  */
 
 @each $pixels, $rems in $type-scale {
-	.#{$prefix}-ts-#{$pixels} {
+	.rvt-ts-#{$pixels} {
 		font-size: $rems !important;
 	}
 }
@@ -30,7 +30,7 @@
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
 		@each $pixels, $rems in $type-scale {
-			.#{$prefix}-ts-#{$pixels}-#{$variable}-up {
+			.rvt-ts-#{$pixels}-#{$variable}-up {
 				font-size: $rems !important;
 			}
 		}

--- a/src/sass/utilities/_visibility.scss
+++ b/src/sass/utilities/_visibility.scss
@@ -8,23 +8,23 @@
 }
 
 @each $variable, $size in $breakpoints {
-	.#{$prefix}-hide-#{$variable}-down {
+	.rvt-hide-#{$variable}-down {
 		@extend %start-hidden;
 	}
 
 	@include mq($size) {
-		.#{$prefix}-hide-#{$variable}-down {
+		.rvt-hide-#{$variable}-down {
 			display: block !important;
 		}
 
-		th.#{$prefix}-hide-#{$variable}-down,
-		td.#{$prefix}-hide-#{$variable}-down {
+		th.rvt-hide-#{$variable}-down,
+		td.rvt-hide-#{$variable}-down {
 			display: table-cell !important;
 		}
 	}
 
 	@include mq($size) {
-		.#{$prefix}-hide-#{$variable}-up {
+		.rvt-hide-#{$variable}-up {
 			display: none !important;
 		}
 	}

--- a/src/sass/utilities/_width.scss
+++ b/src/sass/utilities/_width.scss
@@ -6,7 +6,7 @@
 // Builds non-responsive width utility classes
 
 @each $token, $width in $widths {
-	.#{$prefix}-width-#{$token} {
+	.rvt-width-#{$token} {
 		width: 100% !important;
 		max-width: $width !important;
 	}
@@ -17,7 +17,7 @@
 @each $variable, $size in $breakpoints {
 	@include mq($size) {
 		@each $token, $width in $widths {
-			.#{$prefix}-width-#{$token}-#{$variable}-up {
+			.rvt-width-#{$token}-#{$variable}-up {
 				width: 100% !important;
 				max-width: $width !important;
 			}

--- a/src/sass/utilities/_z-index.scss
+++ b/src/sass/utilities/_z-index.scss
@@ -5,7 +5,7 @@
 
 /* stylelint-disable */
 @each $index, $level in $z-index {
-	.#{$prefix}-z-#{$index} {
+	.rvt-z-#{$index} {
 		z-index: $level !important;
 	}
 }

--- a/src/sass/validation/_base.scss
+++ b/src/sass/validation/_base.scss
@@ -42,7 +42,7 @@
 .rvt-inline-alert {
 	align-items: center;
 	display: flex;
-	font-size: $ts-14;
+	font-size: var(--rvt-ts-14);
 
 	&__icon {
 		height: var(--rvt-spacing-sm);

--- a/src/sass/validation/_base.scss
+++ b/src/sass/validation/_base.scss
@@ -3,25 +3,25 @@
 
 @use "../core" as *;
 
-@include all-inputs(".#{$prefix}-validation-info") {
+@include all-inputs(".rvt-validation-info") {
 	background-color: var(--rvt-color-info-background);
 	border-color: var(--rvt-color-info-border);
 	box-shadow: 0 0 0 0.0625rem var(--rvt-color-info-border);
 }
 
-@include all-inputs(".#{$prefix}-validation-warning") {
+@include all-inputs(".rvt-validation-warning") {
 	background-color: var(--rvt-color-warning-background);
 	border-color: var(--rvt-color-warning-border);
 	box-shadow: 0 0 0 0.0625rem var(--rvt-color-warning-border);
 }
 
-@include all-inputs(".#{$prefix}-validation-danger") {
+@include all-inputs(".rvt-validation-danger") {
 	background-color: var(--rvt-color-danger-background);
 	border-color: var(--rvt-color-danger-border);
 	box-shadow: 0 0 0 0.0625rem var(--rvt-color-danger-border);
 }
 
-@include all-inputs(".#{$prefix}-validation-success") {
+@include all-inputs(".rvt-validation-success") {
 	background-color: var(--rvt-color-success-background);
 	border-color: var(--rvt-color-success-border);
 	box-shadow: 0 0 0 0.0625rem var(--rvt-color-success-border);
@@ -33,13 +33,13 @@
  * alongside groups of form inputs like radio buttons and checkboxes
  */
 
-.rvt-text-input + .#{$prefix}-inline-alert,
-.rvt-select + .#{$prefix}-inline-alert,
-.rvt-textarea + .#{$prefix}-inline-alert {
+.rvt-text-input + .rvt-inline-alert,
+.rvt-select + .rvt-inline-alert,
+.rvt-textarea + .rvt-inline-alert {
 	margin-block-start: $spacing-xs;
 }
 
-.#{$prefix}-inline-alert {
+.rvt-inline-alert {
 	align-items: center;
 	display: flex;
 	font-size: $ts-14;
@@ -82,35 +82,35 @@
 	&--standalone {
 		padding: $spacing-xs;
 
-		&.#{$prefix}-inline-alert--is-invalid,
-		&.#{$prefix}-inline-alert--danger {
+		&.rvt-inline-alert--is-invalid,
+		&.rvt-inline-alert--danger {
 			background-color: var(--rvt-color-danger-background);
 
-			.#{$prefix}-inline-alert__message {
+			.rvt-inline-alert__message {
 				color: var(--rvt-color-danger-main);
 			}
 		}
 
-		&.#{$prefix}-inline-alert--success {
+		&.rvt-inline-alert--success {
 			background-color: var(--rvt-color-success-background);
 
-			.#{$prefix}-inline-alert__message {
+			.rvt-inline-alert__message {
 				color: var(--rvt-color-success-main);
 			}
 		}
 
-		&.#{$prefix}-inline-alert--warning {
+		&.rvt-inline-alert--warning {
 			background-color: var(--rvt-color-warning-background);
 
-			.#{$prefix}-inline-alert__message {
+			.rvt-inline-alert__message {
 				color: var(--rvt-color-warning-main);
 			}
 		}
 
-		&.#{$prefix}-inline-alert--info {
+		&.rvt-inline-alert--info {
 			background-color: var(--rvt-color-info-background);
 
-			.#{$prefix}-inline-alert__message {
+			.rvt-inline-alert__message {
 				color: var(--rvt-color-info-main);
 			}
 		}

--- a/src/sass/validation/_base.scss
+++ b/src/sass/validation/_base.scss
@@ -36,7 +36,7 @@
 .rvt-text-input + .rvt-inline-alert,
 .rvt-select + .rvt-inline-alert,
 .rvt-textarea + .rvt-inline-alert {
-	margin-block-start: $spacing-xs;
+	margin-block-start: var(--rvt-spacing-xs);
 }
 
 .rvt-inline-alert {
@@ -45,13 +45,13 @@
 	font-size: $ts-14;
 
 	&__icon {
-		height: $spacing-sm;
-		width: $spacing-sm;
+		height: var(--rvt-spacing-sm);
+		width: var(--rvt-spacing-sm);
 	}
 
 	&__message {
 		line-height: 1;
-		margin-left: $spacing-xs;
+		margin-left: var(--rvt-spacing-xs);
 	}
 
 	&--success {
@@ -80,7 +80,7 @@
    */
 
 	&--standalone {
-		padding: $spacing-xs;
+		padding: var(--rvt-spacing-xs);
 
 		&.rvt-inline-alert--is-invalid,
 		&.rvt-inline-alert--danger {

--- a/tasks/component-starter-code.scss.txt
+++ b/tasks/component-starter-code.scss.txt
@@ -3,6 +3,6 @@
 
 @use '../core' as *;
 
-.#{$prefix}-{{ slug }} {
+.rvt-{{ slug }} {
   // Styles here
 }


### PR DESCRIPTION
Changes:
1. Replaced Sass class selector `.#{$prefix}-` with `.rvt-`.
2. Replaced Sass vars (`$*`) with CSS vars (`--rvt-*`).
3. Replaced Sass `math` with CSS `calc()`.
4. Removed `@use` declarations where possible.
5. Added license comment banner in some Sass files where I noticed it. (Not comprehensive.)

Future work:
1. Sass loops
2. Sass breakpoints
3. Add a build process for managing license banners. Rivet React has a [license solution](https://github.com/indiana-university/rivet-react/blob/v2.5.4/package.json#L126).
4. Remove Sass class selector interpolation to be compatible with native CSS nesting syntax.