### PR TITLE
Remove the default aspect ratio for one image in image hub

### DIFF
--- a/src/components/image-hub/image-hub.css
+++ b/src/components/image-hub/image-hub.css
@@ -42,7 +42,7 @@
 	}
 
 	img {
-		aspect-ratio: var(--aspect-ratio, var(--aspect-ratio-fullscreen));
+		aspect-ratio: var(--aspect-ratio);
 		height: 100%;
 		max-width: 100%;
 		object-fit: cover;


### PR DESCRIPTION
Fixes bug: [EEDS-143](https://iu-uits.atlassian.net/browse/EEDS-143)

[EEDS-143]: https://iu-uits.atlassian.net/browse/EEDS-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ