### PR TITLE
Add inline code styles

### DIFF
--- a/src/base/base.astro
+++ b/src/base/base.astro
@@ -1,0 +1,24 @@
+---
+export const title = "Base styles";
+---
+
+<h1>Heading level 1</h1>
+<h2>Heading level 2</h2>
+<h3>Heading level 3</h3>
+<h4>Heading level 4</h4>
+<h5>Heading level 5</h5>
+<h6>Heading level 6</h6>
+
+<hr>
+
+<p>Body text.</p>
+
+<p><strong>Strong text</strong>.</p>
+
+<p><em>Emphasized text</em>.</p>
+
+<p>Inline <code>code text with <a href="#">a link</a></code>.</p>
+
+<p>Sub <sub>text</sub>.</p>
+
+<p>Sup <sup>text</sup>.</p>

--- a/src/base/reset.css
+++ b/src/base/reset.css
@@ -30,6 +30,14 @@ body {
 	-webkit-text-size-adjust: 100%;
 }
 
+code {
+	background-color: var(--rvt-color-theme-background-strong);
+	border-radius: var(--rvt-size-2);
+	font-family: var(--rvt-font-family-mono);
+	font-size: 0.96em;
+	padding: var(--rvt-size-2) var(--rvt-size-4);
+}
+
 h1,
 h2,
 h3,

--- a/src/base/reset.css
+++ b/src/base/reset.css
@@ -34,7 +34,7 @@ code {
 	background-color: var(--rvt-color-theme-background-strong);
 	border-radius: var(--rvt-size-2);
 	font-family: var(--rvt-font-family-mono);
-	font-size: 0.96em;
+	font-size: 96%;
 	padding: var(--rvt-size-2) var(--rvt-size-4);
 }
 

--- a/src/sandbox/pages/[...path].astro
+++ b/src/sandbox/pages/[...path].astro
@@ -47,11 +47,13 @@ export function getStaticPaths() {
 		const title = page?.title || segments.at(-1);
 		const isFile = /\.[^/]*$/.test(path);
 		const type = isFile ? "file" : "folder";
+		const isBase = /\/base\//.test(path);
 		const isComponent = /\/components\//.test(path);
 		const isLayout = /\/layouts\//.test(path);
 		const isPrototype = /\/prototypes\//.test(path);
 		const isUtility = /\/utilities\//.test(path);
 		const [fileType] = [
+			isBase && "component",
 			isComponent && "component",
 			isLayout && "layout",
 			isPrototype && "prototype",


### PR DESCRIPTION
Notes:
1. See: [EEDS-219](https://iu-uits.atlassian.net/browse/EEDS-219)
2. I added a new page to showcase the `<code>` styles along with other base styles in: `base / Base styles`
3. I slightly decreased the font size in a way that makes the lowercase glyphs of the mono font and sans-serif font better aligned.
4. I did not add the crimson accent color, because there are valid use cases in which you would have a link within a span of code. This makes the contrast stronger between plain text content and link text.
5. Aside: This is an interesting take on using italics instead of monospace for inline code: [*Styling inline code*](https://kizu.dev/styling-inline-code/)

[EEDS-219]: https://iu-uits.atlassian.net/browse/EEDS-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ