### PR TITLE
Feature Card: Only show arrow if there is a link in the title

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -168,7 +168,7 @@
 	--aspect-ratio: var(--aspect-ratio-rectangle);
 	--padding: var(--rvt-size-32);
 
-	&::before {
+	&:has(.rvt-card__title a)::before {
 		border-left: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
 		border-top: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
 		bottom: 0;
@@ -180,7 +180,7 @@
 		width: var(--padding);
 	}
 
-	&::after {
+	&:has(.rvt-card__title a)::after {
 		--position: calc((var(--padding) - var(--rvt-size-16)) / 2);
 		background-color: currentColor;
 		bottom: var(--position);


### PR DESCRIPTION
Notes:
1. The other card variants already do not show their right-arrow icon when there is no link.
