### PR TITLE
Refine width of body size bold content

### DIFF
--- a/src/base/fonts.css
+++ b/src/base/fonts.css
@@ -126,9 +126,11 @@
 	--rvt-font-12-fluid-mono: var(--rvt-font-weight-normal)
 		var(--rvt-size-12-14) / var(--rvt-size-16) var(--rvt-font-family-mono);
 
-	--rvt-font-14: var(--rvt-font-width-expanded) var(--rvt-font-weight-normal)
+	--rvt-font-14: var(--rvt-font-width-semi-expanded) var(--rvt-font-weight-normal)
 		var(--rvt-size-14) / var(--rvt-size-20) var(--rvt-font-family-sans);
-	--rvt-font-14-bold: var(--rvt-font-width-expanded) var(--rvt-font-weight-bold)
+	--rvt-font-14-bold: var(--rvt-font-width-semi-expanded) var(--rvt-font-weight-bold)
+		var(--rvt-size-14) / var(--rvt-size-20) var(--rvt-font-family-sans);
+	--rvt-font-14-bold-wide: var(--rvt-font-width-expanded) var(--rvt-font-weight-bold)
 		var(--rvt-size-14) / var(--rvt-size-20) var(--rvt-font-family-sans);
 	--rvt-font-14-mono: var(--rvt-font-weight-normal) var(--rvt-size-14) /
 		var(--rvt-size-16) var(--rvt-font-family-mono);
@@ -139,7 +141,9 @@
 	--rvt-font-16-fluid: var(--rvt-font-width-semi-expanded)
 		var(--rvt-font-weight-normal) var(--rvt-size-16-18) / var(--rvt-size-24-28)
 		var(--rvt-font-family-sans);
-	--rvt-font-16-bold: var(--rvt-font-width-expanded) var(--rvt-font-weight-bold)
+	--rvt-font-16-bold: var(--rvt-font-width-semi-expanded) var(--rvt-font-weight-bold)
+		var(--rvt-size-16) / var(--rvt-size-24) var(--rvt-font-family-sans);
+	--rvt-font-16-bold-wide: var(--rvt-font-width-expanded) var(--rvt-font-weight-bold)
 		var(--rvt-size-16) / var(--rvt-size-24) var(--rvt-font-family-sans);
 	--rvt-font-16-mono: var(--rvt-font-weight-normal) var(--rvt-size-16) /
 		var(--rvt-size-24) var(--rvt-font-family-mono);

--- a/src/components/billboard/billboard.scss
+++ b/src/components/billboard/billboard.scss
@@ -62,7 +62,7 @@
 	}
 
 	.rvt-list-hub__link {
-		font: var(--rvt-font-16-bold);
+		font: var(--rvt-font-16-bold-wide);
 
 		&::before {
 			margin-block-start: var(--rvt-size-4);

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -11,7 +11,7 @@
 	--color-background-pressed: var(--rvt-color-theme-background-strong);
 	--color-text: var(--rvt-color-theme-text-strong);
 	--color-text-hover: var(--rvt-color-theme-background-inverse-strong);
-	--font: var(--rvt-font-16-bold);
+	--font: var(--rvt-font-16-bold-wide);
 	--gap: var(--rvt-spacing-xs);
 	--padding-block: calc(var(--padding-block-total) / 2);
 	--padding-block-total: calc(
@@ -73,7 +73,7 @@
 }
 
 .rvt-button--medium {
-	--font: var(--rvt-font-14-bold);
+	--font: var(--rvt-font-14-bold-wide);
 	--size-height: var(--rvt-size-32);
 }
 
@@ -82,7 +82,7 @@
 	--color-border-hover: var(--rvt-color-theme-ui);
 	--color-text: var(--rvt-color-theme-accent);
 	--color-text-hover: var(--rvt-color-theme-accent-strong);
-	--font: var(--rvt-font-14-bold);
+	--font: var(--rvt-font-14-bold-wide);
 	--gap: var(--rvt-spacing-xxs);
 	--size-height: var(--rvt-size-24);
 	--size-pressed: var(--rvt-size-1);

--- a/src/components/disclosure/disclosure.css
+++ b/src/components/disclosure/disclosure.css
@@ -13,7 +13,7 @@
 		border: none;
 		color: var(--rvt-color-theme-accent);
 		display: flex;
-		font: var(--rvt-font-16-bold);
+		font: var(--rvt-font-16-bold-wide);
 		gap: var(--rvt-spacing-xs);
 		padding: 0;
 

--- a/src/components/dropdown/dropdown.scss
+++ b/src/components/dropdown/dropdown.scss
@@ -84,7 +84,7 @@
 
 	&__menu-heading {
 		color: var(--rvt-color-theme-text-strong);
-		font: var(--rvt-font-16-bold);
+		font: var(--rvt-font-16-bold-wide);
 		padding: var(--rvt-spacing-sm) var(--rvt-spacing-sm) var(--rvt-spacing-xxs);
 
 		&:first-child {

--- a/src/components/file/file.css
+++ b/src/components/file/file.css
@@ -17,7 +17,7 @@
 		cursor: pointer;
 		display: flex;
 		flex-grow: 0;
-		font: var(--rvt-font-16-bold);
+		font: var(--rvt-font-16-bold-wide);
 		margin-bottom: 0;
 		margin-top: 0;
 		width: inherit;
@@ -40,7 +40,7 @@
 
 		span {
 			display: inline-block;
-			font: var(--rvt-font-16-bold);
+			font: var(--rvt-font-16-bold-wide);
 		}
 	}
 }

--- a/src/components/header/header.scss
+++ b/src/components/header/header.scss
@@ -99,7 +99,7 @@
 
 	&-menu__link {
 		color: var(--rvt-color-theme-text-strong);
-		font: var(--rvt-font-14-bold);
+		font: var(--rvt-font-14-bold-wide);
 		padding-block: var(--rvt-spacing-xs);
 		text-decoration: none;
 
@@ -117,7 +117,7 @@
 			color: var(--rvt-color-theme-text-strong);
 			cursor: pointer;
 			display: flex;
-			font: var(--rvt-font-14-bold);
+			font: var(--rvt-font-14-bold-wide);
 			gap: var(--rvt-spacing-xs);
 			margin-top: var(--rvt-size-3);
 			padding-block: var(--rvt-spacing-xxs);

--- a/src/components/hero/hero.scss
+++ b/src/components/hero/hero.scss
@@ -104,7 +104,7 @@
 		margin-block-start: var(--rvt-spacing-lg);
 
 		.rvt-list-hub__link {
-			font: var(--rvt-font-16-bold);
+			font: var(--rvt-font-16-bold-wide);
 		}
 	}
 


### PR DESCRIPTION
Changes:
1. Links and buttons that are bold should be wide, not static content.

Future work:
1. Review naming conventions for font variables. Is the new `--rvt-font-14-bold-wide` and `--rvt-font-16-bold-wide` odd names, given there aren't "wide" variables at larger sizes?