### PR TITLE
Do not add max-width to hero title

### DIFF
--- a/src/components/hero/hero.scss
+++ b/src/components/hero/hero.scss
@@ -31,7 +31,7 @@
 			margin-block-start: 0;
 		}
 
-		> * {
+		> *:not(.rvt-hero__title) {
 			max-width: var(--width-max);
 		}
 	}


### PR DESCRIPTION
Changes
1. Do not add max-width to hero title. This will give more space for the title to spread out, reducing visual line breaks.