### PR TITLE
Update breadcrumbs font

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.css
+++ b/src/components/breadcrumbs/breadcrumbs.css
@@ -6,7 +6,7 @@
 .rvt-breadcrumbs {
 	display: inline-flex;
 	flex-wrap: wrap;
-	font: var(--rvt-font-12-mono);
+	font: var(--rvt-font-14);
 	gap: var(--rvt-size-8) var(--rvt-size-4);
 	list-style: none;
 	margin: 0;


### PR DESCRIPTION
Changes:
1. Change breadcrumbs font from mono to sans serif. This makes the letters easier to read and saves on horizontal space.
