### PR TITLE
Use down arrow only when link starts with #

### DIFF
--- a/src/sass/buttons/_base.scss
+++ b/src/sass/buttons/_base.scss
@@ -114,7 +114,7 @@
 	--rotate: 0;
 	justify-content: space-between;
 
-	&[href*="#"] {
+	&[href^="#"] {
 		--rotate: 90deg;
 	}
 

--- a/src/sass/list-hub/_base.scss
+++ b/src/sass/list-hub/_base.scss
@@ -70,7 +70,7 @@
 		--rotate: -135deg;
 	}
 
-	&__link[href*="#"] {
+	&__link[href^="#"] {
 		--rotate: 0;
 	}
 


### PR DESCRIPTION
Notes:
1. Resolves [EEDS-106](https://iu-uits.atlassian.net/browse/EEDS-106).
2. This makes it so links like `https://example.com/#section` or `/foo.html#bar` still use the external (upper right) and internal (right) arrow directions.
3. This fix is in place for both `button` and `list-hub` components.

[EEDS-106]: https://iu-uits.atlassian.net/browse/EEDS-106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ