### PR TITLE
Refine stat group component

### DIFF
--- a/src/components/stat-group/stat-group.astro
+++ b/src/components/stat-group/stat-group.astro
@@ -1,39 +1,30 @@
 ---
 export const title = "Stat Group";
+
+const stats = [
+	"microscope|$1B+|Research funding driving global breakthroughs",
+	"money-symbol|$75M|Invested in the future of engineering and tech",
+	"trophy|Top 10|Ranked for developing future leaders (TIME)",
+	"globe|805,000+|Alumni leading change in every sector worldwide",
+].map((stat) => {
+	const [sticker, number, description] = stat.split("|");
+	return { sticker, number, description };
+});
 ---
 
 <div class="rvt-stat-group">
 	<ul>
-		<li>
-			<div class="rvt-stat">
-				<rvt-sticker name="microscope" theme="crimson" size="sm"></rvt-sticker>
-				<div class="rvt-stat__number">$1B+</div>
-				<div class="rvt-stat__description">Research funding driving global breakthroughs</div>
-			</div>
-		</li>
-		<li>
-			<div class="rvt-stat">
-				<rvt-sticker name="money-symbol" theme="crimson" size="sm"></rvt-sticker>
-				<div class="rvt-stat__number">$75M</div>
-				<div class="rvt-stat__description">
-					Invested in the future of engineering and tech
-				</div>
-			</div>
-		</li>
-		<li>
-			<div class="rvt-stat">
-				<rvt-sticker name="trophy" theme="crimson" size="sm"></rvt-sticker>
-				<div class="rvt-stat__number">Top 10</div>
-				<div class="rvt-stat__description">Ranked for developing future leaders (TIME)</div>
-			</div>
-		</li>
-		<li>
-			<div class="rvt-stat">
-				<rvt-sticker name="globe" theme="crimson" size="sm"></rvt-sticker>
-				<div class="rvt-stat__number">805,000+</div>
-				<div class="rvt-stat__description">Alumni leading change in every sector worldwide</div>
-			</div>
-		</li>
+		{
+			stats.map((stat) => (
+				<li>
+					<div class="rvt-stat">
+						<rvt-sticker name={stat.sticker} theme="crimson" size="sm" />
+						<div class="rvt-stat__number">{stat.number}</div>
+						<div class="rvt-stat__description">{stat.description}</div>
+					</div>
+				</li>
+			))
+		}
 	</ul>
-	<p>* Stats current as of 2025</p>
+	<p>Stats current as of 2025</p>
 </div>

--- a/src/components/stat-group/stat-group.astro
+++ b/src/components/stat-group/stat-group.astro
@@ -6,25 +6,32 @@ export const title = "Stat Group";
 	<ul>
 		<li>
 			<div class="rvt-stat">
-				<rvt-sticker name="backpack" theme="crimson" size="sm"></rvt-sticker>
-				<div class="rvt-stat__number">$50M+</div>
-				<div class="rvt-stat__description">Research funding</div>
+				<rvt-sticker name="microscope" theme="crimson" size="sm"></rvt-sticker>
+				<div class="rvt-stat__number">$1B+</div>
+				<div class="rvt-stat__description">Research funding driving global breakthroughs</div>
 			</div>
 		</li>
 		<li>
 			<div class="rvt-stat">
-				<rvt-sticker name="book" theme="crimson" size="sm"></rvt-sticker>
-				<div class="rvt-stat__number">88%</div>
+				<rvt-sticker name="money-symbol" theme="crimson" size="sm"></rvt-sticker>
+				<div class="rvt-stat__number">$75M</div>
 				<div class="rvt-stat__description">
-					Students stay in Indiana after graduation
+					Invested in the future of engineering and tech
 				</div>
 			</div>
 		</li>
 		<li>
 			<div class="rvt-stat">
-				<rvt-sticker name="map" theme="crimson" size="sm"></rvt-sticker>
-				<div class="rvt-stat__number">56%</div>
-				<div class="rvt-stat__description">Students graduate debt free</div>
+				<rvt-sticker name="trophy" theme="crimson" size="sm"></rvt-sticker>
+				<div class="rvt-stat__number">Top 10</div>
+				<div class="rvt-stat__description">Ranked for developing future leaders (TIME)</div>
+			</div>
+		</li>
+		<li>
+			<div class="rvt-stat">
+				<rvt-sticker name="globe" theme="crimson" size="sm"></rvt-sticker>
+				<div class="rvt-stat__number">805,000+</div>
+				<div class="rvt-stat__description">Alumni leading change in every sector worldwide</div>
 			</div>
 		</li>
 	</ul>

--- a/src/components/stat-group/stat-group.astro
+++ b/src/components/stat-group/stat-group.astro
@@ -35,5 +35,5 @@ export const title = "Stat Group";
 			</div>
 		</li>
 	</ul>
-	<p class="rvt-stat-group__note">* Stats current as of 2025</p>
+	<p>* Stats current as of 2025</p>
 </div>

--- a/src/components/stat-group/stat-group.css
+++ b/src/components/stat-group/stat-group.css
@@ -48,14 +48,14 @@
 		}
 	}
 
-	@container stat-group (width > 40em) {
+	@container stat-group (width > 40rem) {
 		> * {
 			--min-width: 50%;
 			--padding: var(--rvt-size-40);
 		}
 	}
 
-	@container stat-group (width > 80em) {
+	@container stat-group (width > 80rem) {
 		> * {
 			--min-width: auto;
 			--padding: var(--rvt-size-48);

--- a/src/components/stat-group/stat-group.css
+++ b/src/components/stat-group/stat-group.css
@@ -8,57 +8,47 @@
 	container-type: inline-size;
 
 	.rvt-container > & {
-		padding-block: var(--rvt-spacing-lg);
+		padding-block: var(--rvt-size-32);
 	}
 
 	> ul {
+		border-block-start: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
+		border-inline-start: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
 		display: flex;
-		flex-direction: column;
+		flex-wrap: wrap;
 		list-style-type: "";
 		margin: 0;
 		padding: 0;
 
 		> li {
 			border-block-end: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
-			padding: var(--rvt-spacing-lg) 0;
+			border-inline-end: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
+			flex-basis: 0;
+			flex-grow: 1;
+			min-width: 100%;
+			padding: var(--rvt-size-32);
 		}
 	}
 
 	.rvt-stat-group__note {
+		border-block-end: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
+		border-inline: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
 		color: var(--rvt-color-theme-accent);
 		font: var(--rvt-font-12-mono);
-		margin-block: var(--rvt-spacing-sm) 0;
+		margin: 0;
+		padding: var(--rvt-size-16) var(--rvt-size-32);
 	}
 
 	@container stat-group (width > 40em) {
-		> ul {
-			flex-direction: row;
-			flex-wrap: wrap;
-
-			> li {
-				border: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
-				flex-basis: 0;
-				flex-grow: 1;
-				margin-block-start: var(--rvt-size-n1);
-				margin-inline-start: var(--rvt-size-n1);
-				min-width: 50%;
-				padding: var(--rvt-size-64);
-			}
+		> ul > li {
+			min-width: 50%;
+			padding: var(--rvt-size-48);
 		}
 	}
 
-	@container stat-group (width > 68.75em) {
+	@container stat-group (width > 75em) {
 		> ul > li {
-			border-block-end: none;
-			border-block-start: none;
-			border-inline-start: none;
-			margin-block-start: 0;
-			margin-inline-start: 0;
 			min-width: auto;
-
-			&:last-child {
-				border-inline-end: none;
-			}
 		}
 	}
 }

--- a/src/components/stat-group/stat-group.css
+++ b/src/components/stat-group/stat-group.css
@@ -42,6 +42,10 @@
 		font: var(--rvt-font-12-mono);
 		margin: 0;
 		padding: var(--rvt-size-16) var(--padding);
+
+		&::before {
+			content: "*";
+		}
 	}
 
 	@container stat-group (width > 40em) {

--- a/src/components/stat-group/stat-group.css
+++ b/src/components/stat-group/stat-group.css
@@ -11,6 +11,11 @@
 		padding-block: var(--rvt-size-32);
 	}
 
+	> * {
+		--min-width: 100%;
+		--padding: var(--rvt-size-32);
+	}
+
 	> ul {
 		border-block-start: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
 		border-inline-start: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
@@ -25,31 +30,31 @@
 			border-inline-end: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
 			flex-basis: 0;
 			flex-grow: 1;
-			min-width: 100%;
-			padding: var(--rvt-size-32);
+			min-width: var(--min-width);
+			padding: var(--padding);
 		}
 	}
 
-	.rvt-stat-group__note {
+	> p {
 		border-block-end: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
 		border-inline: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
 		color: var(--rvt-color-theme-accent);
 		font: var(--rvt-font-12-mono);
 		margin: 0;
-		padding: var(--rvt-size-16) var(--rvt-size-32);
+		padding: var(--rvt-size-16) var(--padding);
 	}
 
 	@container stat-group (width > 40em) {
-		> ul > li {
-			min-width: 50%;
-			padding: var(--rvt-size-40);
+		> * {
+			--min-width: 50%;
+			--padding: var(--rvt-size-40);
 		}
 	}
 
-	@container stat-group (width > 75em) {
-		> ul > li {
-			min-width: auto;
-			padding: var(--rvt-size-48);
+	@container stat-group (width > 80em) {
+		> * {
+			--min-width: auto;
+			--padding: var(--rvt-size-48);
 		}
 	}
 }

--- a/src/components/stat-group/stat-group.css
+++ b/src/components/stat-group/stat-group.css
@@ -42,13 +42,14 @@
 	@container stat-group (width > 40em) {
 		> ul > li {
 			min-width: 50%;
-			padding: var(--rvt-size-48);
+			padding: var(--rvt-size-40);
 		}
 	}
 
 	@container stat-group (width > 75em) {
 		> ul > li {
 			min-width: auto;
+			padding: var(--rvt-size-48);
 		}
 	}
 }


### PR DESCRIPTION
Changes:
1. Removed the need for `.rvt-stat-group__note`. This style is applied to direct children that are `<p>`.
2. This note will also have the `*` prepended to it automatically, as all of these notes should have it.
3. These stats are now all styled the same at all container sizes: It is a box with no gap between stats. The padding in the boxes slightly increases as the container width increases.
