### PR TITLE
Add prepare script

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
 	],
 	"scripts": {
 		"build": "vite build",
+		"prepare": "pnpm build",
 		"preview": "pnpm build"
 	},
 	"devDependencies": {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -30,6 +30,7 @@
 		"prebuild": "rimraf dist tmp",
 		"build": "style-dictionary build",
 		"dev": "pnpm build",
+		"prepare": "pnpm build",
 		"preview": "pnpm build"
 	},
 	"devDependencies": {


### PR DESCRIPTION
The "prepare" script automatically runs during package install. This makes it so we can install Rivet from the `v3-main` branch and use the locally-built `dist` files in local projects. That allows us to test changes in the `v3-main` branch (or other branches based on it) in other environments without needing to publish a release to npm. This is a first step in allowing us to move prototypes outside of the Rivet repo.