### PR TITLE
Fix Safari bug: Oblique style in Hero component does not work

### DIFF
--- a/packages/core/src/base/fonts.css
+++ b/packages/core/src/base/fonts.css
@@ -230,4 +230,5 @@
 
 	--rvt-font-variation-black: "YTAS" 720, "YTLC" 530;
 	--rvt-font-variation-grade: "GRAD" 150;
+	--rvt-font-variation-slant: "slnt" -10;
 }

--- a/packages/core/src/components/hero/hero.scss
+++ b/packages/core/src/components/hero/hero.scss
@@ -216,7 +216,7 @@
 :is(.rvt-hero--feature, .rvt-hero--split, .rvt-hero--statement) {
 	.rvt-hero__title {
 		font: var(--rvt-font-36-fluid-extra-black);
-		font-style: oblique 10deg;
+		font-variation-settings: var(--rvt-font-variation-slant);
 		text-transform: uppercase;
 	}
 }


### PR DESCRIPTION
@zttodd Found this unique bug.

> Hey there, on the IU Bloomington home page, the hero is using the italicized text that's styled with:

```css
font-style: oblique 10deg;
```

> However, it appears that on iOS, even up to `26.5`, the addition of `10deg` is causing that oblique style to fail, making the text display as normal instead of italics. This appears to be because [on Safari, the oblique slant degree isn't supported from `-90` to `13` degrees](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-style#browser_compatibility), and we've got it set to `10deg`. Could we set it to `14deg` to work around this?

---

After testing, setting it to `14deg` is not a universal solution. Instead, replacing it with the slant setting does work in all browsers. The `-10` value is equivalent to the `10deg` value it is replacing, so there is no visual regression.

Note: `"slnt"` is in lowercase because it is a standard axis. In contrast, `"YTAS"`, `"YTLC"`, and `"GRAD"` are custom axes set by the font itself and therefore they are uppercase.