### PR TITLE
Upgrade dependencies and format code

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -45,7 +45,7 @@ jobs:
         run: npm run build
         working-directory: ${{ env.BUILD_PATH }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ${{ env.BUILD_PATH }}/dist-astro
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
 			},
 			"devDependencies": {
 				"@octokit/rest": "22.0.1",
-				"astro": "6.1.4",
+				"astro": "6.1.10",
 				"npm-run-all": "4.1.5",
-				"prettier": "3.8.1",
+				"prettier": "3.8.3",
 				"prettier-plugin-astro": "0.14.1",
 				"rimraf": "6.1.3",
 				"sass": "1.99.0",
@@ -32,23 +32,23 @@
 			"license": "MIT"
 		},
 		"node_modules/@astrojs/internal-helpers": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.8.0.tgz",
-			"integrity": "sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
+			"integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			}
 		},
 		"node_modules/@astrojs/markdown-remark": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.0.tgz",
-			"integrity": "sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.1.tgz",
+			"integrity": "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@astrojs/internal-helpers": "0.8.0",
+				"@astrojs/internal-helpers": "0.9.0",
 				"@astrojs/prism": "4.0.1",
 				"github-slugger": "^2.0.0",
 				"hast-util-from-html": "^2.0.3",
@@ -85,38 +85,21 @@
 			}
 		},
 		"node_modules/@astrojs/telemetry": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.0.tgz",
-			"integrity": "sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
+			"integrity": "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"ci-info": "^4.2.0",
-				"debug": "^4.4.0",
+				"ci-info": "^4.4.0",
 				"dlv": "^1.1.3",
 				"dset": "^3.1.4",
-				"is-docker": "^3.0.0",
-				"is-wsl": "^3.1.0",
+				"is-docker": "^4.0.0",
+				"is-wsl": "^3.1.1",
 				"which-pm-runs": "^1.1.0"
 			},
 			"engines": {
 				"node": "18.20.8 || ^20.3.0 || >=22.0.0"
-			}
-		},
-		"node_modules/@astrojs/telemetry/node_modules/is-wsl": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-inside-container": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=16"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
@@ -249,9 +232,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-			"integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -2444,16 +2427,16 @@
 			}
 		},
 		"node_modules/astro": {
-			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/astro/-/astro-6.1.4.tgz",
-			"integrity": "sha512-SRy1bONuCHkGWhI5JiWCQKVDVbeaXOikjAVZs/Nz+lvUvubtdLoZfnacmuZHQ9RL2IOkU54M8/qZYm9ypJDKrg==",
+			"version": "6.1.10",
+			"resolved": "https://registry.npmjs.org/astro/-/astro-6.1.10.tgz",
+			"integrity": "sha512-jQAIki6c862oxRr7OXXC+h3n4wg1EpmKgCH3vv1FtXM9VFmD2iTjlaxrfb0I6eQCwtUjSBxfJBFBDSXHu7Wing==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@astrojs/compiler": "^3.0.1",
-				"@astrojs/internal-helpers": "0.8.0",
-				"@astrojs/markdown-remark": "7.1.0",
-				"@astrojs/telemetry": "3.3.0",
+				"@astrojs/internal-helpers": "0.9.0",
+				"@astrojs/markdown-remark": "7.1.1",
+				"@astrojs/telemetry": "3.3.1",
 				"@capsizecss/unpack": "^4.0.0",
 				"@clack/prompts": "^1.1.0",
 				"@oslojs/encoding": "^1.1.0",
@@ -2466,7 +2449,6 @@
 				"cookie": "^1.1.1",
 				"devalue": "^5.6.3",
 				"diff": "^8.0.3",
-				"dlv": "^1.1.3",
 				"dset": "^3.1.4",
 				"es-module-lexer": "^2.0.0",
 				"esbuild": "^0.27.3",
@@ -2485,7 +2467,7 @@
 				"p-queue": "^9.1.0",
 				"package-manager-detector": "^1.6.0",
 				"piccolore": "^0.1.3",
-				"picomatch": "^4.0.3",
+				"picomatch": "^4.0.4",
 				"rehype": "^13.0.2",
 				"semver": "^7.7.4",
 				"shiki": "^4.0.2",
@@ -2498,9 +2480,9 @@
 				"ultrahtml": "^1.6.0",
 				"unifont": "~0.7.4",
 				"unist-util-visit": "^5.1.0",
-				"unstorage": "^1.17.4",
+				"unstorage": "^1.17.5",
 				"vfile": "^6.0.3",
-				"vite": "^7.3.1",
+				"vite": "^7.3.2",
 				"vitefu": "^1.1.2",
 				"xxhash-wasm": "^1.1.0",
 				"yargs-parser": "^22.0.0",
@@ -4443,16 +4425,16 @@
 			}
 		},
 		"node_modules/is-docker": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+			"integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"is-docker": "cli.js"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -4532,6 +4514,22 @@
 			},
 			"engines": {
 				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -4764,6 +4762,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-wsl": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/isarray": {
@@ -6170,20 +6184,20 @@
 			"license": "MIT"
 		},
 		"node_modules/oniguruma-parser": {
-			"version": "0.12.1",
-			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
-			"integrity": "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+			"integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/oniguruma-to-es": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.5.tgz",
-			"integrity": "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==",
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+			"integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"oniguruma-parser": "^0.12.1",
+				"oniguruma-parser": "^0.12.2",
 				"regex": "^6.1.0",
 				"regex-recursion": "^6.0.2"
 			}
@@ -6455,9 +6469,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.12",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
 			"dev": true,
 			"funding": [
 				{
@@ -6484,9 +6498,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -7725,14 +7739,14 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.15",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-			"integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+			"version": "0.2.16",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
 	],
 	"devDependencies": {
 		"@octokit/rest": "22.0.1",
-		"astro": "6.1.4",
+		"astro": "6.1.10",
 		"npm-run-all": "4.1.5",
-		"prettier": "3.8.1",
+		"prettier": "3.8.3",
 		"prettier-plugin-astro": "0.14.1",
 		"rimraf": "6.1.3",
 		"sass": "1.99.0",

--- a/src/base/base.astro
+++ b/src/base/base.astro
@@ -9,7 +9,7 @@ export const title = "Base styles";
 <h5>Heading level 5</h5>
 <h6>Heading level 6</h6>
 
-<hr>
+<hr />
 
 <p>Body text.</p>
 

--- a/src/base/fonts.css
+++ b/src/base/fonts.css
@@ -126,12 +126,15 @@
 	--rvt-font-12-fluid-mono: var(--rvt-font-weight-normal)
 		var(--rvt-size-12-14) / var(--rvt-size-16) var(--rvt-font-family-mono);
 
-	--rvt-font-14: var(--rvt-font-width-semi-expanded) var(--rvt-font-weight-normal)
-		var(--rvt-size-14) / var(--rvt-size-20) var(--rvt-font-family-sans);
-	--rvt-font-14-bold: var(--rvt-font-width-semi-expanded) var(--rvt-font-weight-bold)
-		var(--rvt-size-14) / var(--rvt-size-20) var(--rvt-font-family-sans);
-	--rvt-font-14-bold-wide: var(--rvt-font-width-expanded) var(--rvt-font-weight-bold)
-		var(--rvt-size-14) / var(--rvt-size-20) var(--rvt-font-family-sans);
+	--rvt-font-14: var(--rvt-font-width-semi-expanded)
+		var(--rvt-font-weight-normal) var(--rvt-size-14) / var(--rvt-size-20)
+		var(--rvt-font-family-sans);
+	--rvt-font-14-bold: var(--rvt-font-width-semi-expanded)
+		var(--rvt-font-weight-bold) var(--rvt-size-14) / var(--rvt-size-20)
+		var(--rvt-font-family-sans);
+	--rvt-font-14-bold-wide: var(--rvt-font-width-expanded)
+		var(--rvt-font-weight-bold) var(--rvt-size-14) / var(--rvt-size-20)
+		var(--rvt-font-family-sans);
 	--rvt-font-14-mono: var(--rvt-font-weight-normal) var(--rvt-size-14) /
 		var(--rvt-size-16) var(--rvt-font-family-mono);
 
@@ -141,10 +144,12 @@
 	--rvt-font-16-fluid: var(--rvt-font-width-semi-expanded)
 		var(--rvt-font-weight-normal) var(--rvt-size-16-18) / var(--rvt-size-24-28)
 		var(--rvt-font-family-sans);
-	--rvt-font-16-bold: var(--rvt-font-width-semi-expanded) var(--rvt-font-weight-bold)
-		var(--rvt-size-16) / var(--rvt-size-24) var(--rvt-font-family-sans);
-	--rvt-font-16-bold-wide: var(--rvt-font-width-expanded) var(--rvt-font-weight-bold)
-		var(--rvt-size-16) / var(--rvt-size-24) var(--rvt-font-family-sans);
+	--rvt-font-16-bold: var(--rvt-font-width-semi-expanded)
+		var(--rvt-font-weight-bold) var(--rvt-size-16) / var(--rvt-size-24)
+		var(--rvt-font-family-sans);
+	--rvt-font-16-bold-wide: var(--rvt-font-width-expanded)
+		var(--rvt-font-weight-bold) var(--rvt-size-16) / var(--rvt-size-24)
+		var(--rvt-font-family-sans);
 	--rvt-font-16-mono: var(--rvt-font-weight-normal) var(--rvt-size-16) /
 		var(--rvt-size-24) var(--rvt-font-family-mono);
 
@@ -202,8 +207,8 @@
 	--rvt-font-36-fluid-black: var(--rvt-font-width-semi-condensed)
 		var(--rvt-font-weight-black) var(--rvt-size-36-54) / var(--rvt-size-40-56)
 		var(--rvt-font-family-sans);
-	--rvt-font-36-fluid-extra-black: var(--rvt-font-weight-extra-black) var(--rvt-size-36-54) / var(--rvt-size-40-56)
-		var(--rvt-font-family-sans);
+	--rvt-font-36-fluid-extra-black: var(--rvt-font-weight-extra-black)
+		var(--rvt-size-36-54) / var(--rvt-size-40-56) var(--rvt-font-family-sans);
 
 	--rvt-font-42-extra-black: var(--rvt-font-width-extra-expanded)
 		var(--rvt-font-weight-extra-black) var(--rvt-size-42) / var(--rvt-size-44)

--- a/src/components/billboard/billboard.astro
+++ b/src/components/billboard/billboard.astro
@@ -2,10 +2,7 @@
 export const title = "Billboard";
 
 const { reverse = false } = Astro.props;
-const classList = [
-	"rvt-billboard",
-	{ "rvt-billboard--reverse": reverse }
-];
+const classList = ["rvt-billboard", { "rvt-billboard--reverse": reverse }];
 ---
 
 <div class:list={classList}>

--- a/src/components/sticker/sticker.astro
+++ b/src/components/sticker/sticker.astro
@@ -5,17 +5,17 @@ const name = "accessibility";
 ---
 
 <div class="rvt-flex rvt-gap-sm">
-	<rvt-sticker name={name} />
-	<rvt-sticker name={name} theme="danger" />
-	<rvt-sticker name={name} theme="info" />
-	<rvt-sticker name={name} theme="warning" />
-	<rvt-sticker name={name} theme="success" />
+	<rvt-sticker name={name}></rvt-sticker>
+	<rvt-sticker name={name} theme="danger"></rvt-sticker>
+	<rvt-sticker name={name} theme="info"></rvt-sticker>
+	<rvt-sticker name={name} theme="warning"></rvt-sticker>
+	<rvt-sticker name={name} theme="success"></rvt-sticker>
 </div>
 
 <div class="rvt-flex rvt-gap-sm rvt-m-top-md">
-	<rvt-sticker name={name} size="xs" />
-	<rvt-sticker name={name} size="sm" />
-	<rvt-sticker name={name} size="md" />
-	<rvt-sticker name={name} size="lg" />
-	<rvt-sticker name={name} size="xl" />
+	<rvt-sticker name={name} size="xs"></rvt-sticker>
+	<rvt-sticker name={name} size="sm"></rvt-sticker>
+	<rvt-sticker name={name} size="md"></rvt-sticker>
+	<rvt-sticker name={name} size="lg"></rvt-sticker>
+	<rvt-sticker name={name} size="xl"></rvt-sticker>
 </div>

--- a/src/sandbox/pages/[...path].astro
+++ b/src/sandbox/pages/[...path].astro
@@ -10,7 +10,7 @@ export function getStaticPaths() {
 			"@src/**/*.astro",
 			"!@src/sandbox/**/*.astro",
 			"!@src/**/*.tmp.astro",
-			"!@src/**/getStaticPaths.astro"
+			"!@src/**/getStaticPaths.astro",
 		],
 		{ eager: true },
 	);
@@ -80,12 +80,12 @@ export function getStaticPaths() {
 		}
 	}
 
-	const staticPathPages = import.meta.glob(
-		["@src/**/getStaticPaths.astro"],
-		{ eager: true },
+	const staticPathPages = import.meta.glob(["@src/**/getStaticPaths.astro"], {
+		eager: true,
+	});
+	const staticPaths = Object.values(staticPathPages).flatMap(
+		(file: any) => file.getStaticPaths() || [],
 	);
-	const staticPaths = Object.values(staticPathPages)
-		.flatMap((file: any) => file.getStaticPaths() || []);
 
 	return [...staticPaths, ...pathMap.values()].map((props) => {
 		const { path } = props;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"paths": {
 			"@root/*": ["./*"],
-			"@src/*": ["./src/*"],
+			"@src/*": ["./src/*"]
 		}
 	}
 }


### PR DESCRIPTION
Notes:
1. Upgrading from `actions/upload-pages-artifact@v4` to `v5` will clear the warning in the Actions build log.
2. I am still holding off on upgrading to Vite 8 until Astro officially supports it.
3. I forgot to run the format script in recent PRs.

Future work:
1. Automatically run the format script as part of the commit process.
