### PR TITLE
Keep focus outline on top without applying relative position

### DIFF
--- a/src/base/reset.css
+++ b/src/base/reset.css
@@ -92,7 +92,7 @@ sup {
 }
 
 :focus-visible {
+	isolation: isolate;
 	outline: var(--rvt-size-2) solid var(--rvt-color-theme-accent-strong);
 	outline-offset: var(--rvt-size-2);
-	position: relative;
 }


### PR DESCRIPTION
Notes:
1. This bug was introduced in PR #798.
2. The intent of using `position: relative` on focused elements was to increase its stacking context. This was used so that the focus outline of the "Previous" (left) link in the Series Nav component stayed above and visible. Without it, the border between it and the "Next" (right) link would cover the right part of the outline. This all happens because the two links are butted next to one another without any gap.
3. A downstream effect of this was that the right arrow in the Feature Card would not stay in the bottom right corner of the card when the card was in focus. The relative position of the link snapped the right arrow back alongside the link. We are just now noticing this problem because I changed the way the right arrow was rendered in PR #865.
4. Gratefully, there is a different way to force a new stacking context, using [`isolation: isolate`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/isolation). I've never heard or used it before, but it solves the problem perfectly, and it is Baseline Widely Available (since 2020!).