### PR TITLE
Export dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		".": {
 			"browser": "./dist/rivet.js",
 			"import": "./dist/rivet.js"
-		}
+		},
+		"./dist/": "./dist/"
 	},
 	"scripts": {
 		"start": "run-s build:tokens start:astro",


### PR DESCRIPTION
Changes:
1. Added new package export, so that all files in the `dist` folder can be imported without needing to explicitly name each file.

Before, this is the only thing that worked, when referencing from the installed package:

```js
import Rivet from "rivet-core";
```

This change will allow this also to work:

```js
import Rivet from "rivet-core/dist/rivet.js";
import "rivet-core/dist/rivet.css";
import "rivet-core/dist/rivet-icons.css";
import "rivet-core/dist/rivet-stickers.css";
```