### PR TITLE
Fix feature card arrow hover color

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -176,25 +176,6 @@
 		width: var(--padding);
 	}
 
-	&:has(.rvt-card__title a)::after {
-		--position: calc((var(--padding) - var(--rvt-size-16)) / 2);
-		background-color: currentColor;
-		bottom: var(--position);
-		clip-path: path(var(--rvt-icon-arrow-right));
-		content: "";
-		display: block;
-		flex-shrink: 0;
-		height: var(--rvt-spacing-sm);
-		pointer-events: none;
-		position: absolute;
-		right: var(--position);
-		width: var(--rvt-spacing-sm);
-	}
-
-	&:has(.rvt-card__title a:hover)::after {
-		background-color: var(--rvt-color-theme-text-accent);
-	}
-
 	.rvt-card__image {
 		padding: 0;
 	}
@@ -226,7 +207,11 @@
 			color: var(--rvt-color-theme-text-accent);
 
 			&::after {
-				display: none;
+				--position: calc((var(--padding) - var(--rvt-size-16)) / 2);
+				bottom: var(--position);
+				position: absolute;
+				margin: 0;
+				right: var(--position);
 			}
 		}
 	}


### PR DESCRIPTION
Notes:
1. Jenn found a bug in which the hover color of the feature card arrow did not match the hover color of the title's link text.
2. In the original implementation, I had a different solution for the arrow-right icon in the feature card compared to other card types.
3. Now, the same arrow is instead being positioned in the bottom right of the card. This simplifies the code and keeps the arrow color consistent with the title link.
