### PR TITLE
Create Drilldown component

### DIFF
--- a/src/components/components.scss
+++ b/src/components/components.scss
@@ -19,6 +19,7 @@
 @use "container/container.scss";
 @use "dialog/dialog.scss";
 @use "disclosure/disclosure.css";
+@use "drilldown/drilldown.css";
 @use "dropdown/dropdown.scss";
 @use "empty-state/empty-state.scss";
 @use "factoid/factoid.scss";

--- a/src/components/drilldown/drilldown.astro
+++ b/src/components/drilldown/drilldown.astro
@@ -1,0 +1,65 @@
+---
+import { example } from "./example.js";
+
+export const title = "Drilldown";
+
+const { menus = example } = Astro.props;
+---
+
+<rvt-drilldown>
+	{
+		menus.map((menu: any) => (
+			<div
+				data-rvt-drilldown-menu={menu.id}
+				data-rvt-drilldown-parent={menu.parent?.id}
+			>
+				<header>
+					{menu.parent && (
+						<div class="rvt-button-group">
+							{menu.depth > 1 && (
+								<button
+									class="rvt-button rvt-button--medium"
+									data-rvt-drilldown-open="main"
+								>
+									<rvt-icon name="chevrons-left" />
+									Main
+								</button>
+							)}
+							<button
+								class="rvt-button rvt-button--medium"
+								data-rvt-drilldown-open="parent"
+							>
+								<rvt-icon name="chevron-left" />
+								Back
+							</button>
+						</div>
+					)}
+					<h2>
+						<a href={menu.url}>{menu.label}</a>
+					</h2>
+				</header>
+				<ul>
+					{menu.items.map((item: any) => (
+						<li data-rvt-drilldown-child={item.id}>
+							<a
+								aria-current={item.current ? "page" : null}
+								href={item.url || "#"}
+							>
+								{item.label}
+							</a>
+							{item.hasChildren && (
+								<button
+									class="rvt-button rvt-button--medium rvt-button--icon-only"
+									data-rvt-drilldown-open="child"
+								>
+									<span class="rvt-sr-only">{`${item.label} menu`}</span>
+									<rvt-icon name="chevron-right" />
+								</button>
+							)}
+						</li>
+					))}
+				</ul>
+			</div>
+		))
+	}
+</rvt-drilldown>

--- a/src/components/drilldown/drilldown.css
+++ b/src/components/drilldown/drilldown.css
@@ -31,7 +31,7 @@ rvt-drilldown {
 	}
 
 	header {
-		align-items: start;
+		align-items: center;
 		display: flex;
 		gap: var(--rvt-size-8);
 		padding-block: var(--rvt-size-8);
@@ -53,7 +53,7 @@ rvt-drilldown {
 	}
 
 	li {
-		align-items: start;
+		align-items: center;
 		border-block-end: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
 		border-block-start: none;
 		display: flex;

--- a/src/components/drilldown/drilldown.css
+++ b/src/components/drilldown/drilldown.css
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 The Trustees of Indiana University
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+rvt-drilldown {
+	display: block;
+
+	a {
+		color: unset;
+		display: block;
+		flex-grow: 1;
+		margin: 0;
+		padding: var(--rvt-size-4) var(--rvt-size-8);
+		text-decoration: none;
+
+		&:visited {
+			color: inherit;
+		}
+
+		&:hover {
+			color: var(--rvt-color-theme-text-accent);
+			text-decoration: underline;
+		}
+	}
+
+	button.rvt-button {
+		--color-border: var(--rvt-color-theme-ui);
+		--color-border-hover: var(--rvt-color-theme-ui);
+		--color-text-hover: var(--rvt-color-theme-text-accent);
+	}
+
+	header {
+		align-items: start;
+		display: flex;
+		gap: var(--rvt-size-8);
+		padding-block: var(--rvt-size-8);
+
+		:is(h2, h3, h4, h5, h6) {
+			display: block;
+			flex-grow: 1;
+
+			a {
+				font: var(--rvt-font-18-bold);
+			}
+		}
+	}
+
+	ul {
+		border-block-start: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
+		margin: 0;
+		padding: 0;
+	}
+
+	li {
+		align-items: start;
+		border-block-end: var(--rvt-size-1) solid var(--rvt-color-theme-ui);
+		border-block-start: none;
+		display: flex;
+		gap: var(--rvt-size-8);
+		padding: var(--rvt-size-8);
+
+		&:has([aria-current="page"]) {
+			background-color: var(--rvt-color-theme-background-strong);
+
+			a {
+				font: inherit;
+				font-variation-settings: var(--rvt-font-variation-grade);
+			}
+		}
+	}
+}

--- a/src/components/drilldown/drilldown.js
+++ b/src/components/drilldown/drilldown.js
@@ -1,0 +1,132 @@
+/******************************************************************************
+ * Copyright (C) 2018 The Trustees of Indiana University
+ * SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+
+const ELEMENT_NAME = "rvt-drilldown";
+const MAIN = "main";
+const MENU = "menu";
+const OPEN = "open";
+const PARENT = "parent";
+
+function attr(name) {
+	return ["data", ELEMENT_NAME, name].join("-");
+}
+
+function attrSelector(name, value) {
+	const equals = value ? `="${value}"` : "";
+	return `[${attr(name)}${equals}]`;
+}
+
+function focusOnFirstMatch(target, selector) {
+	window.requestAnimationFrame(() => {
+		if (isNotHTML(target)) {
+			return;
+		}
+		const el = target.querySelector(selector);
+		if (isNotHTML(el)) {
+			return;
+		}
+		el.focus();
+	});
+}
+
+function getClosestAttributeValue(target, name) {
+	if (isNotHTML(target)) {
+		return;
+	}
+	const source = target.closest(attrSelector(name));
+	if (isNotHTML(source)) {
+		return;
+	}
+	return source.getAttribute(attr(name));
+}
+
+function isNotHTML(element) {
+	return !(element instanceof HTMLElement);
+}
+
+class RivetDrilldown extends HTMLElement {
+	#abortController;
+
+	connectedCallback() {
+		this.#abortController = new AbortController();
+		const { signal } = this.#abortController;
+		this.addEventListener("click", this.#handleClick, { signal });
+		this.addEventListener("keydown", this.#handleKeydown, {
+			capture: true,
+			signal,
+		});
+		this.#openMenu(this.#currentMenu || this.#mainMenu);
+	}
+
+	disconnectedCallback() {
+		this.#abortController.abort();
+	}
+
+	#handleClick(event) {
+		const { target } = event;
+		const type = getClosestAttributeValue(target, OPEN);
+		const menu = this.#getMenu(target, type);
+		this.#openMenu(menu);
+		this.#focusMenu(menu);
+	}
+
+	#handleKeydown(event) {
+		if (event.key !== "Escape") {
+			return;
+		}
+		const menu = event.shiftKey
+			? this.#mainMenu
+			: this.#getMenu(event.target, PARENT) || this.#mainMenu;
+		if (menu === this.#activeMenu) {
+			return;
+		}
+		this.#openMenu(menu);
+		this.#focusMenu(menu);
+		event.stopPropagation();
+	}
+
+	#focusMenu(menu) {
+		focusOnFirstMatch(menu, "ul a");
+	}
+
+	#getMenu(target, type) {
+		if (type === MAIN) {
+			return this.#mainMenu;
+		}
+		const id = getClosestAttributeValue(target, type);
+		if (!id) {
+			return;
+		}
+		return this.querySelector(attrSelector(MENU, id));
+	}
+
+	#openMenu(menu) {
+		if (isNotHTML(menu)) {
+			return;
+		}
+		this.querySelectorAll(attrSelector(MENU)).forEach((el) => {
+			if (isNotHTML(el)) {
+				return;
+			}
+			el.hidden = el !== menu;
+		});
+	}
+
+	get #activeMenu() {
+		return this.querySelector(`${attrSelector(MENU)}:not([hidden])`);
+	}
+
+	get #currentMenu() {
+		return this.querySelector(`${attrSelector(MENU)}:has([aria-current=page])`);
+	}
+
+	get #mainMenu() {
+		return this.querySelector(
+			`${attrSelector(MENU)}:not(${attrSelector(PARENT)})`,
+		);
+	}
+}
+
+window.customElements.define(ELEMENT_NAME, RivetDrilldown);

--- a/src/components/drilldown/example.js
+++ b/src/components/drilldown/example.js
@@ -1,0 +1,40 @@
+function createItem(label, _id) {
+	const id = _id ? _id : label.toLowerCase().replaceAll(" ", "-");
+	const url = `?${id}`;
+	return { id, label, url };
+}
+
+export const example = [
+	{
+		...createItem("IU Bloomington", "home"),
+		depth: 0,
+		items: [
+			{ ...createItem("Academics"), current: true },
+			{ ...createItem("Admissions"), hasChildren: true },
+			createItem("Cost & Aid", "cost-aid"),
+		],
+	},
+	{
+		...createItem("Admissions"),
+		depth: 1,
+		items: [
+			{ ...createItem("Apply"), hasChildren: true },
+			createItem("Events"),
+			createItem("Visit"),
+			createItem("Meet Your Counselors"),
+		],
+		parent: createItem("IU Bloomington", "home"),
+	},
+	{
+		...createItem("Apply"),
+		depth: 2,
+		items: [
+			createItem("Freshman"),
+			createItem("Graduate"),
+			createItem("Returning"),
+			createItem("Visiting"),
+			createItem("Transfer"),
+		],
+		parent: createItem("Admissions"),
+	},
+];

--- a/src/rivet.js
+++ b/src/rivet.js
@@ -5,6 +5,8 @@
 
 import "./rivet.scss";
 
+import "./components/drilldown/drilldown.js";
+
 import Accordion from "./components/accordion/accordion.js";
 import Alert from "./components/alert/alert.js";
 import Dialog from "./components/dialog/dialog.js";


### PR DESCRIPTION
Notes:
1. I converted this to a custom element (rather than just top-level functions), in order to support the potential initialization of multiple drilldown instances on the same page.
2. This no longer errors if there are no drilldown components on the page when the drilldown JS loads.
3. See the sandbox example page in `components/drilldown/Drilldown`. The IUB prototype is not in this branch to see it there.
4. Exemplar: [Drilldown Menu (Foundation)](https://get.foundation/sites/docs/drilldown-menu.html)
5. Exemplar: [PatternFly Navigation Design Guidelines](https://www.patternfly.org/components/navigation/design-guidelines/)

Changes since the [Drilldown prototype](https://codepen.io/basham/pen/yyaxPbJ):
1. Rename `<iub-sidenav>` to `<rvt-drilldown>`.
2. Rename `data-iub-sidenav-child` to `data-rvt-drilldown-child`.
3. Remove `data-iub-sidenav-main` (no longer needed).
4. Rename `data-iub-sidenav-menu` to `data-rvt-drilldown-menu`.
5. Rename `data-iub-sidenav-open` to `data-rvt-drilldown-open`.
6. Rename `data-iub-sidenav-parent` to `data-rvt-drilldown-parent`.
7. `<rvt-drilldown>` should be a child of its respective `<nav>` (not its parent).

Future work:
1. Create a Menu component ( `<rvt-menu>`). This could be used as children for both Drilldown and Dropdown components.
