### PR TITLE
Adds CLI tool to packages

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,51 @@
+# Rivet CLI
+
+CLI tool for the Rivet Design System
+
+## Commands
+
+### Search
+
+Searches contents of files based on one or more patterns:
+
+`pnpm dlx @rivet-cli/cli search <directory> <patterns> --output <file-name>.md`
+
+**`<directory>`**
+
+name of directory to search
+
+**`<patterns>`**
+
+search pattern(s) separated by a space
+
+_Single pattern_
+
+`pnpm dlx @rivet-cli/cli ... foo`
+
+_Multiple patterns_
+
+`pnpm dlx @rivet-cli/cli ... foo bar`
+
+You can also add quotes around each pattern for easier readability:
+
+`pnpm dlx @rivet-cli/cli ... "foo" "bar"`
+
+#### Examples
+
+**Find all instances of Rivet margin and padding utility classes**:
+
+`pnpm dlx @rivet-cli/cli search <dir-name> rvt-m rvt-p`
+
+**Find all instances of custom Rivet override classes**:
+
+`pnpm dlx @rivet-cli/cli search <dir-name> rvt-c`
+
+## Write full results to Markdown file
+
+By default, a simplified output of results are printed to the command line. If you'd like a thorough report written to a Markdown file, add the `--output` flag:
+
+`pnpm dlx @rivet-cli/cli <command> <patterns> --output <file-name>.md`
+
+**Example: find all instances of custom Rivet override classes and write results to file**:
+
+`pnpm dlx @rivet-cli/cli search <dir-name> rvt-c --output overrides.md`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,12 +38,16 @@ pnpm dlx @rivet-iu/cli search src "rvt-m" "rvt-p"
 pnpm dlx @rivet-iu/cli search src "rvt-c"
 ```
 
-## Write full results to Markdown file
+### Write full results to Markdown file
 
 By default, a simplified output of results are printed to the command line. If you'd like a thorough report written to a Markdown file, add the `--output` flag:
 
-`pnpm dlx @rivet-iu/cli <command> <patterns> --output <file-name>.md`
+```
+pnpm dlx @rivet-iu/cli <command> <patterns> --output <file-name>.md
+```
 
 By default, the file is written to the path from which you are running the command. You can also output the file to a preferred location on your computer:
 
-`pnpm dlx @rivet-iu/cli search <dir-name> rvt-c --output ~/Desktop/<file-name>.md`
+```
+pnpm dlx @rivet-iu/cli search <dir-name> rvt-c --output ~/Desktop/<file-name>.md
+```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,23 +19,23 @@ Searches contents of files based on one or more patterns:
 
 ```shell
 # Single pattern
-`pnpm dlx @rivet-iu/cli ... foo`
+pnpm dlx @rivet-iu/cli search src foo
 
 # Multiple patterns
-`pnpm dlx @rivet-iu/cli ... foo bar`
+pnpm dlx @rivet-iu/cli search src foo bar
 
 # You can also add quotes around each pattern for easier readability
-`pnpm dlx @rivet-iu/cli ... "foo" "bar"`
+pnpm dlx @rivet-iu/cli search src "foo" "bar"
 ```
 
 ### Examples
 
 ```shell
 # Find all instances of Rivet margin and padding utility classes
-`pnpm dlx @rivet-iu/cli search src "rvt-m" "rvt-p"`
+pnpm dlx @rivet-iu/cli search src "rvt-m" "rvt-p"
 
 # Find all instances of custom Rivet override classes
-`pnpm dlx @rivet-iu/cli search src "rvt-c"`
+pnpm dlx @rivet-iu/cli search src "rvt-c"
 ```
 
 ## Write full results to Markdown file

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,28 +4,40 @@ CLI tool for the Rivet Design System
 
 ## Search
 
-Searches contents of files based on one or more patterns:
+Search contents of files based on one or more patterns.
 
 `pnpm dlx @rivet-iu/cli search <directory> <patterns> --output <file-name>.md`
 
 | Element                   | Description                             |
 | ------------------------- | --------------------------------------- |
-| `search`                  | the search command                      |
 | `<directory>`             | name of directory to recursively search |
 | `<patterns>`              | search pattern(s) separated by a space  |
 | `--output <file-name>.md` | output full results to a Markdown file  |
 
 ### Usage
 
+Search for margin utility classes in the current directory.
+
 ```shell
-# Single pattern
-pnpm dlx @rivet-iu/cli search src foo
+pnpm dlx @rivet-iu/cli search . rvt-m-
+```
 
-# Multiple patterns
-pnpm dlx @rivet-iu/cli search src foo bar
+Search for margin and padding utility classes in the src directory. Optionally wrap the patterns in quotes.
 
-# You can also add quotes around each pattern for easier readability
-pnpm dlx @rivet-iu/cli search src "foo" "bar"
+```shell
+pnpm dlx @rivet-iu/cli search src "rvt-m-" "rvt-p-"
+```
+
+Output full results to a Markdown file in the current directory.
+
+```shell
+pnpm dlx @rivet-iu/cli search src "rvt-m-" "rvt-p-" --output results.md
+```
+
+Output full results to a Markdown file on the desktop.
+
+```shell
+pnpm dlx @rivet-iu/cli search src "rvt-m-" "rvt-p-" --output ~/Desktop/results.md
 ```
 
 ### Examples

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -39,27 +39,3 @@ Output full results to a Markdown file on the desktop.
 ```shell
 pnpm dlx @rivet-iu/cli search src "rvt-m-" "rvt-p-" --output ~/Desktop/results.md
 ```
-
-### Examples
-
-```shell
-# Find all instances of Rivet margin and padding utility classes
-pnpm dlx @rivet-iu/cli search src "rvt-m" "rvt-p"
-
-# Find all instances of custom Rivet override classes
-pnpm dlx @rivet-iu/cli search src "rvt-c"
-```
-
-### Write full results to Markdown file
-
-By default, a simplified output of results are printed to the command line. If you'd like a thorough report written to a Markdown file, add the `--output` flag:
-
-```
-pnpm dlx @rivet-iu/cli <command> <patterns> --output <file-name>.md
-```
-
-By default, the file is written to the path from which you are running the command. You can also output the file to a preferred location on your computer:
-
-```
-pnpm dlx @rivet-iu/cli search <dir-name> rvt-c --output ~/Desktop/<file-name>.md
-```

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -6,7 +6,7 @@ CLI tool for the Rivet Design System
 
 Searches contents of files based on one or more patterns:
 
-`pnpm dlx @rivet-cli/cli search <directory> <patterns> --output <file-name>.md`
+`pnpm dlx @rivet-iu/cli search <directory> <patterns> --output <file-name>.md`
 
 | Element                   | Description                             |
 | ------------------------- | --------------------------------------- |
@@ -19,31 +19,31 @@ Searches contents of files based on one or more patterns:
 
 ```shell
 # Single pattern
-`pnpm dlx @rivet-cli/cli ... foo`
+`pnpm dlx @rivet-iu/cli ... foo`
 
 # Multiple patterns
-`pnpm dlx @rivet-cli/cli ... foo bar`
+`pnpm dlx @rivet-iu/cli ... foo bar`
 
 # You can also add quotes around each pattern for easier readability
-`pnpm dlx @rivet-cli/cli ... "foo" "bar"`
+`pnpm dlx @rivet-iu/cli ... "foo" "bar"`
 ```
 
 ### Examples
 
 ```shell
 # Find all instances of Rivet margin and padding utility classes
-`pnpm dlx @rivet-cli/cli search src "rvt-m" "rvt-p"`
+`pnpm dlx @rivet-iu/cli search src "rvt-m" "rvt-p"`
 
 # Find all instances of custom Rivet override classes
-`pnpm dlx @rivet-cli/cli search src "rvt-c"`
+`pnpm dlx @rivet-iu/cli search src "rvt-c"`
 ```
 
 ## Write full results to Markdown file
 
 By default, a simplified output of results are printed to the command line. If you'd like a thorough report written to a Markdown file, add the `--output` flag:
 
-`pnpm dlx @rivet-cli/cli <command> <patterns> --output <file-name>.md`
+`pnpm dlx @rivet-iu/cli <command> <patterns> --output <file-name>.md`
 
 By default, the file is written to the path from which you are running the command. You can also output the file to a preferred location on your computer:
 
-`pnpm dlx @rivet-cli/cli search <dir-name> rvt-c --output ~/Desktop/<file-name>.md`
+`pnpm dlx @rivet-iu/cli search <dir-name> rvt-c --output ~/Desktop/<file-name>.md`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,43 +2,41 @@
 
 CLI tool for the Rivet Design System
 
-## Commands
-
-### Search
+## Search
 
 Searches contents of files based on one or more patterns:
 
 `pnpm dlx @rivet-cli/cli search <directory> <patterns> --output <file-name>.md`
 
-**`<directory>`**
+| Element                   | Description                             |
+| ------------------------- | --------------------------------------- |
+| `search`                  | the search command                      |
+| `<directory>`             | name of directory to recursively search |
+| `<patterns>`              | search pattern(s) separated by a space  |
+| `--output <file-name>.md` | output full results to a Markdown file  |
 
-name of directory to search
+### Usage
 
-**`<patterns>`**
-
-search pattern(s) separated by a space
-
-_Single pattern_
-
+```shell
+# Single pattern
 `pnpm dlx @rivet-cli/cli ... foo`
 
-_Multiple patterns_
-
+# Multiple patterns
 `pnpm dlx @rivet-cli/cli ... foo bar`
 
-You can also add quotes around each pattern for easier readability:
-
+# You can also add quotes around each pattern for easier readability
 `pnpm dlx @rivet-cli/cli ... "foo" "bar"`
+```
 
-#### Examples
+### Examples
 
-**Find all instances of Rivet margin and padding utility classes**:
+```shell
+# Find all instances of Rivet margin and padding utility classes
+`pnpm dlx @rivet-cli/cli search src "rvt-m" "rvt-p"`
 
-`pnpm dlx @rivet-cli/cli search <dir-name> rvt-m rvt-p`
-
-**Find all instances of custom Rivet override classes**:
-
-`pnpm dlx @rivet-cli/cli search <dir-name> rvt-c`
+# Find all instances of custom Rivet override classes
+`pnpm dlx @rivet-cli/cli search src "rvt-c"`
+```
 
 ## Write full results to Markdown file
 
@@ -46,6 +44,6 @@ By default, a simplified output of results are printed to the command line. If y
 
 `pnpm dlx @rivet-cli/cli <command> <patterns> --output <file-name>.md`
 
-**Example: find all instances of custom Rivet override classes and write results to file**:
+By default, the file is written to the path from which you are running the command. You can also output the file to a preferred location on your computer:
 
-`pnpm dlx @rivet-cli/cli search <dir-name> rvt-c --output overrides.md`
+`pnpm dlx @rivet-cli/cli search <dir-name> rvt-c --output ~/Desktop/<file-name>.md`

--- a/packages/cli/commands/search.js
+++ b/packages/cli/commands/search.js
@@ -2,6 +2,15 @@ import { Command } from "commander";
 import fs from "fs";
 import path from "path";
 
+import { searchRegexFlags } from "../lib/config.js";
+import { searchFiles } from "../lib/searchFiles.js";
+import { printConsoleResults } from "../lib/output/console.js";
+import { printMarkdownResults } from "../lib/output/markdown.js";
+import {
+	getMatchesByPattern,
+	getTotalMatches,
+} from "../lib/aggregateResults.js";
+
 const searchCommand = new Command("search")
 	.description("find strings matching a pattern")
 	.argument("<dir>", "directory to search in")
@@ -19,70 +28,10 @@ const searchCommand = new Command("search")
 
 		// Build regex from pattern(s)
 		// Global search, ignores case
-		const regex = new RegExp(patterns.join("|"), "gi");
+		const regex = new RegExp(patterns.join("|"), searchRegexFlags);
 
-		// Matches for each file
-		const filesWithMatches = [];
-
-		const search = (searchedDir) => {
-			// Get every file and directory in the searched directory
-			const entries = fs.readdirSync(searchedDir, {
-				recursive: true,
-
-				// Include <fs.Dirent> information about directories
-				withFileTypes: true,
-			});
-
-			// Filter out everything but desired files
-			const excludedDirs = ["dist", "node_modules"];
-			const files = entries.filter(
-				(entry) =>
-					entry.isFile() &&
-					!entry.parentPath
-						.split(path.sep)
-						.some((seg) => excludedDirs.includes(seg)),
-			);
-
-			for (const file of files) {
-				// Construct full file path from Dirent properties
-				const fullPath = path.join(file.parentPath, file.name);
-
-				// Get contents of file
-				const contents = fs.readFileSync(fullPath, "utf8");
-
-				const lines = contents
-					// Split contents line by line
-					.split(/\r?\n/)
-
-					// Put line and its line number into an object
-					.map((line, index) => ({
-						line,
-						lineNumber: index + 1,
-					}))
-
-					// Filter to only lines containing a pattern match
-					.filter(({ line }) => {
-						regex.lastIndex = 0;
-						return regex.test(line);
-					})
-
-					// Attach every matched pattern to each result
-					.map(({ line, lineNumber }) => ({
-						line,
-						lineNumber,
-						matches: line.match(regex),
-					}));
-
-				if (lines.length > 0) {
-					filesWithMatches.push({
-						filePath: fullPath,
-						lines,
-					});
-				}
-			}
-		};
-
-		search(dirPath);
+		// Search files for matches
+		const filesWithMatches = searchFiles(dirPath, regex);
 
 		/*
 		 * Total matches
@@ -90,15 +39,7 @@ const searchCommand = new Command("search")
 		 * Get integer value of total matches of all patterns across every file
 		 */
 
-		const totalMatches = filesWithMatches.reduce((acc, file) => {
-			// Get total matches for each attached 'matches' array
-			return (
-				acc +
-				file.lines.reduce((lineAcc, line) => {
-					return lineAcc + line.matches.length;
-				}, 0)
-			);
-		}, 0);
+		const totalMatches = getTotalMatches(filesWithMatches);
 
 		/*
 		 * Total matches per pattern
@@ -106,145 +47,23 @@ const searchCommand = new Command("search")
 		 * Get object with total match integer value per each pattern
 		 */
 
-		// Get matches for each pattern
-		const matchesByPattern = filesWithMatches.reduce((acc, file) => {
-			// Each matched line
-			file.lines.forEach((line) => {
-				// Each matched pattern per line
-				line.matches.forEach((match) => {
-					const normalizedMatch = match.toLowerCase();
-					if (!acc[normalizedMatch]) {
-						acc[normalizedMatch] = [];
-					}
-
-					acc[normalizedMatch].push({
-						filePath: file.filePath,
-						fileName: path.basename(file.filePath),
-						lineNumber: line.lineNumber,
-						line: line.line,
-					});
-				});
-			});
-			return acc;
-		}, {});
+		const matchesByPattern = getMatchesByPattern(filesWithMatches);
 
 		/*
 		 * Output results
 		 */
 
-		// Write results to user-named file
 		if (options.output) {
-			const fileIntro = () => {
-				return [
-					`# Rivet CLI`,
-
-					``,
-
-					`## Search results for: \"${patterns.join('\", \"')}\"`,
-
-					``,
-
-					`**Total matches: ${totalMatches}**`,
-				];
-			};
-
-			const patternTable = () => {
-				return [
-					`| Pattern | Count |`,
-					`|---------|-------|`,
-					...Object.entries(matchesByPattern).map(
-						([pattern, lines]) => `| ${pattern} | ${lines.length} |`,
-					),
-				];
-			};
-
-			const patternSections = Object.entries(matchesByPattern).flatMap(
-				([pattern, lines]) => {
-					const fileData = lines.reduce(
-						(acc, { filePath, fileName, lineNumber, line }) => {
-							if (!acc[filePath]) {
-								acc[filePath] = { fileName, filePath, occurrences: [] };
-							}
-
-							acc[filePath].occurrences.push({ lineNumber, line });
-							return acc;
-						},
-						{},
-					);
-
-					const fileSections = Object.values(fileData).flatMap(
-						({ filePath, fileName, occurrences }) => {
-							// Construct relative path for CTRL/CMD + clicking and opening files
-							const relativePath = path.relative(
-								path.dirname(path.resolve(options.output)),
-								filePath,
-							);
-
-							const rows = occurrences.map(
-								({ lineNumber, line }) => `| ${lineNumber} | ${line} |`,
-							);
-							return [
-								`### [${fileName}](${relativePath})`,
-								`\`${filePath}\``,
-								`| Line | Match |`,
-								`|------|-------|`,
-								...rows,
-								``,
-							];
-						},
-					);
-
-					return [`## ${pattern}`, ``, ...fileSections];
-				},
+			// Write results to user-named file
+			printMarkdownResults(
+				patterns,
+				matchesByPattern,
+				totalMatches,
+				options.output,
 			);
-
-			const markdown = [
-				...fileIntro(),
-
-				``,
-
-				...patternTable(),
-
-				``,
-
-				...patternSections,
-			].join("\n");
-
-			// Write Markdown syntax file
-			fs.writeFileSync(options.output, markdown);
-
-			console.log(`\n-----------------------------------`);
-			console.log(`Rivet CLI`);
-			console.log(`-----------------------------------`);
-
-			console.log(`\nResults written to ${options.output}\n`);
 		} else {
-			const patternResults = Object.entries(matchesByPattern)
-				.map(([pattern, lines]) => ` * ${pattern}: ${lines.length}`)
-				.join("\n");
-
-			console.log(`\n--------------------------------`);
-			console.log(`Rivet CLI - Search results`);
-			console.log(`--------------------------------`);
-
-			console.log(`\nSEARCH QUERY`);
-
-			console.log(`\nQueried patterns: `, `"${patterns.join('", "')}"`);
-
-			console.log(`\n--------------------------------`);
-
-			console.log(`\nMATCHES`);
-
-			console.log(`\nTotal matches: ${totalMatches}\n`);
-
-			const tableData = Object.entries(matchesByPattern).map(
-				([pattern, lines]) => ({
-					Pattern: pattern,
-					Count: lines.length,
-				}),
-			);
-
-			console.table(tableData);
+			// Print results to command line
+			printConsoleResults(patterns, matchesByPattern, totalMatches);
 		}
 	});
 

--- a/packages/cli/commands/search.js
+++ b/packages/cli/commands/search.js
@@ -1,0 +1,81 @@
+import { Command } from "commander";
+import fs from "fs";
+import path from "path";
+
+const searchCommand = new Command("search")
+	.description("find strings matching a pattern")
+	.argument("<dir>", "directory to search in")
+	.argument(
+		"<pattern...>",
+		"specify string (for multiples, separate each with a space)",
+	)
+	.option("-o, --output <file>", "write results to a Markdown file")
+	.action((dir, patterns, options) => {
+		const dirPath = path.resolve(dir);
+		if (!fs.existsSync(dirPath)) {
+			console.error(`\nError: the "${dir}" directory does not exist\n`);
+			process.exit(1);
+		}
+
+		// Build regex from pattern(s)
+		// Global search, ignores case
+		const regex = new RegExp(patterns.join("|"), "gi");
+
+		// Results for each file
+		const filesWithMatches = [];
+
+		const search = (searchedDir) => {
+			// Get every file and directory in the searched directory
+			const entries = fs.readdirSync(searchedDir, {
+				recursive: true,
+
+				// Include <fs.Dirent> information about directories
+				withFileTypes: true,
+			});
+
+			// Filter out everything except files
+			const files = entries.filter((entry) => entry.isFile());
+
+			for (const file of files) {
+				// Construct full file path from Dirent properties
+				const fullPath = path.join(file.parentPath, file.name);
+
+				// Get contents of file
+				const contents = fs.readFileSync(fullPath, "utf8");
+
+				const lines = contents
+					// Split contents line by line
+					.split(/\r?\n/)
+
+					// Put line and its line number into an object
+					.map((line, i) => ({
+						line,
+						lineNumber: i + 1,
+					}))
+
+					// Filter to only lines containing a pattern match
+					.filter(({ line }) => {
+						regex.lastIndex = 0;
+						return regex.test(line);
+					})
+
+					// Attach every matched pattern to each result
+					.map(({ line, lineNumber }) => ({
+						line,
+						lineNumber,
+						matches: line.match(regex),
+					}));
+
+				if (lines.length > 0) {
+					filesWithMatches.push({
+						filePath: fullPath,
+						lines,
+					});
+				}
+			}
+		};
+
+		search(dirPath);
+	});
+
+export default searchCommand;

--- a/packages/cli/commands/search.js
+++ b/packages/cli/commands/search.js
@@ -33,8 +33,15 @@ const searchCommand = new Command("search")
 				withFileTypes: true,
 			});
 
-			// Filter out everything except files
-			const files = entries.filter((entry) => entry.isFile());
+			// Filter out everything but desired files
+			const excludedDirs = ["dist", "node_modules"];
+			const files = entries.filter(
+				(entry) =>
+					entry.isFile() &&
+					!entry.parentPath
+						.split(path.sep)
+						.some((seg) => excludedDirs.includes(seg)),
+			);
 
 			for (const file of files) {
 				// Construct full file path from Dirent properties

--- a/packages/cli/commands/search.js
+++ b/packages/cli/commands/search.js
@@ -21,7 +21,7 @@ const searchCommand = new Command("search")
 		// Global search, ignores case
 		const regex = new RegExp(patterns.join("|"), "gi");
 
-		// Results for each file
+		// Matches for each file
 		const filesWithMatches = [];
 
 		const search = (searchedDir) => {
@@ -48,9 +48,9 @@ const searchCommand = new Command("search")
 					.split(/\r?\n/)
 
 					// Put line and its line number into an object
-					.map((line, i) => ({
+					.map((line, index) => ({
 						line,
-						lineNumber: i + 1,
+						lineNumber: index + 1,
 					}))
 
 					// Filter to only lines containing a pattern match
@@ -76,6 +76,99 @@ const searchCommand = new Command("search")
 		};
 
 		search(dirPath);
+
+		/*
+		 * Total matches
+		 * -------------
+		 * Get integer value of total matches of all patterns across every file
+		 */
+
+		const totalMatches = filesWithMatches.reduce((acc, file) => {
+			// Get total matches for each attached 'matches' array
+			return (
+				acc +
+				file.lines.reduce((lineAcc, line) => {
+					return lineAcc + line.matches.length;
+				}, 0)
+			);
+		}, 0);
+
+		/*
+		 * Total matches per pattern
+		 * -------------------------
+		 * Get object with total match integer value per each pattern
+		 */
+
+		// Get matches for each pattern
+		const matchesByPattern = filesWithMatches.reduce((acc, file) => {
+			// Each matched line
+			file.lines.forEach((line) => {
+				// Each matched pattern per line
+				line.matches.forEach((match) => {
+					const normalizedMatch = match.toLowerCase();
+					const currentCount = acc[normalizedMatch] || 0;
+					acc[normalizedMatch] = currentCount + 1;
+				});
+			});
+			return acc;
+		}, {});
+
+		/*
+		 * Output results
+		 */
+
+		// Write results to user-named file
+		if (options.output) {
+			// Construct Markdown syntax
+			const markdown = [
+				`# Search results for: ${patterns.join(", ")}`,
+
+				``,
+
+				`**Total matches: ${totalMatches}**`,
+
+				``,
+
+				`| Pattern | Count |`,
+				`|---------|-------|`,
+				...Object.entries(matchesByPattern).map(
+					([pattern, count]) => `| ${pattern} | ${count} |`,
+				),
+
+				``,
+			].join("\n");
+
+			// Write Markdown syntax file
+			fs.writeFileSync(options.output, markdown);
+			console.log(`\nResults written to ${options.output}\n`);
+		} else {
+			const patternResults = Object.entries(matchesByPattern)
+				.map(([pattern, count]) => `  * ${pattern}: ${count}`)
+				.join("\n");
+
+			console.log(`\n--------------------------------`);
+			console.log(`Rivet CLI - Search results`);
+			console.log(`--------------------------------`);
+
+			console.log(`\nSEARCH QUERY`);
+
+			console.log(`\nQueried patterns: `, `"${patterns.join('", "')}"`);
+
+			console.log(`\n--------------------------------`);
+
+			console.log(`\nMATCHES`);
+
+			console.log(`\nTotal matches: ${totalMatches}\n`);
+
+			const tableData = Object.entries(matchesByPattern).map(
+				([pattern, count]) => ({
+					Pattern: pattern,
+					Count: count,
+				}),
+			);
+
+			console.table(tableData);
+		}
 	});
 
 export default searchCommand;

--- a/packages/cli/commands/search.js
+++ b/packages/cli/commands/search.js
@@ -112,6 +112,7 @@ const searchCommand = new Command("search")
 
 					acc[normalizedMatch].push({
 						filePath: file.filePath,
+						fileName: path.basename(file.filePath),
 						lineNumber: line.lineNumber,
 						line: line.line,
 					});
@@ -152,18 +153,41 @@ const searchCommand = new Command("search")
 
 			const patternSections = Object.entries(matchesByPattern).flatMap(
 				([pattern, lines]) => {
-					const rows = lines.map(
-						({ filePath, lineNumber, line }) =>
-							`| ${filePath} | ${lineNumber} | ${line} |`,
+					const fileData = lines.reduce(
+						(acc, { filePath, fileName, lineNumber, line }) => {
+							if (!acc[filePath]) {
+								acc[filePath] = { fileName, filePath, occurrences: [] };
+							}
+
+							acc[filePath].occurrences.push({ lineNumber, line });
+							return acc;
+						},
+						{},
 					);
 
-					return [
-						`## ${pattern}`,
-						`| File | Line | Match |`,
-						`|------|------|-------|`,
-						...rows,
-						``,
-					];
+					const fileSections = Object.values(fileData).flatMap(
+						({ filePath, fileName, occurrences }) => {
+							// Construct relative path for CTRL/CMD + clicking and opening files
+							const relativePath = path.relative(
+								path.dirname(path.resolve(options.output)),
+								filePath,
+							);
+
+							const rows = occurrences.map(
+								({ lineNumber, line }) => `| ${lineNumber} | ${line} |`,
+							);
+							return [
+								`### [${fileName}](${relativePath})`,
+								`\`${filePath}\``,
+								`| Line | Match |`,
+								`|------|-------|`,
+								...rows,
+								``,
+							];
+						},
+					);
+
+					return [`## ${pattern}`, ``, ...fileSections];
 				},
 			);
 
@@ -189,7 +213,7 @@ const searchCommand = new Command("search")
 			console.log(`\nResults written to ${options.output}\n`);
 		} else {
 			const patternResults = Object.entries(matchesByPattern)
-				.map(([pattern, count]) => `  * ${pattern}: ${count}`)
+				.map(([pattern, lines]) => ` * ${pattern}: ${lines.length}`)
 				.join("\n");
 
 			console.log(`\n--------------------------------`);
@@ -207,9 +231,9 @@ const searchCommand = new Command("search")
 			console.log(`\nTotal matches: ${totalMatches}\n`);
 
 			const tableData = Object.entries(matchesByPattern).map(
-				([pattern, count]) => ({
+				([pattern, lines]) => ({
 					Pattern: pattern,
-					Count: count,
+					Count: lines.length,
 				}),
 			);
 

--- a/packages/cli/commands/search.js
+++ b/packages/cli/commands/search.js
@@ -106,8 +106,15 @@ const searchCommand = new Command("search")
 				// Each matched pattern per line
 				line.matches.forEach((match) => {
 					const normalizedMatch = match.toLowerCase();
-					const currentCount = acc[normalizedMatch] || 0;
-					acc[normalizedMatch] = currentCount + 1;
+					if (!acc[normalizedMatch]) {
+						acc[normalizedMatch] = [];
+					}
+
+					acc[normalizedMatch].push({
+						filePath: file.filePath,
+						lineNumber: line.lineNumber,
+						line: line.line,
+					});
 				});
 			});
 			return acc;
@@ -119,27 +126,66 @@ const searchCommand = new Command("search")
 
 		// Write results to user-named file
 		if (options.output) {
-			// Construct Markdown syntax
+			const fileIntro = () => {
+				return [
+					`# Rivet CLI`,
+
+					``,
+
+					`## Search results for: \"${patterns.join('\", \"')}\"`,
+
+					``,
+
+					`**Total matches: ${totalMatches}**`,
+				];
+			};
+
+			const patternTable = () => {
+				return [
+					`| Pattern | Count |`,
+					`|---------|-------|`,
+					...Object.entries(matchesByPattern).map(
+						([pattern, lines]) => `| ${pattern} | ${lines.length} |`,
+					),
+				];
+			};
+
+			const patternSections = Object.entries(matchesByPattern).flatMap(
+				([pattern, lines]) => {
+					const rows = lines.map(
+						({ filePath, lineNumber, line }) =>
+							`| ${filePath} | ${lineNumber} | ${line} |`,
+					);
+
+					return [
+						`## ${pattern}`,
+						`| File | Line | Match |`,
+						`|------|------|-------|`,
+						...rows,
+						``,
+					];
+				},
+			);
+
 			const markdown = [
-				`# Search results for: ${patterns.join(", ")}`,
+				...fileIntro(),
 
 				``,
 
-				`**Total matches: ${totalMatches}**`,
+				...patternTable(),
 
 				``,
 
-				`| Pattern | Count |`,
-				`|---------|-------|`,
-				...Object.entries(matchesByPattern).map(
-					([pattern, count]) => `| ${pattern} | ${count} |`,
-				),
-
-				``,
+				...patternSections,
 			].join("\n");
 
 			// Write Markdown syntax file
 			fs.writeFileSync(options.output, markdown);
+
+			console.log(`\n-----------------------------------`);
+			console.log(`Rivet CLI`);
+			console.log(`-----------------------------------`);
+
 			console.log(`\nResults written to ${options.output}\n`);
 		} else {
 			const patternResults = Object.entries(matchesByPattern)

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env node

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -1,1 +1,13 @@
 #!/usr/bin/env node
+
+import { Command } from "commander";
+import pkg from "./package.json" with { type: "json" };
+
+const program = new Command();
+
+program
+	.name("rivet")
+	.description(`${pkg.description}`)
+	.version(`${pkg.version}`);
+
+program.parse();

--- a/packages/cli/index.js
+++ b/packages/cli/index.js
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
 
-import { Command } from "commander";
 import pkg from "./package.json" with { type: "json" };
+import { Command } from "commander";
+import searchCommand from "./commands/search.js";
 
 const program = new Command();
 
 program
-	.name("rivet")
+	.name(`${pkg.name}`)
 	.description(`${pkg.description}`)
 	.version(`${pkg.version}`);
+
+program.addCommand(searchCommand);
 
 program.parse();

--- a/packages/cli/lib/aggregateResults.js
+++ b/packages/cli/lib/aggregateResults.js
@@ -1,0 +1,38 @@
+// lib/aggregateResults.js
+
+import path from "path";
+
+export function getTotalMatches(filesWithMatches) {
+	return filesWithMatches.reduce((acc, file) => {
+		// Get total matches for each attached 'matches' array
+		return (
+			acc +
+			file.lines.reduce((lineAcc, line) => {
+				return lineAcc + line.matches.length;
+			}, 0)
+		);
+	}, 0);
+}
+
+export function getMatchesByPattern(filesWithMatches) {
+	return filesWithMatches.reduce((acc, file) => {
+		// Each matched line
+		file.lines.forEach((line) => {
+			// Each matched pattern per line
+			line.matches.forEach((match) => {
+				const normalizedMatch = match.toLowerCase();
+				if (!acc[normalizedMatch]) {
+					acc[normalizedMatch] = [];
+				}
+
+				acc[normalizedMatch].push({
+					filePath: file.filePath,
+					fileName: path.basename(file.filePath),
+					lineNumber: line.lineNumber,
+					line: line.line,
+				});
+			});
+		});
+		return acc;
+	}, {});
+}

--- a/packages/cli/lib/config.js
+++ b/packages/cli/lib/config.js
@@ -1,0 +1,4 @@
+// lib/config.js
+
+export const excludedDirs = ["dist", "node_modules"];
+export const searchRegexFlags = "gi";

--- a/packages/cli/lib/deprecatedElements.js
+++ b/packages/cli/lib/deprecatedElements.js
@@ -1,0 +1,64 @@
+// lib/deprecated.js
+
+export const classes = [
+	{
+		name: "rvt-button--success",
+		version: "Rivet 2",
+		replacement: "None",
+	},
+	{
+		name: "rvt-button--danger",
+		version: "Rivet 2",
+		replacement: "None",
+	},
+	{
+		name: "rvt-button--plain",
+		version: "Rivet 2",
+		replacement: "None",
+	},
+	{
+		name: "rvt-container-sm",
+		version: "Rivet 2",
+		replacement: "rvt-container",
+	},
+	{
+		name: "rvt-container-md",
+		version: "Rivet 2",
+		replacement: "rvt-container",
+	},
+	{
+		name: "rvt-container-lg",
+		version: "Rivet 2",
+		replacement: "rvt-container",
+	},
+	{
+		name: "rvt-container-xl",
+		version: "Rivet 2",
+		replacement: "rvt-container",
+	},
+	{
+		name: "rvt-link-hub",
+		version: "Rivet 2",
+		replacement: "rvt-list-hub",
+	},
+	{
+		name: "rvt-link-hub__item",
+		version: "Rivet 2",
+		replacement: "rvt-list-hub__item",
+	},
+	{
+		name: "rvt-link-hub__text",
+		version: "Rivet 2",
+		replacement: "rvt-list-hub__text",
+	},
+	{
+		name: "rvt-link-hub__description",
+		version: "Rivet 2",
+		replacement: "rvt-list-hub__description",
+	},
+	{
+		name: "rvt-accordion",
+		version: "Rivet 2",
+		replacement: "rvt-accordion",
+	},
+];

--- a/packages/cli/lib/output/console.js
+++ b/packages/cli/lib/output/console.js
@@ -1,0 +1,26 @@
+// lib/output/console.js
+
+export function printConsoleResults(patterns, matchesByPattern, totalMatches) {
+	console.log(`\n--------------------------------`);
+	console.log(`Rivet CLI - Search results`);
+	console.log(`--------------------------------`);
+
+	console.log(`\nSEARCH QUERY`);
+
+	console.log(`\nQueried patterns: `, `"${patterns.join('", "')}"`);
+
+	console.log(`\n--------------------------------`);
+
+	console.log(`\nMATCHES`);
+
+	console.log(`\nTotal matches: ${totalMatches}\n`);
+
+	const tableData = Object.entries(matchesByPattern).map(
+		([pattern, lines]) => ({
+			Pattern: pattern,
+			Count: lines.length,
+		}),
+	);
+
+	console.table(tableData);
+}

--- a/packages/cli/lib/output/markdown.js
+++ b/packages/cli/lib/output/markdown.js
@@ -1,0 +1,96 @@
+// lib/output/markdown.js
+
+import fs from "fs";
+import path from "path";
+
+export function printMarkdownResults(
+	patterns,
+	matchesByPattern,
+	totalMatches,
+	outputPath,
+) {
+	const fileIntro = () => {
+		return [
+			`# Rivet CLI`,
+
+			``,
+
+			`## Search results for: \"${patterns.join('\", \"')}\"`,
+
+			``,
+
+			`**Total matches: ${totalMatches}**`,
+		];
+	};
+
+	const patternTable = () => {
+		return [
+			`| Pattern | Count |`,
+			`|---------|-------|`,
+			...Object.entries(matchesByPattern).map(
+				([pattern, lines]) => `| ${pattern} | ${lines.length} |`,
+			),
+		];
+	};
+
+	const patternSections = Object.entries(matchesByPattern).flatMap(
+		([pattern, lines]) => {
+			const fileData = lines.reduce(
+				(acc, { filePath, fileName, lineNumber, line }) => {
+					if (!acc[filePath]) {
+						acc[filePath] = { fileName, filePath, occurrences: [] };
+					}
+
+					acc[filePath].occurrences.push({ lineNumber, line });
+					return acc;
+				},
+				{},
+			);
+
+			const fileSections = Object.values(fileData).flatMap(
+				({ filePath, fileName, occurrences }) => {
+					// Construct relative path for CTRL/CMD + clicking and opening files
+					const relativePath = path.relative(
+						path.dirname(path.resolve(outputPath)),
+						filePath,
+					);
+
+					const rows = occurrences.map(
+						({ lineNumber, line }) => `| ${lineNumber} | ${line} |`,
+					);
+					return [
+						`### [${fileName}](${relativePath})`,
+						`\`${filePath}\``,
+						`| Line | Match |`,
+						`|------|-------|`,
+						...rows,
+						``,
+					];
+				},
+			);
+
+			return [`## ${pattern}`, ``, ...fileSections];
+		},
+	);
+
+	const markdown = [
+		...fileIntro(),
+
+		``,
+
+		...patternTable(),
+
+		``,
+
+		...patternSections,
+	].join("\n");
+
+	// Write Markdown syntax file
+	fs.writeFileSync(outputPath, markdown);
+
+	console.log(`\n-----------------------------------`);
+	console.log(`Rivet CLI`);
+	console.log(`-----------------------------------`);
+
+	console.log(`\nResults written to ${outputPath}\n`);
+}

--- a/packages/cli/lib/output/markdown.js
+++ b/packages/cli/lib/output/markdown.js
@@ -12,13 +12,9 @@ export function printMarkdownResults(
 	const fileIntro = () => {
 		return [
 			`# Rivet CLI`,
-
 			``,
-
 			`## Search results for: \"${patterns.join('\", \"')}\"`,
-
 			``,
-
 			`**Total matches: ${totalMatches}**`,
 		];
 	};

--- a/packages/cli/lib/output/markdown.js
+++ b/packages/cli/lib/output/markdown.js
@@ -66,11 +66,11 @@ export function printMarkdownResults(
 					);
 
 					return [
-						`### [${fileName}](${relativePath})`,
-						`\`${filePath}\``,
-						`\`\`\``,
+						`### [${fileName}](${relativePath})\n`,
+						`\`${filePath}\`\n`,
+						"```",
 						...rows,
-						`\`\`\``,
+						"```\n",
 					];
 				},
 			);
@@ -81,13 +81,9 @@ export function printMarkdownResults(
 
 	const markdown = [
 		...fileIntro(),
-
 		``,
-
 		...patternTable(),
-
 		``,
-
 		...patternSections,
 	].join("\n");
 

--- a/packages/cli/lib/output/markdown.js
+++ b/packages/cli/lib/output/markdown.js
@@ -26,7 +26,7 @@ export function printMarkdownResults(
 	const patternTable = () => {
 		return [
 			`| Pattern | Count |`,
-			`|---------|-------|`,
+			`|---------|------:|`,
 			...Object.entries(matchesByPattern).map(
 				([pattern, lines]) => `| ${pattern} | ${lines.length} |`,
 			),
@@ -55,16 +55,22 @@ export function printMarkdownResults(
 						filePath,
 					);
 
-					const rows = occurrences.map(
-						({ lineNumber, line }) => `| ${lineNumber} | ${line} |`,
+					// Get value of longest line number to right align values in output
+					const maxWidth = Math.max(
+						...occurrences.map(({ lineNumber }) => String(lineNumber).length),
 					);
+
+					const rows = occurrences.map(
+						({ lineNumber, line }) =>
+							`${String(lineNumber).padStart(maxWidth)} | ${line.trim()}`,
+					);
+
 					return [
 						`### [${fileName}](${relativePath})`,
 						`\`${filePath}\``,
-						`| Line | Match |`,
-						`|------|-------|`,
+						`\`\`\``,
 						...rows,
-						``,
+						`\`\`\``,
 					];
 				},
 			);

--- a/packages/cli/lib/searchFiles.js
+++ b/packages/cli/lib/searchFiles.js
@@ -1,0 +1,71 @@
+// lib/searchFiles.js
+
+import fs from "fs";
+import path from "path";
+
+import { excludedDirs } from "../lib/config.js";
+
+export function searchFiles(dirPath, regex) {
+	const filesWithMatches = [];
+
+	const search = (searchedDir) => {
+		// Get every file and directory in the searched directory
+		const entries = fs.readdirSync(searchedDir, {
+			recursive: true,
+
+			// Include <fs.Dirent> information about directories
+			withFileTypes: true,
+		});
+
+		// Filter out everything but desired files
+		const files = entries.filter(
+			(entry) =>
+				entry.isFile() &&
+				!entry.parentPath
+					.split(path.sep)
+					.some((seg) => excludedDirs.includes(seg)),
+		);
+
+		for (const file of files) {
+			// Construct full file path from Dirent properties
+			const fullPath = path.join(file.parentPath, file.name);
+
+			// Get contents of file
+			const contents = fs.readFileSync(fullPath, "utf8");
+
+			const lines = contents
+				// Split contents line by line
+				.split(/\r?\n/)
+
+				// Put line and its line number into an object
+				.map((line, index) => ({
+					line,
+					lineNumber: index + 1,
+				}))
+
+				// Filter to only lines containing a pattern match
+				.filter(({ line }) => {
+					regex.lastIndex = 0;
+					return regex.test(line);
+				})
+
+				// Attach every matched pattern to each result
+				.map(({ line, lineNumber }) => ({
+					line,
+					lineNumber,
+					matches: line.match(regex),
+				}));
+
+			if (lines.length > 0) {
+				filesWithMatches.push({
+					filePath: fullPath,
+					lines,
+				});
+			}
+		}
+	};
+
+	search(dirPath);
+
+	return filesWithMatches;
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,9 +20,12 @@
 	"bin": {
 		"rivet": "index.js"
 	},
-	"scripts": {
-		"test": "echo \"Error: no test specified\" && exit 1"
-	},
+	"files": [
+		"index.js",
+		"README.md",
+		"commands/",
+		"lib/"
+	],
 	"dependencies": {
 		"commander": "15.0.0"
 	}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@rivet-iu/cli",
+	"version": "1.0.0",
+	"description": "CLI tool for the Rivet Design System",
+	"publishConfig": {
+		"access": "public"
+	},
+	"license": "BSD-3-Clause",
+	"homepage": "https://rivet.iu.edu",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/indiana-university/rivet-source"
+	},
+	"bugs": {
+		"url": "https://github.com/indiana-university/rivet-source/issues",
+		"email": "rivet@iu.edu"
+	},
+	"type": "module",
+	"main": "index.js",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"devDependencies": {
+		"commander": "15.0.0"
+	}
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,10 +17,13 @@
 	},
 	"type": "module",
 	"main": "index.js",
+	"bin": {
+		"rivet": "index.js"
+	},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
-	"devDependencies": {
+	"dependencies": {
 		"commander": "15.0.0"
 	}
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@rivet-iu/cli",
-	"version": "1.0.0",
+	"version": "1.0.0-alpha.0",
 	"description": "CLI tool for the Rivet Design System",
 	"publishConfig": {
 		"access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 0.14.1
 
   packages/cli:
-    devDependencies:
+    dependencies:
       commander:
         specifier: 15.0.0
         version: 15.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,202 +1,3 @@
----
-lockfileVersion: '9.0'
-
-importers:
-
-  .:
-    configDependencies: {}
-    packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: ^11.5.0
-        version: 11.5.0
-      pnpm:
-        specifier: ^11.5.0
-        version: 11.5.0
-
-packages:
-
-  '@pnpm/exe@11.5.0':
-    resolution: {integrity: sha512-4hzOXq1HHrNPjwI8k1rt7Ot/Yrdx1JX3pn/L/M95ii1gid1Q6ZK6dVg4+gbSgUdPsYmYDZ4/Yfc0A7vd5C0ndg==}
-    hasBin: true
-
-  '@pnpm/linux-arm64@11.5.0':
-    resolution: {integrity: sha512-NV9HdzzCB0epuI9LqZZeTaqjH3OweNQSQCS76GzEkFxJHS9e5Gvu7tgex91gxVL7bCZ+R4yr/3d3yexBFtr2ug==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@pnpm/linux-x64@11.5.0':
-    resolution: {integrity: sha512-vH83rRx4iPk/bwm9pBVCn+5hXbcQI66I/4zk6Vc09SusJgTqOdbN4U6VhMcGIqSEdr901ksYGCyIbMv7f6Guew==}
-    cpu: [x64]
-    os: [linux]
-
-  '@pnpm/linuxstatic-arm64@11.5.0':
-    resolution: {integrity: sha512-2nOnMW1rSwGv22q2yZz1HlGT3ly/Ij8wUlX0NB4n+Krx7nETRHA3MgWsbkVejxHknDcTulRVudAghuX9rgrXcw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/linuxstatic-x64@11.5.0':
-    resolution: {integrity: sha512-ONOC1Mg0JusHtjzkRlre9di1QO+GAjy4HP7jMjDx21yGhrSheNdUweTXbekMH1EflRd19kTU6d8M3zewJFPtVg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@pnpm/macos-arm64@11.5.0':
-    resolution: {integrity: sha512-od0ALdTxs4A7s5vAH5q2l2phzCJb98+PVOW1rq7BGpWGeYxQ+EwvL+vq0KaO6iLsn/eVVoncCkgZ/k6QNYuTgw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@pnpm/win-arm64@11.5.0':
-    resolution: {integrity: sha512-9HqbI80FjVVqFx4+EPxYYNfeP9Sx69W6kYqUDvOJn9G7RJ/2NNNQ898cVHTMpXlW1/PrMEcijmdpa/NjZIrWiQ==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@pnpm/win-x64@11.5.0':
-    resolution: {integrity: sha512-Q89CQqFGAsWmfvHZs5Kbbar45q3GBYtfAdPUCiVMVNJoLi3dsBS2LCvUq8ak3AufkFDaJBpvhaFcDP2M1NXr3A==}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    resolution: {integrity: sha512-ruy44Lpepdk1FqDz38vExBY/PVUsjxZA+chd9wozjUH9JjuDT/HEaQYA6wYN9mf041l0yLVar6BCZuWABJvHSA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    resolution: {integrity: sha512-By85MSWrMZa+c26TcnAy8SDk0sTUkYlNnwknSchkhHpGXOtjNDUOxJE9oByBnGbeuIE1PiQsxDG3Ud+IVV9yuA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    resolution: {integrity: sha512-7P+er8+rP9iNeN+bfmccM4hTAaLP6PQJPKWSA4iSk2bNvo6KU6RyPgYeHxXmzNKzPVRcypZQTpFgstHam6maVg==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    resolution: {integrity: sha512-37iO/Dp6m5DDaC2sf3zPtx/hl9FV3Xze4xoYidrxxS9bgP3S8ALroxRK6xBG/1TtfXKTvolvp+IjrUU6ujIGmA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    resolution: {integrity: sha512-jbI8jvuYCaA3MVUdu8vLoLAFqC+iNMpiSuLbxlAgg7x3K5bsS8nOpTRnkLF7vISJ+rVR8W+7ThXlXlUQ93ulkw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    resolution: {integrity: sha512-e9FBWDe+lv7QKAwtKOt6A2W/fyy/aEEfr0g6j/hWzvQcrzHCsz07BNQYlNOjTfeytrtLU7k449H1PI95jA4OjQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    resolution: {integrity: sha512-09PxnVIQcd+UOn4WAW73WU6PXL7DwGS6wPlkMhMg2zlHHG65F3vHepOw06HFCq+N42qkaNAc8AKIabWvtk6cIQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    resolution: {integrity: sha512-E//yT4ni2SyhwP8JRjVGWr3cbnhWDiPLgnQ66qqaanjjnMiu3O/2tjCPQXlcGc/DEYofpDc9fvhv6tALQsMV9w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@reflink/reflink@0.1.19':
-    resolution: {integrity: sha512-DmCG8GzysnCZ15bres3N5AHCmwBwYgp0As6xjhQ47rAUTUXxJiK+lLUxaGsX3hd/30qUpVElh05PbGuxRPgJwA==}
-    engines: {node: '>= 10'}
-
-  detect-libc@2.1.2:
-    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
-    engines: {node: '>=8'}
-
-  pnpm@11.5.0:
-    resolution: {integrity: sha512-2/zE+Bz0hZev1Lw5H/3xLBHxqfuDo5W/prCi2cwv2P/rr9scy9UpYyFT95OQTCYVt/Cf4aNFRz/Rw1hFFyqOsQ==}
-    engines: {node: '>=22.13'}
-    hasBin: true
-
-snapshots:
-
-  '@pnpm/exe@11.5.0':
-    dependencies:
-      '@reflink/reflink': 0.1.19
-      detect-libc: 2.1.2
-    optionalDependencies:
-      '@pnpm/linux-arm64': 11.5.0
-      '@pnpm/linux-x64': 11.5.0
-      '@pnpm/linuxstatic-arm64': 11.5.0
-      '@pnpm/linuxstatic-x64': 11.5.0
-      '@pnpm/macos-arm64': 11.5.0
-      '@pnpm/win-arm64': 11.5.0
-      '@pnpm/win-x64': 11.5.0
-
-  '@pnpm/linux-arm64@11.5.0':
-    optional: true
-
-  '@pnpm/linux-x64@11.5.0':
-    optional: true
-
-  '@pnpm/linuxstatic-arm64@11.5.0':
-    optional: true
-
-  '@pnpm/linuxstatic-x64@11.5.0':
-    optional: true
-
-  '@pnpm/macos-arm64@11.5.0':
-    optional: true
-
-  '@pnpm/win-arm64@11.5.0':
-    optional: true
-
-  '@pnpm/win-x64@11.5.0':
-    optional: true
-
-  '@reflink/reflink-darwin-arm64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-darwin-x64@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-arm64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-gnu@0.1.19':
-    optional: true
-
-  '@reflink/reflink-linux-x64-musl@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-arm64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink-win32-x64-msvc@0.1.19':
-    optional: true
-
-  '@reflink/reflink@0.1.19':
-    optionalDependencies:
-      '@reflink/reflink-darwin-arm64': 0.1.19
-      '@reflink/reflink-darwin-x64': 0.1.19
-      '@reflink/reflink-linux-arm64-gnu': 0.1.19
-      '@reflink/reflink-linux-arm64-musl': 0.1.19
-      '@reflink/reflink-linux-x64-gnu': 0.1.19
-      '@reflink/reflink-linux-x64-musl': 0.1.19
-      '@reflink/reflink-win32-arm64-msvc': 0.1.19
-      '@reflink/reflink-win32-x64-msvc': 0.1.19
-
-  detect-libc@2.1.2: {}
-
-  pnpm@11.5.0: {}
-
----
 lockfileVersion: '9.0'
 
 settings:
@@ -215,13 +16,19 @@ importers:
         version: 17.0.8
       node:
         specifier: runtime:24.x
-        version: runtime:24.16.0
+        version: runtime:24.18.0
       prettier:
         specifier: 3.8.4
         version: 3.8.4
       prettier-plugin-astro:
         specifier: 0.14.1
         version: 0.14.1
+
+  packages/cli:
+    devDependencies:
+      commander:
+        specifier: 15.0.0
+        version: 15.0.0
 
   packages/core:
     dependencies:
@@ -1337,6 +1144,10 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
+
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
@@ -2089,125 +1900,94 @@ packages:
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
 
-  node@runtime:24.16.0:
+  node@runtime:24.18.0:
     resolution:
       type: variations
       variants:
         - resolution:
             archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-MN/Y5EMiwnEoE/JeFjwlPK1TvkPgmJB7i1NIvxdKSWg=
+            bin: bin/node
+            integrity: sha256-ZGOiNzn2sjAOvsXM1gJ14TjjhY/Br8bo+bxOT2pLdvo=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-aix-ppc64.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-aix-ppc64.tar.gz
           targets:
             - cpu: ppc64
               os: aix
         - resolution:
             archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-ORidq07rFXBsQkrwrAijBEyeSPfbEqfXf2t6r8fdXfY=
+            bin: bin/node
+            integrity: sha256-4al+FMmcgD6WxzOUAyguoFpJnDL42D3v6e9exm+XntE=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-darwin-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-darwin-arm64.tar.gz
           targets:
             - cpu: arm64
               os: darwin
         - resolution:
             archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-KYtMezy4B2XIcD5CuQMkpOzjtmNJR7iedpw8mAq1UYU=
+            bin: bin/node
+            integrity: sha256-39Db0+chUDQ033tyBecZ9hs6OjGyvPlym4uR/qJA8IA=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-darwin-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-darwin-x64.tar.gz
           targets:
             - cpu: x64
               os: darwin
         - resolution:
             archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-WJ9bbdT8/uTf2nMBOQPJZquqir2T28nUNlRORytPDnQ=
+            bin: bin/node
+            integrity: sha256-a0SEwhkCdBdd+aqPKOLXWKgZyxwf5qtIHi+VtGOrhQg=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-arm64.tar.gz
           targets:
             - cpu: arm64
               os: linux
         - resolution:
             archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-JStYIFNNwDBKKFQcmkRDfPpyAufyAiXSjUk5MsWOl6o=
+            bin: bin/node
+            integrity: sha256-/hM4ly95KDxrwh5h2/RXa76MBa3tKZnUHIZDrTAmUUI=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-ppc64le.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-ppc64le.tar.gz
           targets:
             - cpu: ppc64le
               os: linux
         - resolution:
             archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-Vnrwl1s0BVFrmx3cZEKaI+yMWi+mzwE5EmGkzHdOPt0=
+            bin: bin/node
+            integrity: sha256-Nx68E5RfwWlJPnUvLdr6+rbs2My0Ubz/RuCfacXdjHo=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-s390x.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-s390x.tar.gz
           targets:
             - cpu: s390x
               os: linux
         - resolution:
             archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-L69qOH6bYriI4hxU8BJJ+ydTf/7PGELyn0yRnQpZoP8=
+            bin: bin/node
+            integrity: sha256-eDEwmElj23upy9AQierywu+wVcfBaTyUMXS5Z7MFDLg=
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64.tar.gz
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-x64.tar.gz
           targets:
             - cpu: x64
               os: linux
         - resolution:
             archive: zip
-            bin:
-              node: node.exe
-            integrity: sha256-FINGEdTGs8BgVOcAdzK5BHTBbgsy85XgW1Wlce9xxtI=
-            prefix: node-v24.16.0-win-arm64
+            bin: node.exe
+            integrity: sha256-8nRmmtuTsf0Pv48h/QeGCencyEMz1PJxjS3eP5oWGgE=
+            prefix: node-v24.18.0-win-arm64
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-win-arm64.zip
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-win-arm64.zip
           targets:
             - cpu: arm64
               os: win32
         - resolution:
             archive: zip
-            bin:
-              node: node.exe
-            integrity: sha256-7aypvVjsjpIDfaxOh31S9rj0MLgcGLV+JktOL7ERzVY=
-            prefix: node-v24.16.0-win-x64
+            bin: node.exe
+            integrity: sha256-CuaEBrQtdyVmHal5sUA+yZJtogXGdwgn8zqsnY8m6CE=
+            prefix: node-v24.18.0-win-x64
             type: binary
-            url: https://nodejs.org/download/release/v24.16.0/node-v24.16.0-win-x64.zip
+            url: https://nodejs.org/download/release/v24.18.0/node-v24.18.0-win-x64.zip
           targets:
             - cpu: x64
               os: win32
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-hd3ieqc1A7A9rfoEEKgABntOP3Avt/yqO+ryhN/Maek=
-            type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-arm64-musl.tar.gz
-          targets:
-            - cpu: arm64
-              os: linux
-              libc: musl
-        - resolution:
-            archive: tarball
-            bin:
-              node: bin/node
-            integrity: sha256-UN9djUdIktT3uQYWffNvd/W5OQj2PcUy3FaCGcq2WEE=
-            type: binary
-            url: https://unofficial-builds.nodejs.org/download/release/v24.16.0/node-v24.16.0-linux-x64-musl.tar.gz
-          targets:
-            - cpu: x64
-              os: linux
-              libc: musl
-    version: 24.16.0
+    version: 24.18.0
     hasBin: true
 
   normalize-path@3.0.0:
@@ -3807,6 +3587,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@15.0.0: {}
+
   common-ancestor-path@2.0.0: {}
 
   component-emitter@2.0.0: {}
@@ -4763,7 +4545,7 @@ snapshots:
 
   node-mock-http@1.0.4: {}
 
-  node@runtime:24.16.0: {}
+  node@runtime:24.18.0: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Details

These updates add a command line interface tool to the packages folder. This tool was written with [commander.js](https://github.com/tj/commander.js/) as a new dependency.

In its initial version, this tool includes one command (called "subcommands") named `search`. This command will search specified directories for instances of one or more strings and either return the results to the console or write them to a Markdown file. A full list of documentation for this command can be found in the README within the `packages/cli` folder. More commands can be created in the future to extend functionality.

While not currently used, a `deprecatedElements.js` file was created to be potentially used in a future feature to assist with migrating developers from Rivet versions 1 or 2 into version 3.

## Notes for reviewers

Once this tool is completed and merged into the stable branch, the intended use will be for the developer/user to pull and run the package from the `npm` without installing anything, like this:

```
`pnpm dlx @rivet-iu/cli search <directory> <patterns> --output <file-name>.md`
```

For the purposes of testing the work locally, here are two simple ways to test the functionality for this pull request:

**Using `pnpm exec`**:

```
pnpm exec ./packages/cli/index.js search ./packages/core rvt-m- rvt-p- --output test.md
```

**Using `node`**:

```
node ./packages/cli/index.js search ./packages/core rvt-m- rvt-p- --output test.md
```